### PR TITLE
BRS-411 Add ability to mount snowplow from configmap

### DIFF
--- a/.github/workflows/build-public.yaml
+++ b/.github/workflows/build-public.yaml
@@ -13,6 +13,7 @@ env:
   IMAGE_NAME: public
   BUILDER_IMAGE_NAME: public-builder
   DEPLOYMENT_NAME: public
+  GATSBY_ENABLE_SNOWPLOW: true
 
 jobs:
   build:

--- a/infrastructure/helm/bcparks/templates/public/public-deployment.yaml
+++ b/infrastructure/helm/bcparks/templates/public/public-deployment.yaml
@@ -39,18 +39,27 @@ spec:
               path: /
               port: 3000
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 5
             timeoutSeconds: 1
-            periodSeconds: 10
+            periodSeconds: 3
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 10
           startupProbe:
             httpGet:
               path: /
               port: 3000
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 5
             timeoutSeconds: 1
-            periodSeconds: 10
+            periodSeconds: 3
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 10
+          volumeMounts:
+            - name: snowplow
+              mountPath: /usr/share/caddy/_scripts
+              readOnly: true
+      volumes:
+        - name: snowplow
+          configMap:
+            name: snowplow
+            defaultMode: 420

--- a/src/staging/src/components/footer.js
+++ b/src/staging/src/components/footer.js
@@ -234,9 +234,12 @@ export default function Footer() {
   return (
     <>
       {/* The next 3 lines will load the Snowplow script mounted from OpenShift configmap. */}
-      <Helmet>
-        <script src="/_scripts/snowplow.js"/>
-      </Helmet>
+      {process.env.GATSBY_ENABLE_SNOWPLOW === "true" && (
+        <Helmet>
+          <script src="/_scripts/snowplow.js" />
+        </Helmet>
+      )}
+      
       <footer id="footer">
         <div className="home-footer" id="home-footer">
           <Box sx={{ margin: "40px 0" }}>

--- a/src/staging/src/components/footer.js
+++ b/src/staging/src/components/footer.js
@@ -5,6 +5,7 @@ import {
   InputLabel,
   TextField
 } from "@material-ui/core"
+import { Helmet } from "react-helmet";
 
 import SearchIcon from "@material-ui/icons/Search"
 import bcParksWordmark from "../images/BCParks_Wordmark_White.svg"
@@ -232,6 +233,10 @@ export default function Footer() {
 
   return (
     <>
+      {/* The next 3 lines will load the Snowplow script mounted from OpenShift configmap. */}
+      <Helmet>
+        <script src="/_scripts/snowplow.js"/>
+      </Helmet>
       <footer id="footer">
         <div className="home-footer" id="home-footer">
           <Box sx={{ margin: "40px 0" }}>


### PR DESCRIPTION
### Jira Ticket:
BRS-411 

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-411 

### Description:
I'm using the `react-helmet` package to load the Snowplow script into the `Footer` component.  It will attempt to load it from `/_scripts/snowplow.js` path.  The snowplow.js file is mounted into the container at runtime from OpenShift ConfigMap.  This allows us to use different script per environment and we are able to update them on the fly without rebuilding.

I have created the ConfigMap in dev, test and prod.  So this PR will just work once deployed.  Note that the `snowplow.js` value in prod is currently a placeholder and won't do anything when mounted.
