### PR TITLE
BRS-408 pagination reset after filter update on mobile view

### DIFF
--- a/src/staging/src/components/search/searchFilter.js
+++ b/src/staging/src/components/search/searchFilter.js
@@ -115,6 +115,7 @@ const SearchFilter = ({
     selectedFacilities,])
 
   const searchParkFilter = () => {
+    setCurrentPage(1);
     navigate("/explore", {
       state: {
         selectedActivities,
@@ -472,6 +473,7 @@ SearchFilter.propTypes = {
     setQuickSearch: PropTypes.func.isRequired,
     searchText: PropTypes.string.isRequired,
     setSearchText: PropTypes.func.isRequired,
+    setCurrentPage: PropTypes.func.isRequired
   }),
 }
 

--- a/src/staging/src/components/search/searchFilter.js
+++ b/src/staging/src/components/search/searchFilter.js
@@ -35,6 +35,7 @@ const SearchFilter = ({
     setSelectedFacilities,
     searchText,
     setSearchText,
+    setCurrentPage,
   },
 
 }) => {
@@ -55,6 +56,7 @@ const SearchFilter = ({
         ...selectedActivities.filter(a => a.value !== activity.value),
       ])
     }
+    setCurrentPage(1);
   }
 
   const handleFacilityCheck = (facility, event) => {
@@ -65,6 +67,7 @@ const SearchFilter = ({
         ...selectedFacilities.filter(f => f.value !== facility.value),
       ])
     }
+    setCurrentPage(1);
   }
 
   const handleShowFilterClick = index => {
@@ -77,12 +80,14 @@ const SearchFilter = ({
     setSelectedActivities(chips =>
       chips.filter(chip => chip.value !== chipToDelete.value)
     )
+    setCurrentPage(1);
   }
 
   const handleFacilityDelete = chipToDelete => {
     setSelectedFacilities(chips =>
       chips.filter(chip => chip.value !== chipToDelete.value)
     )
+    setCurrentPage(1);
   }
 
   const handleFilterDelete = chipToDelete => () => {
@@ -91,6 +96,7 @@ const SearchFilter = ({
     } else if (chipToDelete.type === "facility") {
       handleFacilityDelete(chipToDelete)
     }
+    setCurrentPage(1);
   }
 
   const setFilters = useCallback(() => {

--- a/src/staging/src/pages/explore.js
+++ b/src/staging/src/pages/explore.js
@@ -1413,6 +1413,7 @@ export default function Explore({ location, data }) {
           setQuickSearch,
           searchText,
           setSearchText,
+          setCurrentPage,
         }}
       />
       <Footer>{data.strapiWebsites.Footer}</Footer>

--- a/src/staging/src/pages/explore.js
+++ b/src/staging/src/pages/explore.js
@@ -300,6 +300,7 @@ export default function Explore({ location, data }) {
   }
 
   const handleSearch = () => {
+    setCurrentPage(1);
     setSearchText(inputText)
   }
 
@@ -598,6 +599,7 @@ export default function Explore({ location, data }) {
                               onKeyPress={ev => {
                                 if (ev.key === "Enter") {
                                   setSearchText(inputText)
+                                  setCurrentPage(1)
                                   ev.preventDefault()
                                 }
                               }}


### PR DESCRIPTION
### Jira Ticket:
BRS-408

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-408

### Description:
This change resets the park pagination to page 1 after filters are updated. The `searchFilter` component is used in mobile view which has different handler functions for when a filter is checked/unchecked. This change passes the `setCurrentPage` state function from the explore page to the `searchFilter` component so the currentPage state can be tracked there.