### PR TITLE
BRS-410 (part 2): check park display flag on alerts, park pages, and search

### DIFF
--- a/src/cms/api/protected-area/services/protected-area.js
+++ b/src/cms/api/protected-area/services/protected-area.js
@@ -147,8 +147,9 @@ module.exports = {
         )
         .groupBy("protected_areas.id");
 
-      // Only include published parks
+      // Only include published & displayed parks
       query.whereNotNull("protected_areas.published_at");
+      query.where("protected_areas.isDisplayed", true);
 
       if (typeCode) {
         query.where("protected_areas.typeCode", typeCode);
@@ -268,8 +269,9 @@ module.exports = {
       )
       .groupBy("protected_areas.id");
 
-    // Only include published parks
-    query.whereNotNull("protected_areas.published_at");
+      // Only include published & displayed parks
+      query.whereNotNull("protected_areas.published_at");
+      query.where("protected_areas.isDisplayed", true);
 
     if (typeCode) {
       query.where("protected_areas.typeCode", typeCode);

--- a/src/cms/api/protected-area/services/protected-area.js
+++ b/src/cms/api/protected-area/services/protected-area.js
@@ -269,9 +269,9 @@ module.exports = {
       )
       .groupBy("protected_areas.id");
 
-      // Only include published & displayed parks
-      query.whereNotNull("protected_areas.published_at");
-      query.where("protected_areas.isDisplayed", true);
+    // Only include published & displayed parks
+    query.whereNotNull("protected_areas.published_at");
+    query.where("protected_areas.isDisplayed", true);
 
     if (typeCode) {
       query.where("protected_areas.typeCode", typeCode);

--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -97,6 +97,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   type StrapiProtectedArea implements Node {
     orcs: Int
     hasDayUsePass: String
+    isDisplayed: Boolean
     parkContact: String
     urlPath: String @parkPath
     parkActivities: [StrapiParkActivities]
@@ -137,7 +138,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 async function createParks({ graphql, actions, reporter }) {
   const parkQuery = `
   {
-    allStrapiProtectedArea {
+    allStrapiProtectedArea(filter: {isDisplayed: {eq: true}}) {
       nodes {
         id
         orcs

--- a/src/staging/src/components/advisories/advisoryCard.js
+++ b/src/staging/src/components/advisories/advisoryCard.js
@@ -56,7 +56,7 @@ const AdvisoryCard = ({ advisory, index }) => {
                       )}
                       <div>
                         {advisory.protectedAreas.length > 0 &&
-                          advisory.protectedAreas.filter(park => park.published_at).map((par, index) => (
+                          advisory.protectedAreas.filter(park => park.published_at && park.isDisplayed).map((par, index) => (
                             <Badge
                               pill variant="light"
                               className="parkLink my-2"

--- a/src/staging/src/pages/alerts.js
+++ b/src/staging/src/pages/alerts.js
@@ -213,7 +213,7 @@ const PublicAdvisoryPage = ({ data }) => {
     // unfiltered count for the header
 
     // exclude unpublished parks
-    let q = "/public-advisories/count?protectedAreas.published_at_null=false";
+    let q = "/public-advisories/count?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true";
 
     if (advisoryType === "wildfire") {
       q += "&eventType.eventType_contains=wildfire";
@@ -240,7 +240,7 @@ const PublicAdvisoryPage = ({ data }) => {
   const getApiQuery = useCallback((advisoryTypeFilter) => {
 
     // Order by date and exclude unpublished parks
-    let q = "?protectedAreas.published_at_null=false&_sort=advisoryDate:DESC";
+    let q = "?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true&_sort=advisoryDate:DESC";
 
     if (advisoryTypeFilter === "wildfire") {
       q += "&eventType.eventType_contains=wildfire";

--- a/src/staging/src/pages/parks.js
+++ b/src/staging/src/pages/parks.js
@@ -48,7 +48,7 @@ export default ParksPage
 
 export const query = graphql`
   {
-    allStrapiProtectedArea(sort: { fields: protectedAreaName }) {
+    allStrapiProtectedArea(filter: {isDisplayed: {eq: true}}, sort: { fields: protectedAreaName }) {
       edges {
         node {
           id


### PR DESCRIPTION
### Jira Ticket:
BRS-410

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-410

### Description:
Consumes the `isDisplayed` flag added to strapi in #308.  This is part 2 of 2 replacing https://github.com/bcgov/bcparks.ca/pull/301 - the plan is to deploy that change, set the data, then merge and deploy this one.


Once it's in place, we can run the following query to show all protected areas via API endpoint:

```
UPDATE protected_areas SET published_at = NOW() WHERE published_at IS NULL;
```
