### PR TITLE
BRS-339 Match explore page park status with highest precedence advisory

### DIFF
--- a/src/cms/api/protected-area/services/protected-area.js
+++ b/src/cms/api/protected-area/services/protected-area.js
@@ -94,8 +94,8 @@ module.exports = {
           // Include all advisories, filtering out nulls caused by joins.
           // In future this can be replaced with a count
           knex.raw(
-            'array_remove(array_agg(DISTINCT ?? ORDER BY ??), NULL) AS "advisories"',
-            ["public_advisories.title", "public_advisories.title"]
+            'to_json(array_remove(array_agg(DISTINCT ?? ORDER BY ??), NULL)) AS "advisories"',
+            ["public_advisories.*", "public_advisories.*"]
           ),
           // Include all active park photos. Photo ordering hasn't been implemented
           // yet, so order is indeterminate. We do check that the photo is active.

--- a/src/staging/gatsby-config.js
+++ b/src/staging/gatsby-config.js
@@ -35,6 +35,7 @@ module.exports = {
           "facility-types",
           "menus",
           "park-operation",
+          "access-statuses"
         ],
         queryLimit: -1,
       },

--- a/src/staging/src/components/park/parkAccessStatus.js
+++ b/src/staging/src/components/park/parkAccessStatus.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql, useStaticQuery } from "gatsby"
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles"
 import { Card, CardHeader, Avatar } from "@material-ui/core"
@@ -21,38 +22,27 @@ const ICONS = {
   "red": redStatusIcon,
 }
 
-const PRECEDENCES = {
-  1: {
-    text: "Full Closure",
-    color: "red"
-  },
-  2: {
-    text: "Partial Closure",
-    color: "yellow"
-  },
-  3: {
-    text: "Inaccessible",
-    color: "yellow"
-  },
-  4: {
-    text: "Warning",
-    color: "yellow"
-  },
-  5: {
-    text: "Closed to the public",
-    color: "yellow"
-  },
-  6: {
-    text: "Restricted; permit required",
-    color: "yellow"
-  },
-  99: {
-    text: "Open",
-    color: "blue"
-  },
-}
-
 export default function ParkAccessStatus({ advisories }) {
+
+  const data = useStaticQuery(
+    graphql`
+      {
+        allStrapiAccessStatuses {
+          edges {
+            node {
+              id
+              color
+              accessStatus
+              precedence
+            }
+          }
+        }
+      }
+    `
+  )
+
+  const accessStatusList = data?.allStrapiAccessStatuses.edges;
+
   const classes = useStyles()
   let parkStatusIcon = blueStatusIcon
   let parkStatusText = "Open to public access"
@@ -73,11 +63,19 @@ export default function ParkAccessStatus({ advisories }) {
         });
       } else {
         // advisory is coming from explore page
-        accessStatuses.push({
-          precedence: advisory.accessStatus,
-          color: PRECEDENCES[advisory.accessStatus].color,
-          text: PRECEDENCES[advisory.accessStatus].text,
+        // get accessStatus based on precedence
+        let thisStatus = accessStatusList.filter(status => {
+          return status.node.precedence === advisory.accessStatus;
         })
+        if (!thisStatus || thisStatus.length === 0) {
+          break;
+        } else {
+          accessStatuses.push({
+            precedence: thisStatus[0].node.precedence,
+            color: thisStatus[0].node.color,
+            text: thisStatus[0].node.accessStatus,
+          })
+        }
       }
     }
   }

