### PR TITLE
BRS-335 (part 2): use photo sort order

### DIFF
--- a/src/cms/api/protected-area/services/protected-area.js
+++ b/src/cms/api/protected-area/services/protected-area.js
@@ -92,20 +92,26 @@ module.exports = {
         .select(
           "protected_areas.*",
           // Include all advisories, filtering out nulls caused by joins.
-          // In future this can be replaced with a count
           knex.raw(
             'to_json(array_remove(array_agg(DISTINCT ?? ORDER BY ??), NULL)) AS "advisories"',
             ["public_advisories.*", "public_advisories.*"]
           ),
-          // Include all active park photos. Photo ordering hasn't been implemented
-          // yet, so order is indeterminate. We do check that the photo is active.
-          // TODO: could likely be done as a join instead of subquery
+          // Include all active park photos. Ordering is by featured first,
+          // then sort order, then most recently taken first (as a fallback
+          // for cases where the order is not specified).
+          // Only includes the first 6 photos, as a some parks may have large galleries
           knex.raw(
             `array(
               SELECT "thumbnailUrl"
               FROM park_photos
               WHERE park_photos.orcs = protected_areas.orcs
                   AND park_photos."isActive" = TRUE
+                  AND park_photos."thumbnailUrl" IS NOT NULL
+              ORDER BY park_photos."isFeatured" DESC NULLS LAST,
+              	  park_photos."sortOrder" ASC NULLS LAST,
+              	  park_photos."dateTaken" DESC,
+                  park_photos."id" DESC
+              LIMIT 6
             ) AS "parkPhotos"`
           ),
           // Check all associated park operations rows, and set hasReservations

--- a/src/cms/api/protected-area/services/protected-area.js
+++ b/src/cms/api/protected-area/services/protected-area.js
@@ -108,8 +108,8 @@ module.exports = {
                   AND park_photos."isActive" = TRUE
                   AND park_photos."thumbnailUrl" IS NOT NULL
               ORDER BY park_photos."isFeatured" DESC NULLS LAST,
-              	  park_photos."sortOrder" ASC NULLS LAST,
-              	  park_photos."dateTaken" DESC,
+                  park_photos."sortOrder" ASC NULLS LAST,
+                  park_photos."dateTaken" DESC,
                   park_photos."id" DESC
               LIMIT 6
             ) AS "parkPhotos"`

--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -92,6 +92,8 @@ exports.createSchemaCustomization = ({ actions }) => {
   type StrapiParkPhoto implements Node {
     orcs: Int
     isActive: Boolean
+    sortOrder: Int
+    isFeatured: Boolean
   }
 
   type StrapiProtectedArea implements Node {

--- a/src/staging/src/templates/park.js
+++ b/src/staging/src/templates/park.js
@@ -63,7 +63,7 @@ export default function ParkTemplate({ data }) {
   const apiBaseUrl = data.site.siteMetadata.apiURL
 
   const park = data.strapiProtectedArea
-  const photos = data.allStrapiParkPhoto.nodes
+  const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]
   const operations = data.allStrapiParkOperation.nodes
 
   const activeActivities = sortBy(
@@ -440,12 +440,22 @@ export const query = graphql`
         hasReservations
       }
     }
-    allStrapiParkPhoto(
-      filter: { orcs: { eq: $orcs }, isActive: { eq: true } }
+    # Park photos are split into featured and non-featured in order to sort correctly,
+    # with null values last.
+    featuredPhotos:allStrapiParkPhoto(
+      filter: { orcs: { eq: $orcs }, isFeatured: { eq: true }, isActive: { eq: true } }
+      sort: {order: [ASC, DESC, DESC], fields: [sortOrder, dateTaken, strapiId]}
     ) {
       nodes {
-        orcs
-        isActive
+        imageUrl
+        caption
+      }
+    }
+    regularPhotos:allStrapiParkPhoto(
+      filter: { orcs: { eq: $orcs }, isFeatured: { ne: true }, isActive: { eq: true } }
+      sort: {order: [ASC, DESC, DESC], fields: [sortOrder, dateTaken, strapiId]}
+    ) {
+      nodes {
         imageUrl
         caption
       }


### PR DESCRIPTION
### Jira Ticket:
BRS-335

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-335

### Description:
Uses the new feature photo/sort order fields to rank photos in search results and photo galleries.
