### PR TITLE
BRS-380 Add strapi caching middleware and redis

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: strapi
-      BUILDER_IMAGE: registry.access.redhat.com/ubi8/nodejs-14:1-43
+      BUILDER_IMAGE: registry.access.redhat.com/ubi8/nodejs-14:1-56
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2

--- a/infrastructure/helm/bcparks/templates/cms/cms-deployment.yaml
+++ b/infrastructure/helm/bcparks/templates/cms/cms-deployment.yaml
@@ -35,6 +35,8 @@ spec:
               containerPort: {{ .Values.cms.service.port }}
               protocol: TCP
           env:            
+            - name: NODE_OPTIONS
+              value: --max_old_space_size=4096
             - name: NODE_ENV
               value: {{ .Values.cms.env.nodeEnv }}
             - name: STRAPI_TELEMETRY_DISABLED
@@ -97,7 +99,26 @@ spec:
             - name: STRAPI_SMTP_FROM
               value: {{ .Values.cms.env.smtpFrom }}
             - name: STRAPI_SMTP_REPLY_TO
-              value: {{ .Values.cms.env.smtpReplyTo }}
+              value: {{ .Values.cms.env.smtpReplyTo }}              
+            - name: STRAPI_CACHE_ENABLED
+              value: {{ .Values.cms.env.cacheEnabled | quote }}
+            - name: STRAPI_CACHE_TYPE
+              value: {{ .Values.cms.env.cacheType }}
+            - name: STRAPI_CACHE_MODELS
+              value: {{ .Values.cms.env.cacheModels }}
+            - name: STRAPI_CACHE_TTL
+              value: {{ .Values.cms.env.cacheTtl | quote }}
+            - name: STRAPI_CACHE_TIMEOUT
+              value: {{ .Values.cms.env.cacheTimeout | quote }}
+            - name: REDIS_HOST
+              value: {{ .Release.Name }}-{{ .Values.redis.componentName }}
+            - name: REDIS_PORT
+              value: {{ .Values.redis.service.port | quote }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-{{ .Values.redis.componentName }}-secret
+                  key: REDIS_PASSWORD
           envFrom:
             - secretRef:
                 name: {{ template "bcparks_cms_secret" . }}

--- a/infrastructure/helm/bcparks/templates/redis/redis-configmap.yaml
+++ b/infrastructure/helm/bcparks/templates/redis/redis-configmap.yaml
@@ -1,0 +1,19 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.redis.componentName }}-config
+  labels:
+    component: {{ .Values.redis.componentName }}
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+data:
+  redis.conf: |
+    appendonly no
+    cluster-enabled no
+    cluster-require-full-coverage no
+    cluster-migration-barrier 1
+    protected-mode no
+    save 900 1
+    save 300 10
+    save 60 10000

--- a/infrastructure/helm/bcparks/templates/redis/redis-deployment.yaml
+++ b/infrastructure/helm/bcparks/templates/redis/redis-deployment.yaml
@@ -1,0 +1,68 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.redis.componentName }}
+  labels:
+    component: {{ .Values.redis.componentName }}
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      component: {{ .Values.redis.componentName }}
+      release: {{ .Release.Name }}
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        component: {{ .Values.redis.componentName }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Values.redis.componentName }}
+          command:
+            - redis-server
+          args:
+            - '/conf/redis.conf'
+            - '--requirepass'
+            - $(REDIS_PASSWORD)
+          resources:
+{{ toYaml .Values.redis.resources | indent 12 }}
+          image: {{ .Values.images.redis.name }}:{{ .Values.images.redis.tag }}
+          imagePullPolicy: {{ .Values.redis.imagePullPolicy }}
+          ports:
+            - name: {{ .Values.redis.service.portName }}
+              containerPort: {{ .Values.redis.service.port }}
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name }}-{{ .Values.redis.componentName }}-secret
+          volumeMounts:
+            - name: conf
+              mountPath: /conf
+              readOnly: false
+            - name: data
+              mountPath: /data
+              readOnly: false
+          readinessProbe:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - test "$(redis-cli -h $HOSTNAME -a $REDIS_PASSWORD ping)" == "PONG"
+                initialDelaySeconds: 15
+                timeoutSeconds: 1
+                failureThreshold: 3
+      volumes:
+        - name: conf
+          configMap:
+            name: {{ .Release.Name }}-{{ .Values.redis.componentName }}-config
+            defaultMode: 420
+        - name: data
+          emptyDir: {}

--- a/infrastructure/helm/bcparks/templates/redis/redis-service.yaml
+++ b/infrastructure/helm/bcparks/templates/redis/redis-service.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.redis.componentName }}
+  labels:
+    component: {{ .Values.redis.componentName }}
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    component: {{ .Values.redis.componentName }}
+    release: {{ .Release.Name }}
+  ports:
+    - name: {{ .Values.redis.service.portName }}
+      port: {{ .Values.redis.service.port }}

