### PR TITLE
BRS-335 (part 1): add sort order and featured fields

### DIFF
--- a/src/cms/api/park-photo/models/park-photo.settings.json
+++ b/src/cms/api/park-photo/models/park-photo.settings.json
@@ -40,6 +40,16 @@
     },
     "thumbnailUrl": {
       "type": "string"
+    },
+    "isFeatured": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "sortOrder": {
+      "type": "integer",
+      "required": true,
+      "default": 100
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
BRS-335

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-335

### Description:
``sortOrder`` is to be used to order photos in the display (lowest first)

``isFeatured`` is a boolean value to indicate the main photo forvsearch results, etc. Ideally there should be one featured photo per park, but that is not easily enforcable in Strapi, so I think we can fall back to sortOrder if there are multiple values.

