### PR TITLE
NOBUG: But also a bug: Fixed Header build error

### DIFF
--- a/src/staging/src/components/header.js
+++ b/src/staging/src/components/header.js
@@ -48,24 +48,20 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-export default function Header({ children, mode = 'external', content = [] }) {
+export default function Header({ content = [] }) {
   const classes = useStyles();
 
-  if (mode === 'internal') {
-    return (
-      <>
-        <Box className={classes.betaHeader + " bc-bg-yellow bc-color-blue-dk"}>
-          <i className={'fa fa-info-circle ' + classes.infoIcon }></i>
-          <Box className={classes.betaMsg}>
-            This site is in beta
-          </Box>
-          <Box className={classes.linkDivider}>|</Box>
-          <Box className={classes.link}>
-            <a href="#">Help us improve this by submitting here</a>
-          </Box>
+  return (
+    <>
+      <Box className={classes.betaHeader + " bc-bg-yellow bc-color-blue-dk"}>
+        <i className={"fa fa-info-circle " + classes.infoIcon}></i>
+        <Box className={classes.betaMsg}>This site is in beta</Box>
+        <Box className={classes.linkDivider}>|</Box>
+        <Box className={classes.link}>
+          <a href="#">Help us improve this by submitting here</a>
         </Box>
-        <MegaMenu content={content} />
-        </>
-    )
-  }
+      </Box>
+      <MegaMenu content={content} />
+    </>
+  )  
 }

--- a/src/staging/src/pages/explore.js
+++ b/src/staging/src/pages/explore.js
@@ -401,7 +401,7 @@ export default function Explore({ location, data }) {
 
   return (
     <> 
-      <Header mode="internal" content={menuContent} />
+      <Header content={menuContent} />
       <div className="search-body">
         <div className="search-results-main container">
           <div className="search-results-container">


### PR DESCRIPTION
### Description:
Fixed Header build error

Header component wasn't rendering anything if `mode` isn't set to `internal`.  This causes Gatsby build to fail.  For this PR I removed the `mode` check if block for now since it's not really used.  We can add it back later if desired.