### PR TITLE
BRS-446: open camping site in same tab

### DIFF
--- a/src/staging/src/components/megaMenu/desktopMenu.js
+++ b/src/staging/src/components/megaMenu/desktopMenu.js
@@ -100,7 +100,7 @@ const DesktopMenu = ({ linkStructure }) => {
           <Link to="/">
             <img className="bc-parks-logo" src={BCParksLogo} alt="BC Parks logo" />
           </Link>
-          <a href="https://camping.bcparks.ca" rel="noreferrer" target="_blank" className="btn book-campsite-btn">Book a campsite</a>
+          <a href="https://camping.bcparks.ca" className="btn book-campsite-btn">Book a campsite</a>
         </nav>
       </div>
       <div id="desktopNavMenu">

--- a/src/staging/src/components/megaMenu/mobileMenu.js
+++ b/src/staging/src/components/megaMenu/mobileMenu.js
@@ -72,7 +72,7 @@ const MobileMenu = ({ linkStructure }) => {
         })}
         {targetIsRoot &&
           <li className={`text-center nav-item book-campsite-item`}>
-            <a href="https://camping.bcparks.ca" rel="noopener noreferrer nofollow" target="_blank">
+            <a href="https://camping.bcparks.ca">
               <button type="button" className={`btn px-4 py-3`} id="book-campsite">Book a campsite</button>
             </a>
           </li>
@@ -103,7 +103,7 @@ const MobileMenu = ({ linkStructure }) => {
           )
         })}
         <li className={`text-center nav-item book-campsite-item`}>
-          <a href="https://camping.bcparks.ca" rel="noreferrer" target="_blank">
+          <a href="https://camping.bcparks.ca">
             <button type="button" className={`btn px-4 py-3`} id="book-campsite">Book a campsite</button>
           </a>
         </li>
@@ -125,7 +125,7 @@ const MobileMenu = ({ linkStructure }) => {
         <a className="navbar-brand" href="/">
           <img src={BCParksLogo} className="logo" alt="BC Parks logo" />
         </a>
-        <a href="https://camping.bcparks.ca" rel="noreferrer" target="_blank" className="btn book-campsite-btn mr-2">Book a campsite</a>
+        <a href="https://camping.bcparks.ca" className="btn book-campsite-btn mr-2">Book a campsite</a>
         <button
           className={`navbar-toggler border-0 float-right collapsed`}
           type="button"


### PR DESCRIPTION
### Jira Ticket:
BRS-446

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-446

### Description:
Fixes issue flagged by QA. Makes the book a campsite links from the header in the same tab to match the behaviour of the buttons on the park details page.
