### PR TITLE
NOBUG: Add image pruner utility

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -38,10 +38,10 @@ jobs:
 
       - name: Tag Prod images
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin:${{ env.SHORT_SHA }} admin:${{ env.ENVIRONMENT }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder:${{ env.SHORT_SHA }} public-builder:${{ env.ENVIRONMENT }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi:${{ env.SHORT_SHA }} strapi:${{ env.ENVIRONMENT }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag landing:${{ env.SHORT_SHA }} landing:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin:${{ github.event.inputs.releaseTag }} admin:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder:${{ github.event.inputs.releaseTag }} public-builder:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi:${{ github.event.inputs.releaseTag }} strapi:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag landing:${{ github.event.inputs.releaseTag }} landing:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -27,9 +27,6 @@ jobs:
           echo "::error::Git Tag not found, please double check input"
           exit 1
 
-      - name: Set env
-        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -38,10 +35,10 @@ jobs:
 
       - name: Tag Test images
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin:${{ env.SHORT_SHA }} admin:${{ env.ENVIRONMENT }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder:${{ env.SHORT_SHA }} public-builder:${{ env.ENVIRONMENT }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi:${{ env.SHORT_SHA }} strapi:${{ env.ENVIRONMENT }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag landing:${{ env.SHORT_SHA }} landing:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin:${{ github.event.inputs.releaseTag }} admin:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder:${{ github.event.inputs.releaseTag }} public-builder:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi:${{ github.event.inputs.releaseTag }} strapi:${{ env.ENVIRONMENT }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag landing:${{ github.event.inputs.releaseTag }} landing:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -1,0 +1,39 @@
+name: Tag image on Git Tag Push
+
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  TOOLS_NAMESPACE: ${{ secrets.OPENSHIFT_LICENSE_PLATE }}-tools
+  NAMESPACE: ${{ secrets.OPENSHIFT_LICENSE_PLATE }}-test
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run: |
+          echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Login OpenShift
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER_URL }}
+          openshift_token: ${{ secrets.OPENSHIFT_SERVICE_TOKEN }}
+
+      - name: Tag images
+        run: |
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin:${{ env.SHORT_SHA }} admin:${{ env.RELEASE_VERSION }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder:${{ env.SHORT_SHA }} public-builder:${{ env.RELEASE_VERSION }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi:${{ env.SHORT_SHA }} strapi:${{ env.RELEASE_VERSION }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag landing:${{ env.SHORT_SHA }} landing:${{ env.RELEASE_VERSION }}
+
+      - name: Delete images tags with commit hash
+        run: |
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag -d admin:${{ env.SHORT_SHA }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag -d public-builder:${{ env.SHORT_SHA }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag -d strapi:${{ env.SHORT_SHA }}
+          oc -n ${{ env.TOOLS_NAMESPACE }} tag -d landing:${{ env.SHORT_SHA }}

--- a/infrastructure/cronjobs/image-pruner-cronjob.dc.yaml
+++ b/infrastructure/cronjobs/image-pruner-cronjob.dc.yaml
@@ -1,0 +1,71 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+objects:
+  - kind: CronJob
+    apiVersion: batch/v1beta1
+    metadata:
+      name: ${NAME}
+      labels:
+        cronjob: ${NAME}
+        template: ${NAME}-cronjob
+    spec:
+      schedule: 0 10 * * *
+      concurrencyPolicy: Forbid
+      suspend: true
+      jobTemplate:
+        metadata:
+          creationTimestamp: null
+          labels:
+            cronjob: ${NAME}
+            template: ${NAME}-job
+        spec:
+          backoffLimit: 0
+          template:
+            metadata:
+              creationTimestamp: null
+              labels:
+                cronjob: ${NAME}
+                template: ${NAME}-job
+            spec:
+              containers:
+                - terminationMessagePath: /dev/termination-log
+                  name: ${NAME}-cronjob
+                  imagePullPolicy: Always
+                  terminationMessagePolicy: File
+                  image: image-registry.openshift-image-registry.svc:5000/61d198-tools/${NAME}:latest
+                  command:
+                    - "/bin/bash"
+                    - "-c"
+                    - "npm start"
+                  env:
+                    - name: OPENSHIFT_AUTH_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${OPENSHIFT_SECRET}
+                          key: ${OPENSHIFT_SECRET_KEY}
+                    - name: DRY_RUN
+                      value: ${DRY_RUN}
+                    - name: NUM_RELEASES_TO_KEEP
+                      value: ${NUM_RELEASES_TO_KEEP}
+              restartPolicy: Never
+              terminationGracePeriodSeconds: 30
+              activeDeadlineSeconds: 1600
+              dnsPolicy: ClusterFirst
+              securityContext: {}
+              schedulerName: default-scheduler
+      successfulJobsHistoryLimit: 5
+      failedJobsHistoryLimit: 2
+parameters:
+  - name: NAME
+    required: true
+    value: imagetag-pruner
+  - name: OPENSHIFT_SECRET
+    required: true
+  - name: OPENSHIFT_SECRET_KEY
+    required: true
+  - name: DRY_RUN
+    required: false
+    value: "true"
+  - name: NUM_RELEASES_TO_KEEP
+    require: false
+    value: "10"

--- a/tools/imagetag-prune/Dockerfile
+++ b/tools/imagetag-prune/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:14-slim
+
+COPY package.json .
+
+RUN npm install
+
+COPY *.js ./
+
+CMD [ "npm", "start" ]

--- a/tools/imagetag-prune/README.md
+++ b/tools/imagetag-prune/README.md
@@ -1,0 +1,17 @@
+# Image Tag Pruner
+
+A simple Node utility to help prune imagestream tagsin OpenShift tools namespace. 
+
+This is needed because each git commit triggers a new build and creates a new container image tag. Overtime we will end up with a large amount of imagestream tags without clean up.
+
+## Build and Push Container Image
+
+Currently the build process isn't part of the pipeline because it shouldn't need to be rebuilt very often.  It can be added to the pipeline later on if desired.  Note, you will need to log into the OpenShift registry with `oc registry login` first to push the image.
+
+### Build
+`docker build -t image-registry.apps.silver.devops.gov.bc.ca/61d198-tools/imagetag-pruner .`
+
+`docker push image-registry.apps.silver.devops.gov.bc.ca/61d198-tools/imagetag-pruner`
+
+## Cronjob
+There is a [cronjob deploy definition](../../infrastructure/cronjobs/image-pruner-cronjob.dc.yaml).

--- a/tools/imagetag-prune/imagePruner.js
+++ b/tools/imagetag-prune/imagePruner.js
@@ -1,0 +1,171 @@
+"use strict";
+
+const p = require("phin");
+
+/**
+ * Utility class used to retrieve a list of imagestreamtags and determine
+ * if they should be pruned.
+ *
+ * Default behavior is to keep "latest", "dev", "test", and "prod" tags for
+ * all images.
+ *
+ * Default behavior will keep "numReleasesToKeep" number of tags matching the
+ * "releaseTagRegex" and "gitShaHashRegex" regex patterns.
+ *
+ * Dry run will compute imagestreamtags to delete but not actually delete them.
+ */
+class ImagePruner {
+  constructor({
+    openShiftUrl,
+    openShiftToken,
+    releaseTagRegex,
+    gitShaHashRegex,
+    numReleasesToKeep = 10,
+    imageTagsToIgnore = ["latest", "dev", "test", "prod"],
+    imageStreamsToPrune = [],
+    dryRun = true,
+  }) {
+    this.openShiftToken = openShiftToken;
+    this.openShiftImageTagsUrl = openShiftUrl;
+
+    // Regex pattern used to match release tags
+    this.releaseTagRegex = new RegExp(releaseTagRegex, "i");
+
+    // Regex pattern used to match git sha hash
+    this.gitShaHashRegex = new RegExp(gitShaHashRegex, "i");
+
+    this.imageStreamsToPrune = imageStreamsToPrune;
+    this.imageTagsToIgnore = imageTagsToIgnore;
+    this.numReleasesToKeep = numReleasesToKeep;
+
+    this.dryRun = dryRun;
+
+    this.releaseTagsToKeep = [];
+    this.gitHashTagsToKeep = [];
+    this.imageTagsToDelete = [];
+  }
+
+  async prune() {
+    if (!this.openShiftToken) {
+      throw new Error("OpenShift auth token not set");
+    }
+
+    await this.#retrieveOpenShiftImageTags();
+
+    await this.#deleteImageTags();
+  }
+
+  async #retrieveOpenShiftImageTags() {
+    const res = await p({
+      url: this.openShiftImageTagsUrl,
+      headers: {
+        Authorization: `Bearer ${this.openShiftToken}`,
+      },
+      parse: "json",
+    });
+
+    // Sort the items from newest to oldest
+    const sortedItems = res.body.items
+      .map((item) => {
+        const tokens = item.metadata.name.split(":");
+        return {
+          imageName: tokens[0],
+          tag: tokens[1],
+          creationTimestamp: new Date(item.metadata.creationTimestamp),
+        };
+      })
+      .sort((a, b) => b.creationTimestamp - a.creationTimestamp);
+
+    for (const item of sortedItems) {
+      if (this.#shouldCleanImage(item.imageName, item.tag)) {
+        this.imageTagsToDelete.push({
+          imageName: item.imageName,
+          tagName: item.tag,
+        });
+      }
+    }
+  }
+
+  #shouldCleanImage(name, tag) {
+    if (!this.imageStreamsToPrune.includes(name)) {
+      return false;
+    }
+
+    if (this.imageTagsToIgnore.includes(tag)) {
+      return false;
+    }
+
+    // Check if tag matches a release tag pattern.
+    if (tag.match(this.releaseTagRegex)) {
+      // Because multiple images can have the same release tag due to mono repo setup,
+      // we want to check if the tag is already in the list of release tags to keep
+      if (this.releaseTagsToKeep.includes(tag)) {
+        return false;
+      }
+
+      // Only keep up to "numReleasesToKeep" release tags
+      if (this.releaseTagsToKeep.length < this.numReleasesToKeep) {
+        this.releaseTagsToKeep.push(tag);
+        return false;
+      }
+    }
+
+    // Check if tag matches a git hash pattern.
+    if (tag.match(this.gitShaHashRegex)) {
+      // Because multiple images can have the same git hash due to mono repo setup,
+      // we want to check if the tag is already in the list of git hashes to keep
+      if (this.gitHashTagsToKeep.includes(tag)) {
+        return false;
+      }
+
+      // Only keep up to "numReleasesToKeep" git hashes
+      if (this.gitHashTagsToKeep.length < this.numReleasesToKeep) {
+        this.gitHashTagsToKeep.push(tag);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  async #deleteImageTags() {
+    if (this.dryRun) {
+      console.log(
+        "This is only a dryrun, nothing will be removed.  Set dry run env to false to perform actual deletions.\n"
+      );
+    }
+    console.log(
+      `${this.imageTagsToDelete.length} images tags matched pruned criteria\n`
+    );
+
+    for (const tag of this.imageTagsToDelete) {
+      console.log(
+        `${this.dryRun ? "--DRY-RUN--" : ""}Deleting ${tag.imageName}:${
+          tag.tagName
+        }`
+      );
+      if (!this.dryRun) {
+        try {
+          const res = await p({
+            url: `${this.openShiftImageTagsUrl}/${tag.imageName}:${tag.tagName}`,
+            method: "DELETE",
+            headers: {
+              Authorization: `Bearer ${this.openShiftToken}`,
+            },
+            parse: "json",
+          });
+
+          if (res.statusCode !== 200) {
+            throw new Error(res.statusMessage);
+          }
+
+          console.log(`Deleted ${tag.imageName}:${tag.tagName}`);
+        } catch (err) {
+          console.error(`Error deleting ${tag.imageName}:${tag.tagName} `, err);
+        }
+      }
+    }
+  }
+}
+
+module.exports = ImagePruner;

--- a/tools/imagetag-prune/index.js
+++ b/tools/imagetag-prune/index.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const ImagePruner = require("./imagePruner");
+
+const OPENSHIFT_AUTH_TOKEN = process.env.OPENSHIFT_AUTH_TOKEN;
+const OPENSHIFT_API_URL =
+  process.env.OPENSHIFT_API_URL ||
+  "https://api.silver.devops.gov.bc.ca:6443/apis/image.openshift.io/v1";
+const TOOLS_NAMESPACE = process.env.TOOLS_NAMESPACE || "61d198-tools";
+
+// Regex pattern used to match git sha hash abcd345
+const GIT_SHA_HASH_REGEX =
+  process.env.GIT_SHA_HASH_REGEX || "\\b[0-9a-f]{7}\\b";
+
+  // Regex pattern used to match release tags, e.g., v1.12.3
+const RELEASE_TAG_REGEX =
+  process.env.RELEASE_TAG_REGEX || "^v[0-9]*\\.[0-9]*\\.[0-9]*-?.*";
+
+const IMAGETAGS_TO_KEEP = splitAndTrim(process.env.IMAGETAGS_TO_KEEP) || [
+  "latest",
+  "dev",
+  "test",
+  "prod",
+];
+const IMAGESTRAMS_TO_CLEAN = splitAndTrim(process.env.IMAGESTRAMS_TO_CLEAN) || [
+  "admin",
+  "landing",
+  "public-builder",
+  "strapi",
+];
+
+// Always keep the last "NUM_RELEASES_TO_KEEP" tags
+const NUM_RELEASES_TO_KEEP = process.env.NUM_RELEASES_TO_KEEP || 10;
+
+const DRY_RUN = process.env.DRY_RUN !== "false";
+
+function splitAndTrim(str) {
+  if (str) {
+    return str.split(",").map((item) => item.trim());
+  }
+
+  return str;
+}
+
+const pruner = new ImagePruner({
+  openShiftUrl: `${OPENSHIFT_API_URL}/namespaces/${TOOLS_NAMESPACE}/imagestreamtags`,
+  openShiftToken: OPENSHIFT_AUTH_TOKEN,
+  releaseTagRegex: RELEASE_TAG_REGEX,
+  gitShaHashRegex: GIT_SHA_HASH_REGEX,
+  imageStreamsToPrune: IMAGESTRAMS_TO_CLEAN,
+  imageTagsToIgnore: IMAGETAGS_TO_KEEP,
+  numReleasesToKeep: NUM_RELEASES_TO_KEEP,
+  dryRun: DRY_RUN,
+});
+
+pruner.prune();

--- a/tools/imagetag-prune/package.json
+++ b/tools/imagetag-prune/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "imagetag-prune",
+  "description": "Utility to help prune older image tags in OpenShift namespace",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "phin": "^3.6.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bcgov/bcparks.ca"
+  }
+}


### PR DESCRIPTION
### Description:
- Added a simple utility to help prune older container image tags
- Added a new Github Action to retag images from git hash to the release tag (e.g., from `strapi:f60463d`  to `strapi:v1.0.16`) when a new release tag is created