### PR TITLE
NOBUG: update sass plugin

### DIFF
--- a/src/staging/package.json
+++ b/src/staging/package.json
@@ -26,7 +26,7 @@
     "gatsby-plugin-material-ui": "^3.0.1",
     "gatsby-plugin-offline": "^4.2.0",
     "gatsby-plugin-react-helmet": "^4.2.0",
-    "gatsby-plugin-sass": "^3.0.0",
+    "gatsby-plugin-sass": "^4.13.0",
     "gatsby-plugin-sharp": "^3.11.0",
     "gatsby-plugin-typography": "^3.2.0",
     "gatsby-source-filesystem": "^3.8.0",


### PR DESCRIPTION
Fixes `warn Plugin gatsby-plugin-sass is not compatible with your gatsby version 3.14.6 - It requires gatsby@^2.0.0`