### PR TITLE
NOBUG: Fix page-data cache for Gatsby Caddy

### DIFF
--- a/src/staging/Caddyfile
+++ b/src/staging/Caddyfile
@@ -1,9 +1,6 @@
 :3000 {
-    # try_files {path} / =404
-
-    header /public/page-data/* Cache-Control "public, max-age=0, must-revalidate"
+    header /page-data/* Cache-Control "public, max-age=0, must-revalidate"
     header /static/* Cache-Control "public, max-age=31536000, immutable"
-    header /page-data/app-data.json Cache-Control "public, max-age=0, must-revalidate"
 
     encode gzip
 


### PR DESCRIPTION
### Description:
Fixed the incorrect caching config for Gatsby Caddy.  `/public/page-data/*` was incorrect, the correct path should be `/page-data/*`
