### PR TITLE
NOBUG: remove global style overrides

### DIFF
--- a/src/staging/src/styles/global.scss
+++ b/src/staging/src/styles/global.scss
@@ -10,13 +10,6 @@ html {
   background-color: white;
   font-family: $globalFont !important;
 }
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  border: none;
-  display: block;
-}
 
 head,script,style {
   display: none !important;


### PR DESCRIPTION
May break a few things but we can't have everything with
`display: block;`.
