### PR TITLE
NOBUG: remove strapi image fields on parkphoto

### DIFF
--- a/src/cms/api/park-photo/models/park-photo.settings.json
+++ b/src/cms/api/park-photo/models/park-photo.settings.json
@@ -32,22 +32,6 @@
     "photographer": {
       "type": "string"
     },
-    "image": {
-      "model": "file",
-      "via": "related",
-      "allowedTypes": ["images"],
-      "plugin": "upload",
-      "required": false,
-      "pluginOptions": {}
-    },
-    "thumbnail": {
-      "model": "file",
-      "via": "related",
-      "allowedTypes": ["images"],
-      "plugin": "upload",
-      "required": false,
-      "pluginOptions": {}
-    },
     "isActive": {
       "type": "boolean"
     },


### PR DESCRIPTION
We should be using imageUrl & thumbnailUrl anyways. If any file fields fields are present, `gatsby-source-strapi` always loads all the images in them (!!), which has been a cause of build failures and slows things down.
<img width="940" alt="Screen Shot 2022-02-16 at 9 39 28 AM" src="https://user-images.githubusercontent.com/134694/154326286-b00c372c-8eb4-445a-817f-f5d374142bff.png">

