### PR TITLE
BRS-395-3 replacing accordion components in park information page with bootstrap

### DIFF
--- a/src/staging/src/components/park/advisoryDetails.js
+++ b/src/staging/src/components/park/advisoryDetails.js
@@ -110,6 +110,7 @@ export default function AdvisoryDetails({ advisories }) {
                 // Otherwise the activeKey is set to null, effectively removing the 'open' state from the accordion.
                 // This is a cheeky way to programmatically open one, some, or all items simultaneously.
                 activeKey={expandeds[index] ? advisory.id : null}
+                key={advisory.id}
                 aria-controls={advisory.title}
                 className="mb-4">
                 <Accordion.Toggle as={Container} className="accordion-toggle" onClick={() => {

--- a/src/staging/src/components/park/campingDetails.js
+++ b/src/staging/src/components/park/campingDetails.js
@@ -1,130 +1,129 @@
 import React, { useState } from "react"
-import {
-  Box,
-  Button,
-  Grid,
-  Paper,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-} from "@material-ui/core"
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
+import "../../styles/cmsSnippets/parkInfoPage.scss"
+import Row from "react-bootstrap/Row"
+import Col from "react-bootstrap/Col"
+import Accordion from "react-bootstrap/Accordion"
+import Container from "react-bootstrap/Container"
 import Heading from "./heading"
 import HtmlContent from "./htmlContent"
-import Spacer from "./spacer"
 import StaticIcon from "./staticIcon"
+import { navigate } from "gatsby"
+
+function toCamping() {
+  navigate("https://camping.bcparks.ca/");
+}
 
 export default function CampingDetails({ data }) {
   const campingFacilities = data.parkFacilities.filter(facility =>
     facility.facilityType.facilityName.toLowerCase().includes("camping")
-  ) 
+  )
   const [reservationsExpanded, setReservationsExpanded] = useState(false)
   const [expanded, setExpanded] = useState(Array(campingFacilities.length).fill(false))
 
   if (campingFacilities.length === 0) return null
 
-  const toggleExpand = index => (event, isExpanded) => {
-    expanded[index] = isExpanded
+  const toggleExpand = index => {
+    expanded[index] = !expanded[index]
     setExpanded([...expanded])
   }
 
-  return (
-    <Grid
-      item
-      xs={12}
-      id="park-camping-details-container"
-      className="anchor-link"
-    >
-      <Paper elevation={0}>
-        <div className="d-block d-sm-block d-xs-block d-md-block d-lg-none d-xl-none">
-          <Grid item xs={12} container>
-            {data.hasReservations && (
-              <Button
-                className="yellow-button full-width"
-                href="https://camping.bcparks.ca/"
-              >
-                Book a campsite
-              </Button>
-            )}
-          </Grid>
-          <br />
-        </div>
-        <Grid container>
-          <Grid item xs={6}>
-            <Heading>Camping</Heading>
-          </Grid>
+  const toggleReservations = () => {
+    setReservationsExpanded(!reservationsExpanded);
+  }
 
-          <Grid
-            item
-            xs={6}
-            container
-            justifyContent="flex-end"
-            alignItems="flex-start"
-          >
-            <div className="d-none d-xl-block d-lg-block d-md-none d-sm-none d-xs-none">
-              {data.hasReservations && (
-                <Button
-                  className="yellow-button"
-                  href="https://camping.bcparks.ca/"
-                >
-                  Book a campsite
-                </Button>
+  return (
+    <div className="mb-5">
+      <Row
+        id="park-camping-details-container"
+        className="anchor-link d-flex justify-content-between"
+      >
+        {data.hasReservations && (
+          <Col lg={{ span: 4, order: 'last' }} xl={3} md={{ span: 12, order: 'first' }}
+            className="mb-3">
+            <button
+              className="btn btn-warning btn-block booking-button p-2"
+              onClick={() => toCamping()}
+            >
+              Book a campsite
+            </button>
+          </Col>
+        )}
+        <Col md={{ order: 'last' }} lg={{ order: 'first' }}>
+          <Heading>Camping</Heading>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          {campingFacilities.length > 0 && (
+            <div id="park-camping-list-container" className="anchor-link">
+              {data.reservations && (
+                <div key="reservation">
+                  <Accordion
+                    key="reservations"
+                    aria-controls="reservations"
+                    className="park-details mb-2"
+                  >
+                    <Accordion.Toggle as={Container}
+                      eventKey="0"
+                      id="panel1a-header"
+                      onClick={() => toggleReservations()}
+                    >
+                      <div className="d-flex justify-content-between p-3 accordion-toggle">
+                        <HtmlContent className="accordion-header pl-2">Reservations</HtmlContent>
+                        <div className="d-flex align-items-center expand-icon">
+                          <i className={(reservationsExpanded ? "open " : "close ") + "fa fa-angle-down mx-3"}></i>
+                        </div>
+                      </div>
+                    </Accordion.Toggle>
+
+                    <Accordion.Collapse
+                      eventKey="0"
+                    >
+                      <div className="p-3 pl-5">
+                        <HtmlContent>{data.reservations}</HtmlContent>
+                      </div>
+                    </Accordion.Collapse>
+                  </Accordion>
+                </div>
               )}
             </div>
-          </Grid>
-        </Grid>
-        {campingFacilities.length > 0 && (
-          <div id="park-camping-list-container" className="anchor-link">
-            <Grid container spacing={2}>
-              {data.reservations && (
-                <Grid key="reservation" item xs={12}>
-                  <Accordion
-                    expanded={reservationsExpanded}
-                    onChange={() => setReservationsExpanded(!reservationsExpanded)}
-                    className="park-details-shaded"
-                  >
-                    <AccordionSummary
-                      expandIcon={<ExpandMoreIcon />}
-                      aria-controls="reservations"
-                      id="panel1a-header"
-                    >
-                      <HtmlContent>Reservations</HtmlContent>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <HtmlContent>{data.reservations}</HtmlContent>
-                    </AccordionDetails>
-                  </Accordion>
-                </Grid>
-              )}
-              {campingFacilities.map((facility, index) => (
-                <Grid key={index} item xs={12}>
-                  <Accordion
-                    expanded={expanded[index]}
-                    onChange={toggleExpand(index)}
-                  >
-                    <AccordionSummary
-                      expandIcon={<ExpandMoreIcon />}
-                      aria-controls={facility.facilityType.facilityName}
-                      id={index}
-                    >
-                      <Box mr={1}>
-                        <StaticIcon name={facility.facilityType.icon} size={48} />
-                      </Box>
-                      <HtmlContent className="pl15 p10t">
-                        {facility.facilityType.facilityName}
-                      </HtmlContent>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <HtmlContent>{facility.description}</HtmlContent>
-                    </AccordionDetails>
-                  </Accordion>
-                </Grid>
-              ))}
-            </Grid>
-          </div>
-        )}
-        <Spacer />
-      </Paper>
-    </Grid>
+          )}
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          {campingFacilities.map((facility, index) => (
+            <Accordion
+              key={"campingFacility" + index}
+              className="park-details mb-2"
+            >
+              <Accordion.Toggle as={Container}
+                aria-controls={facility.facilityType.facilityName}
+                eventKey="0"
+                id={index}
+                onClick={() => toggleExpand(index)}
+              >
+                <div className="d-flex justify-content-between p-3 accordion-toggle">
+                  <div className="d-flex justify-content-left align-items-center pl-2">
+                    <StaticIcon name={facility.facilityType.icon} size={48} />
+                    <HtmlContent className="pl-3 accordion-header">{facility.facilityType.facilityName}</HtmlContent>
+                  </div>
+                  <div className="d-flex align-items-center expand-icon">
+                    <i className={(expanded[index] ? "open " : "close ") + "fa fa-angle-down mx-3"}></i>
+                  </div>
+                </div>
+              </Accordion.Toggle>
+              <Accordion.Collapse
+                eventKey="0"
+              >
+                <div className="p-4">
+                  <HtmlContent>{facility.description}</HtmlContent>
+                </div>
+              </Accordion.Collapse>
+            </Accordion>
+          ))}
+        </Col>
+      </Row>
+    </div>
   )
 }

--- a/src/staging/src/components/park/parkActivity.js
+++ b/src/staging/src/components/park/parkActivity.js
@@ -1,16 +1,11 @@
 import React, { useState } from "react"
-import {
-  Paper,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Grid,
-  Box,
-} from "@material-ui/core"
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
+import "../../styles/cmsSnippets/parkInfoPage.scss"
+import Row from "react-bootstrap/Row"
+import Col from "react-bootstrap/Col"
+import Accordion from "react-bootstrap/Accordion"
+import Container from "react-bootstrap/Container"
 import Heading from "./heading"
 import HtmlContent from "./htmlContent"
-import Spacer from "./spacer"
 import StaticIcon from "./staticIcon"
 
 export default function ParkActivity({ data }) {
@@ -19,51 +14,58 @@ export default function ParkActivity({ data }) {
     Array(activityData.length).fill(false)
   )
 
-  if (activityData.length === 0) return null
+  if (activityData.length === 0) return null;
 
-  const handleChange = id => (event, isExpanded) => {
-    expanded[id] = isExpanded
+
+  const toggleExpand = index => {
+    expanded[index] = !expanded[index]
     setExpanded([...expanded])
   }
 
   return (
-    <Grid item xs={12} id="park-activity-container" className="anchor-link">
-      <Paper elevation={0}>
-        <Grid container>
-          <Grid item xs={12}>
-            <Heading>Activities</Heading>
-          </Grid>
-        </Grid>
-        <Grid container spacing={1}>
+    <div className="mb-5">
+      <Row
+        id="park-camping-details-container"
+        className="anchor-link"
+      >
+        <Col>
+          <Heading>Activities</Heading>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
           {activityData.map((activity, index) => (
-            <Grid key={index} item xs={12}>
-              <Paper>
-                <Accordion
-                  expanded={expanded[index]}
-                  onChange={handleChange(index)}
-                >
-                  <AccordionSummary
-                    expandIcon={<ExpandMoreIcon />}
-                    aria-controls={activity.activityType.activityName}
-                    id={index}
-                  >
-                    <Box mr={1}>
-                      <StaticIcon name={activity.activityType.icon} size={48} />
-                    </Box>
-                    <HtmlContent className="pl15 p10t">
-                      {activity.activityType.activityName}
-                    </HtmlContent>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <HtmlContent>{activity.description}</HtmlContent>
-                  </AccordionDetails>
-                </Accordion>
-              </Paper>
-            </Grid>
+            <Accordion
+              key={"parkActivity" + index}
+              className="park-details mb-2"
+            >
+              <Accordion.Toggle as={Container}
+                aria-controls={activity.activityType.activityName}
+                eventKey="0"
+                id={index}
+                onClick={() => toggleExpand(index)}
+              >
+                <div className="d-flex justify-content-between p-3 accordion-toggle">
+                  <div className="d-flex justify-content-left align-items-center pl-2">
+                    <StaticIcon name={activity.activityType.icon} size={48} />
+                    <HtmlContent className="pl-3 accordion-header">{activity.activityType.activityName}</HtmlContent>
+                  </div>
+                  <div className="d-flex align-items-center expand-icon">
+                    <i className={(expanded[index] ? "open " : "close ") + "fa fa-angle-down mx-3"}></i>
+                  </div>
+                </div>
+              </Accordion.Toggle>
+              <Accordion.Collapse
+                eventKey="0"
+              >
+                <div className="p-4">
+                  <HtmlContent>{activity.description}</HtmlContent>
+                </div>
+              </Accordion.Collapse>
+            </Accordion>
           ))}
-        </Grid>
-        <Spacer />
-      </Paper>
-    </Grid>
+        </Col>
+      </Row>
+    </div>
   )
 }

--- a/src/staging/src/components/park/parkFacility.js
+++ b/src/staging/src/components/park/parkFacility.js
@@ -1,16 +1,11 @@
 import React, { useState } from "react"
-import {
-  Paper,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Grid,
-  Box,
-} from "@material-ui/core"
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
+import "../../styles/cmsSnippets/parkInfoPage.scss"
+import Row from "react-bootstrap/Row"
+import Col from "react-bootstrap/Col"
+import Accordion from "react-bootstrap/Accordion"
+import Container from "react-bootstrap/Container"
 import Heading from "./heading"
 import HtmlContent from "./htmlContent"
-import Spacer from "./spacer"
 import StaticIcon from "./staticIcon"
 
 export default function ParkFacility({ data }) {
@@ -21,50 +16,56 @@ export default function ParkFacility({ data }) {
 
   if (facilityData.length === 0) return null
 
-  const handleChange = id => (event, isExpanded) => {
-    expanded[id] = isExpanded
+  const toggleExpand = index => {
+    expanded[index] = !expanded[index]
     setExpanded([...expanded])
   }
 
-  return (
-    <Grid item xs={12} id="park-facility-container" className="anchor-link">
-      <Paper elevation={0}>
-        <Grid container>
-          <Grid item xs={12}>
-            <Heading>Facilities</Heading>
-          </Grid>
-        </Grid>
 
-        <Grid container spacing={1}>
+  return (
+    <div className="mb-5">
+      <Row
+        id="park-facility-container"
+        className="anchor-link"
+      >
+        <Col>
+          <Heading>Facilities</Heading>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
           {facilityData.map((facility, index) => (
-            <Grid key={index} item xs={12}>
-              <Paper>
-                <Accordion
-                  expanded={expanded[index]}
-                  onChange={handleChange(index)}
-                >
-                  <AccordionSummary
-                    expandIcon={<ExpandMoreIcon />}
-                    aria-controls={facility.activityName}
-                    id={index}
-                  >
-                    <Box mr={1}>
-                      <StaticIcon name={facility.facilityType.icon} size={48} />
-                    </Box>
-                    <HtmlContent className="pl15 p10t">
-                      {facility.facilityType.facilityName}
-                    </HtmlContent>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <HtmlContent>{facility.description}</HtmlContent>
-                  </AccordionDetails>
-                </Accordion>
-              </Paper>
-            </Grid>
+            <Accordion
+              key={"parkFacility" + index}
+              className="park-details mb-2"
+            >
+              <Accordion.Toggle as={Container}
+                aria-controls={facility.activityName}
+                eventKey="0"
+                id={index}
+                onClick={() => toggleExpand(index)}
+              >
+                <div className="d-flex justify-content-between p-3 accordion-toggle">
+                  <div className="d-flex justify-content-left align-items-center pl-2">
+                    <StaticIcon name={facility.facilityType.icon} size={48} />
+                    <HtmlContent className="pl-3 accordion-header">{facility.facilityType.facilityName}</HtmlContent>
+                  </div>
+                  <div className="d-flex align-items-center expand-icon">
+                    <i className={(expanded[index] ? "open " : "close ") + "fa fa-angle-down mx-3"}></i>
+                  </div>
+                </div>
+              </Accordion.Toggle>
+              <Accordion.Collapse
+                eventKey="0"
+              >
+                <div className="p-4">
+                  <HtmlContent>{facility.description}</HtmlContent>
+                </div>
+              </Accordion.Collapse>
+            </Accordion>
           ))}
-        </Grid>
-        <Spacer />
-      </Paper>
-    </Grid>
+        </Col>
+      </Row>
+    </div>
   )
 }

--- a/src/staging/src/styles/cmsSnippets/parkInfoPage.scss
+++ b/src/staging/src/styles/cmsSnippets/parkInfoPage.scss
@@ -1,0 +1,56 @@
+@import "../global.scss";
+
+.booking-button {
+  background-color: $colorGold !important;
+  border: 2px solid $colorGold !important;
+
+  &:hover{
+    background-color: transparent !important;
+    border: 2px solid $colorGold !important;
+    text-decoration: underline;
+  }
+}
+
+.expand-icon{
+  color: rgba(0, 0, 0, 0.54);
+
+  & .open{
+    font-size: 1.5rem;
+    -webkit-transform: rotate(180deg);
+    -moz-transform: rotate(180deg);
+    -ms-transform: rotate(180deg);
+    -o-transform: rotate(180deg);
+    transform: rotate(180deg);
+    transition: 0.3s;
+  }
+
+  & .close{
+    font-size: 1.5rem;
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+    transition: 0.3s;
+  }
+}
+
+.park-details {
+  background-color: white;
+  color: $colorBlue;
+  border-radius: 4px;
+  border: 1px solid $colorBlue;
+
+  &:hover{
+    border: 1px solid $colorGold;
+  }
+}
+
+.accordion-toggle {
+  cursor: pointer;
+}
+
+.accordion-header{
+  font-size: 16px;
+  color: #003366 !important;
+}


### PR DESCRIPTION
### Jira Ticket:
BRS-395

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-395

### Description:

This change is part of a series of updates to replace MUI Accordion components with bootstrap equivalents.

This particular change updates the accordion components on the park information pages.

NOTE: `b24b177` is to fix accordion collapsing jitters and to add keys to mapped React child components. The original commit, `663a8ee`, contained the major accordion changes, but this history was lost in a poor rebase. All changes now contained in `b24b177`.