### PR TITLE
BRS-393 react helmet shows correct page title on home & explore pages

### DIFF
--- a/src/staging/src/pages/explore.js
+++ b/src/staging/src/pages/explore.js
@@ -35,6 +35,7 @@ import parksLogo from "../images/Mask_Group_5.png"
 import Carousel from "react-material-ui-carousel"
 import SearchFilter from "../components/search/searchFilter"
 import NoSearchResults from "../components/search/noSearchResults"
+import Seo from "../components/seo"
 
 export const query = graphql`
   query {
@@ -454,6 +455,7 @@ export default function Explore({ location, data }) {
 
   return (
     <>
+      <Seo title="Explore"/>
       <Header content={menuContent} />
       <div className="search-body">
         <div className="search-results-main container">

--- a/src/staging/src/pages/index.js
+++ b/src/staging/src/pages/index.js
@@ -8,6 +8,7 @@ import MainSearch from "../components/search/mainSearch"
 import PageContent from "../components/pageContent/pageContent"
 
 import "../styles/home.scss"
+import Seo from "../components/seo"
 
 export const query = graphql`
   query {
@@ -56,7 +57,7 @@ export const query = graphql`
 `
 
 export default function Home({ data }) {
- 
+
   const pageContent = data.strapiPages.Content || [];
   const menuContent = data?.allStrapiMenus?.nodes || []
 
@@ -83,38 +84,38 @@ export default function Home({ data }) {
         <></>
       ) : (
         <div id="home">
-        <div className="park-search-container-wrapper home-max-width-override">
-          <Header mode="internal" content={menuContent} />
+          <Seo title="Home"/>
+          <div className="park-search-container-wrapper home-max-width-override">
+            <Header mode="internal" content={menuContent} />
             <div className="park-search">
               <div id="home-parks-search">
                 <MainSearch />
               </div>
-            <div className="home-page-search-bg">
-              <StaticImage src="../images/home/search_bg.png"
-                placeholder="blurred"
-                loading="eager"
-                style={{ display: "block" }}
-                alt="Mount Robson Park" />
-            </div> 
-          </div>
-        </div>
-        <div className="home-content-width-override">
-          <div id="main">
-            {pageContent.map(content =>
-              <div key={content.strapi_component + '-' + content.id}>
-                <PageContent contentType={content.strapi_component} content={content}></PageContent>
+              <div className="home-page-search-bg">
+                <StaticImage src="../images/home/search_bg.png"
+                  placeholder="blurred"
+                  loading="eager"
+                  style={{ display: "block" }}
+                  alt="Mount Robson Park" />
               </div>
-            )}
+            </div>
+          </div>
+          <div className="home-content-width-override">
+            <div id="main">
+              {pageContent.map(content =>
+                <div key={content.strapi_component + '-' + content.id}>
+                  <PageContent contentType={content.strapi_component} content={content}></PageContent>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="home-max-width-override">
+            <Footer>
+              {data.strapiWebsites.Footer}
+            </Footer>
           </div>
         </div>
-        <div className="home-max-width-override">
-          <Footer>
-            {data.strapiWebsites.Footer}
-          </Footer>
-        </div>
-      </div>
       )}
     </>
   )
 }
-       


### PR DESCRIPTION
### Jira Ticket:
BRS-393

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-393

### Description:

Old Behaviour: Page tab title (helmet) doesn't update when navigating back home from 404 page.
Reason: Home page does not have `SEO` or `Helmet` component to update tab wording on navigation.
Solution: `SEO` component added to home page. A quick comb of other major pages was done to see if this problem existed anywhere else. Updated tab titles now read as follows:

Home page: `Home | BC Parks`
Explore page `Explore | BC Parks`