### PR TITLE
BRS-442 Bump Patroni image tag

### DIFF
--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -22,7 +22,7 @@ images:
     tag: latest
   patroni:
     name: image-registry.openshift-image-registry.svc:5000/61d198-tools/patroni-postgres
-    tag: 12.4-latest
+    tag: 2.0.1-12.4
   backup:
     name: image-registry.openshift-image-registry.svc:5000/61d198-tools/backup-container
     tag: postgres-latest


### PR DESCRIPTION
### Jira Ticket:
BRS-442

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-442

### Description:
Bump Patroni image tag version to the upgraded Patroni version (Patroni 2.0.1 - Postgresql 12.4)