--- a/infrastructure/helm/bcparks/templates/secrets/redis-secret.yaml
+++ b/infrastructure/helm/bcparks/templates/secrets/redis-secret.yaml
@@ -1,0 +1,17 @@
+{{- if not (lookup "v1" "Secret" .Release.Namespace (printf "%s-redis-secret" .Release.Name)) -}}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-redis-secret
+  labels:
+    component: {{ .Values.cms.componentName }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
+stringData:
+  REDIS_PASSWORD: {{ randAlphaNum 50 | quote }}
+{{- end -}}

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -29,6 +29,9 @@ images:
   landing:
     name: image-registry.openshift-image-registry.svc:5000/61d198-tools/landing
     tag: latest
+  redis:
+    name: image-registry.openshift-image-registry.svc:5000/61d198-tools/redis
+    tag: 6.2.6-alpine
 
 cms:
   componentName: cms
@@ -54,6 +57,11 @@ cms:
     smtpPort: 25
     smtpFrom: noreply@gov.bc.ca
     smtpReplyTo: noreply@gov.bc.ca
+    cacheEnabled: true
+    cacheType: redis
+    cacheModels: public-advisory,protected-area
+    cacheTtl: 300000
+    cacheTimeout: 10000
 
   service:
     portName: strapi
@@ -214,3 +222,21 @@ landing:
   service:
     portName: landing
     port: 3000
+
+
+redis:
+  imagePullPolicy: Always
+
+  componentName: redis
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 25m
+      memory: 64Mi
+
+  service:
+    portName: redis
+    port: 6379

--- a/src/cms/config/middleware.js
+++ b/src/cms/config/middleware.js
@@ -1,16 +1,38 @@
-module.exports = {
-  settings: {
-    cors: {
-      origin: [
-        "http://localhost:3000",
-        "http://localhost:1337",
-        "https://*-61d198-dev.apps.silver.devops.gov.bc.ca",
-        "https://*-61d198-test.apps.silver.devops.gov.bc.ca",
-        "https://*-61d198-prod.apps.silver.devops.gov.bc.ca",
-        "https://*.bcparks.ca",
-        "https://bcparks.ca",
-        "*",
-      ],
+module.exports = ({ env }) => {
+  const modelsToCache = env(
+    "STRAPI_CACHE_MODELS",
+    "public-advisory,protected-area"
+  )
+    .split(",")
+    .map((item) => item.trim());
+
+  return {
+    settings: {
+      cors: {
+        origin: [
+          "http://localhost:3000",
+          "http://localhost:1337",
+          "https://*-61d198-dev.apps.silver.devops.gov.bc.ca",
+          "https://*-61d198-test.apps.silver.devops.gov.bc.ca",
+          "https://*-61d198-prod.apps.silver.devops.gov.bc.ca",
+          "https://*.bcparks.ca",
+          "https://bcparks.ca",
+          "*",
+        ],
+      },
+      cache: {
+        enabled: env.bool("STRAPI_CACHE_ENABLED", false),
+        maxAge: env.int("STRAPI_CACHE_TTL", 300000), // Default cache ttl of 5 minutes
+        models: modelsToCache,
+        cacheTimeout: env.int("STRAPI_CACHE_TIMEOUT", 10000),
+        type: env("STRAPI_CACHE_TYPE", "mem"),
+        redisConfig: {
+          host: env("REDIS_HOST", "localhost"),
+          port: env.int("REDIS_PORT", 6379),
+          name: "redis-primary",
+          password: env("REDIS_PASSWORD", null),
+        },
+      },
     },
-  },
+  };
 };

--- a/src/cms/package.json
+++ b/src/cms/package.json
@@ -25,6 +25,7 @@
     "strapi": "3.6.1",
     "strapi-admin": "3.6.1",
     "strapi-connector-bookshelf": "3.6.1",
+    "strapi-middleware-cache": "^2.1.7",
     "strapi-plugin-content-manager": "3.6.1",
     "strapi-plugin-content-type-builder": "3.6.1",
     "strapi-plugin-documentation": "^3.6.1",


### PR DESCRIPTION
### Jira Ticket:
BRS-380

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-380

### Description:
- Added strapi-caching-middleware
- Added Redis OpenShift resources
- strapi-caching-middleware is disabled by default.  It can be enabled with `STRAPI_CACHE_ENABLED=true` for in memory caching.  
- To enable Redis integration, set `STRAPI_CACHE_TYPE=redis`, and `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` if not using default values