--- a/src/staging/src/components/park/parkAccessStatus.js
+++ b/src/staging/src/components/park/parkAccessStatus.js
@@ -31,6 +31,7 @@ export default function ParkAccessStatus({ advisories }) {
           edges {
             node {
               id
+              strapiId
               color
               accessStatus
               precedence
@@ -64,8 +65,8 @@ export default function ParkAccessStatus({ advisories }) {
       } else {
         // advisory is coming from explore page
         // get accessStatus based on precedence
-        let thisStatus = accessStatusList.filter(status => {
-          return status.node.precedence === advisory.accessStatus;
+        let thisStatus = accessStatusList.find(status => {
+          return status.node.strapiId === advisory.accessStatus;
         })
         if (!thisStatus || thisStatus.length === 0) {
           break;

--- a/src/staging/src/components/park/parkAccessStatus.js
+++ b/src/staging/src/components/park/parkAccessStatus.js
@@ -68,13 +68,13 @@ export default function ParkAccessStatus({ advisories }) {
         let thisStatus = accessStatusList.find(status => {
           return status.node.strapiId === advisory.accessStatus;
         })
-        if (!thisStatus || thisStatus.length === 0) {
+        if (!thisStatus) {
           break;
         } else {
           accessStatuses.push({
-            precedence: thisStatus[0].node.precedence,
-            color: thisStatus[0].node.color,
-            text: thisStatus[0].node.accessStatus,
+            precedence: thisStatus.node.precedence,
+            color: thisStatus.node.color,
+            text: thisStatus.node.accessStatus,
           })
         }
       }

--- a/src/staging/src/components/park/parkAccessStatus.js
+++ b/src/staging/src/components/park/parkAccessStatus.js
@@ -20,18 +20,68 @@ const ICONS = {
   "yellow": yellowStatusIcon,
   "red": redStatusIcon,
 }
+
+const PRECEDENCES = {
+  1: {
+    text: "Full Closure",
+    color: "red"
+  },
+  2: {
+    text: "Partial Closure",
+    color: "yellow"
+  },
+  3: {
+    text: "Inaccessible",
+    color: "yellow"
+  },
+  4: {
+    text: "Warning",
+    color: "yellow"
+  },
+  5: {
+    text: "Closed to the public",
+    color: "yellow"
+  },
+  6: {
+    text: "Restricted; permit required",
+    color: "yellow"
+  },
+  99: {
+    text: "Open",
+    color: "blue"
+  },
+}
+
 export default function ParkAccessStatus({ advisories }) {
   const classes = useStyles()
   let parkStatusIcon = blueStatusIcon
   let parkStatusText = "Open to public access"
 
-  const accessStatuses = advisories.filter(advisory => advisory.accessStatus).map(advisory => {
-    return {
-      precedence: advisory.accessStatus.precedence,
-      color: advisory.accessStatus.color,
-      text: advisory.accessStatus.accessStatus,
+  // unfortunately, incoming advisories from parks details and explore pages are structured differently.
+  // we need to differentiate between the two structures. 
+
+  let accessStatuses = [];
+
+  for (let advisory of advisories) {
+    if (advisory.accessStatus) {
+      if (advisory.accessStatus.precedence) {
+        // advisory is coming from parks details page
+        accessStatuses.push({
+          precedence: advisory.accessStatus.precedence,
+          color: advisory.accessStatus.color,
+          text: advisory.accessStatus.accessStatus,
+        });
+      } else {
+        // advisory is coming from explore page
+        accessStatuses.push({
+          precedence: advisory.accessStatus,
+          color: PRECEDENCES[advisory.accessStatus].color,
+          text: PRECEDENCES[advisory.accessStatus].text,
+        })
+      }
     }
-  })
+  }
+
   accessStatuses.sort((a, b) => {
     return a.precedence - b.precedence
   })

--- a/src/staging/src/pages/explore.js
+++ b/src/staging/src/pages/explore.js
@@ -36,6 +36,7 @@ import Carousel from "react-material-ui-carousel"
 import SearchFilter from "../components/search/searchFilter"
 import NoSearchResults from "../components/search/noSearchResults"
 import Seo from "../components/seo"
+import ParkAccessStatus from "../components/park/parkAccessStatus"
 
 export const query = graphql`
   query {
@@ -455,7 +456,7 @@ export default function Explore({ location, data }) {
 
   return (
     <>
-      <Seo title="Explore"/>
+      <Seo title="Explore" />
       <Header content={menuContent} />
       <div className="search-body">
         <div className="search-results-main container">
@@ -488,7 +489,7 @@ export default function Explore({ location, data }) {
               </div>
             </div>
             <div className="row no-gutters">
-            <div className="col-lg-3 col-md-12 col-sm-12">
+              <div className="col-lg-3 col-md-12 col-sm-12">
                 <div className="search-results-quick-filter m15t d-none d-xl-block d-lg-block d-md-none d-sm-none d-xs-none">
                   <div className="row no-gutters">
                   </div>
@@ -821,7 +822,7 @@ export default function Explore({ location, data }) {
                   {!isLoading && (
                     <>
                       {!searchResults ||
-                        (searchResults.length === 0 && (<NoSearchResults></NoSearchResults>) )}
+                        (searchResults.length === 0 && (<NoSearchResults></NoSearchResults>))}
                       {searchResults && searchResults.length > 0 && (
                         <>
                           {searchResults
@@ -884,16 +885,9 @@ export default function Explore({ location, data }) {
                                           <div className="col-lg-7 p20t park-content p20l">
                                             <div className="row">
                                               <div className="col-12 park-overview-content text-blue small-font">
-                                                {r.isOpenToPublic && (
-                                                  <div className="text-green font-weight-bold">
-                                                    Open to public access
-                                                  </div>
-                                                )}
-                                                {!r.isOpenToPublic && (
-                                                  <div className="text-red font-weight-bold">
-                                                    Closed to public access
-                                                  </div>
-                                                )}
+                                                <div>
+                                                  <ParkAccessStatus advisories={r.advisories}/>
+                                                </div>
                                               </div>
                                             </div>
                                             <Link
@@ -922,7 +916,7 @@ export default function Explore({ location, data }) {
                                                             src={redAlertIcon}
                                                           />
                                                           <div className="pl15 text-blue pb20">
-                                                            {a} (1)
+                                                            {a.title} (1)
                                                           </div>
                                                         </>
                                                       )}
@@ -1240,7 +1234,7 @@ export default function Explore({ location, data }) {
                                                             src={redAlertIcon}
                                                           />
                                                           <div className="pl15 text-blue">
-                                                            {a} (1)
+                                                            {a.title} (1)
                                                           </div>
                                                         </>
                                                       )}


### PR DESCRIPTION
### Jira Ticket:
BRS-339

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-339

### Description:
This ticket changes the accessStatus component on the parks exploration page to match the actual accessStatus of the advisories associated with the park, and not infer accessStatus indirectly.

When searching for parks, the API already returns the titles of the advisories within the park object, so the API has been slightly modified to return the whole advisory, including the accessStatus.

Unfortunately, the structure of an advisory within a park object as mentioned above differs from that of an advisory directly returned via the API,. The React Component `ParkAccessStatus` which displays the access status on the parks details pages was modified to be able to accept the differing structures, so that this component could be also leveraged on the explore page.