### PR TITLE
BC-521 filtering homepage advisories

### DIFF
--- a/src/cms/data/pages.json
+++ b/src/cms/data/pages.json
@@ -1,18 +1,18 @@
-{"page":
-	[
+{
+	"page": [
 		{
-		  "Slug": "/about",
-		  "Template": "Template2"    
+			"Slug": "/about",
+			"Template": "Template2"
 		},
 		{
-		  "Slug": "/home",
-		  "Template": "Template1",
-		  "Content": [
-			  {
-				  "__component": "parks.html-area",
-				  "HTML": "<div class=\"home-advisories text-sm-center\" id=\"home-advisories\"><p class=\"zone-header\"><span>Advisories<\/span><\/p><div class=\"zone-hr\"><hr><\/div><p class=\"zone-content\"><span>Updated Monday to Friday from 8:30 am to 4:30 pm, excluding statutory holidays.<\/span><\/p><div class=\"zone-links row no-gutters\"><div class=\"advisory col-12 col-sm-6\"><p><button class=\"btn btn-primary advisory-button btn-block rounded-0 shadow\"> <a> <span class=\"text-white font-weight-bold\">Parks affected by flooding <span class=\"fa fa-chevron-circle-right\"><\/span> <\/span> <\/a> <\/button><\/p><\/div><div class=\"advisory col-12 col-sm-6\"><p><button class=\"btn btn-primary advisory-button btn-block rounded-0 shadow\"> <a> <span class=\"text-white font-weight-bold\">Parks affected by wildfires <span class=\"fa fa-chevron-circle-right test\"> <\/span> <\/span> <\/a> <\/button><\/p><\/div><\/div><\/div>"
-			  },
-			  {
+			"Slug": "/home",
+			"Template": "Template1",
+			"Content": [
+				{
+					"__component": "parks.html-area",
+					"HTML":"<div class=\"home-advisories text-sm-center\" id=\"home-advisories\"><p class=\"zone-header\"><span>Advisories</span></p><div class=\"zone-hr\"><hr></div><p class=\"zone-content\"><span>Updated Monday to Friday from 8:30 am to 4:30 pm, excluding statutory holidays.</span></p><div class=\"zone-links row no-gutters\"><div class=\"advisory col-12 col-sm-4\"><p><button class=\"btn btn-primary advisory-button btn-block shadow\" onclick=\"location.href='/alerts?type=floods'\"> <span class=\"text-white\">Parks affected by flooding <span class=\"fa fa-chevron-circle-right test\"> </span> </span> </button></p></div><div class=\"advisory col-12 col-sm-4\"><p><button class=\"btn btn-primary advisory-button btn-block shadow\" onclick=\"location.href='/alerts?type=wildfires'\"> <a> <span class=\"text-white\">Parks affected by wildfires <span class=\"fa fa-chevron-circle-right test\"> </span> </span> </a> </button></p></div><div class=\"advisory col-12 col-sm-4\"><p><button class=\"btn btn-light all-advisory-button btn-block shadow\" onclick=\"location.href='/alerts'\"> <span class=\"text-primary font-weight-bold\">See all advisories </span> </button>&nbsp;</p></div></div></div>"
+				},
+				{
 					"__component": "parks.html-area",
 					"HTML": "<div class=\"home-plan-your-trip text-sm-center\" id=\"home-plan-your-trip\"><p class=\"zone-header\"><span>Plan your trip<\/span><\/p><div class=\"zone-hr\"><hr><\/div><p class=\"zone-content\"><span>There's an adventure waiting for every visitor.<\/span><\/p><div class=\"zone-cards\"><div class=\"row\"><div class=\"col-6 col-md-3 card-col-padding pr-1 pr-sm-3\" onclick=\"location.href='https:\/\/bcparks.ca\/reserve'\"><div class=\"card grid-card\"><p class=\"card-img shadow\"><img src=\"http:\/\/localhost:1337\/uploads\/Mask_Group_9_2x.png\"><\/p><div class=\"card-body d-flex flex-column d-block d-sm-none\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/reserve\">Camping information<\/a><\/h5><div class=\"mt-auto\"><p class=\"no-mb\"><span class=\"card-text\">Reservation policies and fees.<\/span><\/p><\/div><\/div><div class=\"card-body d-none d-sm-block\"><div class=\"v-align-abs\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/reserve\">Camping information<\/a><\/h5><p class=\"no-mb pt-3\"><span class=\"card-text\">Reservation policies and fees.<\/span><\/p><\/div><\/div><\/div><\/div><div class=\"col-6 col-md-3 card-col-padding pl-1 pl-sm-0 pr-sm-3\" onclick=\"location.href='https:\/\/bcparks.ca\/visiting'\"><div class=\"card grid-card\"><p class=\"card-img shadow\"><img src=\"http:\/\/localhost:1337\/uploads\/Mask_Group_10_2x.png\"><\/p><div class=\"card-body d-flex flex-column d-block d-sm-none\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/visiting\/\">Things to do<\/a><\/h5><div class=\"mt-auto\"><p class=\"no-mb\"><span class=\"card-text\">Explore activities and attractions.<\/span><\/p><\/div><\/div><div class=\"card-body d-none d-sm-block\"><div class=\"v-align-abs\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/visiting\/\">Things to do<\/a><\/h5><p class=\"no-mb pt-3\"><span class=\"card-text\">Explore activities and attractions.<\/span><\/p><\/div><\/div><\/div><\/div><div class=\"col-6 col-md-3 card-col-padding pr-1 pl-sm-0 pr-sm-3\" onclick=\"location.href='https:\/\/bcparks.ca\/accessibility'\"><div class=\"card grid-card\"><p class=\"card-img shadow\"><img src=\"http:\/\/localhost:1337\/uploads\/Mask_Group_12_bs_2x.png\"><\/p><div class=\"card-body d-flex flex-column d-block d-sm-none\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/accessibility\/\">Accessibility<\/a><\/h5><div class=\"mt-auto\"><p class=\"no-mb\"><span class=\"card-text\">BC Parks are for everyone.<\/span><\/p><\/div><\/div><div class=\"card-body d-none d-sm-block\"><div class=\"v-align-abs\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/accessibility\/\">Accessibility<\/a><\/h5><p class=\"no-mb pt-3\"><span class=\"card-text\">BC Parks are for everyone.<\/span><\/p><\/div><\/div><\/div><\/div><div class=\"col-6 col-md-3 card-col-padding pl-1 pl-sm-0\" onclick=\"location.href='https:\/\/bcparks.ca\/visiting\/responsible-recreation\/'\"><div class=\"card grid-card\"><p class=\"card-img shadow\"><img src=\"http:\/\/localhost:1337\/uploads\/Mask_Group_12_2x.png\"><\/p><div class=\"card-body d-flex flex-column d-block d-sm-none\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/visiting\/responsible-recreation\/\">Visit responsibly<\/a><\/h5><div class=\"mt-auto\"><p class=\"no-mb\"><span class=\"card-text\">Guidelines for a safe and respectful adventure.<\/span><\/p><\/div><\/div><div class=\"card-body d-none d-sm-block\"><div class=\"v-align-abs\"><h5 class=\"card-body-header my-0\"><a href=\"https:\/\/bcparks.ca\/visiting\/responsible-recreation\/\">Visit responsibly<\/a><\/h5><p class=\"no-mb pt-3\"><span class=\"card-text\">Guidelines for a safe and respectful adventure.<\/span><\/p><\/div><\/div><\/div><\/div><\/div><\/div><\/div>"
 				},
@@ -32,7 +32,7 @@
 					"__component": "parks.html-area",
 					"HTML": "<div class=\"carousel slide\" id=\"home-carousel\" data-ride=\"carousel\"><ol class=\"carousel-indicators\"><li class=\"active\" data-target=\"#home-carousel\" data-slide-to=\"0\">&nbsp;<\/li><li data-target=\"#home-carousel\" data-slide-to=\"1\">&nbsp;<\/li><li data-target=\"#home-carousel\" data-slide-to=\"2\">&nbsp;<\/li><\/ol><div class=\"carousel-inner\"><div class=\"carousel-item active\"><p class=\"mb-0\"><img src=\"http:\/\/localhost:1337\/uploads\/carousel_1.jpg\" alt=\"First slide\"><\/p><div class=\"carousel-caption text-right\"><p class=\"mb-0\">Test Photo #1<\/p><p class=\"mb-0\">Photo by 1<\/p><\/div><\/div><div class=\"carousel-item\"><p class=\"mb-0\"><img src=\"http:\/\/localhost:1337\/uploads\/carousel_2.jpg\" alt=\"Second slide\"><\/p><div class=\"carousel-caption text-right\"><p class=\"mb-0\">Test Photo #2<\/p><p class=\"mb-0\">Photo by 2<\/p><\/div><\/div><div class=\"carousel-item\"><p class=\"mb-0\"><img src=\"http:\/\/localhost:1337\/uploads\/carousel_3.jpg\" alt=\"Second slide\"><\/p><div class=\"carousel-caption text-right\"><p class=\"mb-0\">Test Photo #3<\/p><p class=\"mb-0\">Photo by 3<\/p><\/div><\/div><\/div><\/div>"
 				}
-		  ]
+			]
 		}
 	]
-} 
+}

--- a/src/staging/package.json
+++ b/src/staging/package.json
@@ -46,6 +46,8 @@
     "react-icons": "^3.6.1",
     "react-material-ui-carousel": "^2.3.1",
     "react-reveal": "^1.2.2",
+    "react-router-dom": "^5.3.0",
+    "react-scrollspy": "^3.4.3",
     "react-select": "^4.3.1",
     "react-typography": "^0.16.19",
     "react-use-scrollspy": "^3.0.1",

--- a/src/staging/package.json
+++ b/src/staging/package.json
@@ -46,7 +46,6 @@
     "react-icons": "^3.6.1",
     "react-material-ui-carousel": "^2.3.1",
     "react-reveal": "^1.2.2",
-    "react-router-dom": "^5.3.0",
     "react-select": "^4.3.1",
     "react-typography": "^0.16.19",
     "react-use-scrollspy": "^3.0.1",

--- a/src/staging/package.json
+++ b/src/staging/package.json
@@ -47,7 +47,6 @@
     "react-material-ui-carousel": "^2.3.1",
     "react-reveal": "^1.2.2",
     "react-router-dom": "^5.3.0",
-    "react-scrollspy": "^3.4.3",
     "react-select": "^4.3.1",
     "react-typography": "^0.16.19",
     "react-use-scrollspy": "^3.0.1",

--- a/src/staging/src/pages/alerts.js
+++ b/src/staging/src/pages/alerts.js
@@ -44,10 +44,62 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const PublicAdvisoryPage = ({ data }) => {
-  const classes = useStyles()
+const getWildfires = (advisories) => {
+  let advisoryList = [];
+  for (let advisory of advisories) {
+    if (advisory.eventType && advisory.eventType.eventType) {
+      let e = advisory.eventType.eventType;
+      if (e === 'Wildfire' || e === 'Wildfire damage' || e === 'Wildfire nearby') {
+        advisoryList.push(advisory);
+      }
+    }
+  }
+  return (advisoryList);
+}
 
-  const advisories = data.allStrapiPublicAdvisory.nodes.map(advisory => {
+const getFloods = (advisories) => {
+  let advisoryList = [];
+  for (let advisory of advisories) {
+    if (advisory.eventType && advisory.eventType.eventType) {
+      let e = advisory.eventType.eventType;
+      if (e === 'Flood' || e === 'Flood damage') {
+        advisoryList.push(advisory);
+      }
+    }
+  }
+  return (advisoryList);
+}
+
+const PublicAdvisoryPage = ({ data }) => {
+
+  const thisUrl = new URLSearchParams(window.location.search);
+  const params = Object.fromEntries(thisUrl.entries());
+
+  const classes = useStyles()
+  let advisories = [];
+  let pageTitle = 'Public Advisories';
+  let advisoryType = "";
+
+  if (params && params.type) {
+    switch (params.type) {
+      case 'wildfires':
+        advisories = getWildfires(data.allStrapiPublicAdvisory.nodes);
+        pageTitle = 'Public Advisories | Wildfires';
+        advisoryType = 'wildfire ';
+        break;
+      case 'floods':
+        advisories = getFloods(data.allStrapiPublicAdvisory.nodes);
+        pageTitle = 'Public Advisories | Flooding';
+        advisoryType = 'flood ';
+        break;
+      default:
+        advisories = data.allStrapiPublicAdvisory.nodes;
+    }
+  } else {
+    advisories = data.allStrapiPublicAdvisory.nodes;
+  }
+
+  advisories.map(advisory => {
     let alertIcon
     let alertColorCss
     switch (advisory.urgency.color) {
@@ -82,12 +134,12 @@ const PublicAdvisoryPage = ({ data }) => {
       <Menu>{data.strapiWebsites.Navigation}</Menu>
       <Container>
         <br />
-        <h1>Public Advisories</h1>
+        <h1>{pageTitle}</h1>
         <span>
           Updated Monday to Friday from 8:30 am to 4:30 pm, excluding statutory
           holidays.
         </span>
-        <span>There are {advisories.length} advisories in effect.</span>
+        <span>There are {advisories.length} {advisoryType}advisories in effect.</span>
         <br />
         <Grid container spacing={1}>
           {advisories.map((advisory, index) => (
@@ -126,13 +178,12 @@ const PublicAdvisoryPage = ({ data }) => {
                           variant="outlined"
                           component="a"
                           className={classes.chip}
-                          href={`/${
-                            par.slug
-                              ? par.slug
-                              : par.protectedAreaName
-                                  .toLowerCase()
-                                  .replace(/ /g, "-")
-                          }`}
+                          href={`/${par.slug
+                            ? par.slug
+                            : par.protectedAreaName
+                              .toLowerCase()
+                              .replace(/ /g, "-")
+                            }`}
                           key={index}
                           label={par.protectedAreaName}
                         />
@@ -255,3 +306,4 @@ export const query = graphql`
     }
   }
 `
+

--- a/src/staging/src/pages/index.js
+++ b/src/staging/src/pages/index.js
@@ -150,7 +150,7 @@ function AdvisoryBar() {
         <button type="button" className="close" data-dismiss="alert">×</button>
         <span className="text-center">
           <img className="alert-exclamation d-inline-flex pr-4" src={Exclamation} alt="exclamation" />
-          Some parks are currently affected by wildfire activity. <a href="/" className="d-inline-flex underline">See all advisories</a>.
+          Some parks are currently affected by wildfire activity. <a href="/alerts" className="d-inline-flex underline">See all advisories</a>
         </span>
       </div>
     </>

--- a/src/staging/src/styles/home.scss
+++ b/src/staging/src/styles/home.scss
@@ -201,6 +201,15 @@ $desktopBreakpoint: 576px;
     height: 49px;
     text-align: center;
   }
+  .all-advisory-button {
+    background-color: $colorWhite !important;
+    color: $colorBlue;
+    height: 49px;
+    text-align: center;
+    border: 2px solid $colorBlue;
+    border-radius: 5px;
+  }
+
   .advisory-content {
     font-size: 16px;
     color: $colorWhite;
@@ -220,6 +229,9 @@ $desktopBreakpoint: 576px;
       font-size: 25px;
     }
     .advisory-button {
+      height: 90px;
+    }
+    .all-advisory-button {
       height: 90px;
     }
   }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- BC-521
- added button to homepage 'See all advisories'
- linked buttons to /alerts page, wildfire and flooding buttons autofilter results upon navigation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Requires dropping and restoring db. 
Filtering occurs client side and uses existing `allStrapiPublicAdvisory` call. In the future, filtering can be achieved with API calls.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have made corresponding changes to the documentation
- [x ] New and existing unit tests pass locally with my changes
