### PR TITLE
BRS-410 (part 1): add isDisplayed flag to protected areas

### DIFF
--- a/src/cms/api/protected-area/models/protected-area.settings.json
+++ b/src/cms/api/protected-area/models/protected-area.settings.json
@@ -155,6 +155,11 @@
     },
     "slug": {
       "type": "string"
+    },
+    "isDisplayed": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
BRS-410

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-410

### Description:
Adds an isDisplayed flag to protected areas in Strapi. Not used for anything yet, but to be set for future use via this query (and manually after that):

```
UPDATE protected_areas SET "isDisplayed" = TRUE WHERE published_at IS NOT NULL;
```

This is part 1 of 2 replacing #301 - the plan is to deploy this change, set the data, then hide protected areas where it's not set.