### PR TITLE
BRS-394 add rocketchat alerts for build workflow failures

### DIFF
--- a/.github/workflows/build-public.yaml
+++ b/.github/workflows/build-public.yaml
@@ -90,3 +90,13 @@ jobs:
       - name: Trigger rollout
         run: |
           oc -n ${{ secrets.OPENSHIFT_LICENSE_PLATE }}-${{ env.ENV_SUFFIX }} rollout restart deployment bcparks-${{ env.DEPLOYMENT_NAME }}
+
+  alert-if-failure:
+    if: ${{ always() && (needs.build.result=='failure')}}
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Send alert if build fails 
+        id: failure_alert
+        run: |
+          curl -X POST -H 'Content-Type: application/json' --data '{"workflow":"${{github.workflow}}","repo":"${{github.repository}}"}' https://chat.developer.gov.bc.ca/hooks/aPYwd4PeHJh5Wnf7u/MmZPC2AZQoFKuSsGwzmxLtMwX3CmHZYLHYPqLnxAdhZsFLJX

--- a/.github/workflows/build-public.yaml
+++ b/.github/workflows/build-public.yaml
@@ -99,4 +99,4 @@ jobs:
       - name: Send alert if build fails 
         id: failure_alert
         run: |
-          curl -X POST -H 'Content-Type: application/json' --data '{"workflow":"${{github.workflow}}","repo":"${{github.repository}}"}' https://chat.developer.gov.bc.ca/hooks/aPYwd4PeHJh5Wnf7u/MmZPC2AZQoFKuSsGwzmxLtMwX3CmHZYLHYPqLnxAdhZsFLJX
+          curl -X POST -H 'Content-Type: application/json' --data '{"workflow":"${{github.workflow}}","repo":"${{github.repository}}"}' https://chat.developer.gov.bc.ca/hooks/${{ secrets.ROCKETCHAT_TOKEN }}


### PR DESCRIPTION
### Jira Ticket:
BRS-394

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-394

### Description:
This change adds a webhook to the build-public github actions workflow to alert the rocketchat channel `osprey-alerts` if the build workflow fails.

The webhook must be accompanied by a JSON payload containing `workflow` and `repo` fields, for context.

Use the `curl` below to test the bot for incoming webhooks - otherwise, the bot should only show alerts when the build workflow fails.

`curl -X POST -H 'Content-Type: application/json' --data '{"workflow":"Test workflow","repo":"testUser/testRepo"}' https://chat.developer.gov.bc.ca/hooks/aPYwd4PeHJh5Wnf7u/MmZPC2AZQoFKuSsGwzmxLtMwX3CmHZYLHYPqLnxAdhZsFLJX`
