### PR TITLE
BRS-471 advisory filters still visible when no advisories present

### DIFF
--- a/src/staging/src/components/advisories/advisoryFilter.js
+++ b/src/staging/src/components/advisories/advisoryFilter.js
@@ -182,7 +182,7 @@ const AdvisoryFilter = ({ filterFunctions }) => {
             Event type
           </label>
           <NativeSelect
-            value={advisoryType}
+            value={getType()}
             id="advisory-type"
             
             className={classes.typeSelect + " h50p"}

--- a/src/staging/src/pages/alerts.js
+++ b/src/staging/src/pages/alerts.js
@@ -402,7 +402,6 @@ const PublicAdvisoryPage = ({ data }) => {
 
         <br />
         <h1>{pageTitle}</h1>
-        {advisoryCount > 0 &&
         <div className={classes.advisoriesHeader}>
           <div className={classes.advisoryCountNotice}>
             <div className={classes.advisoryCount}>
@@ -415,8 +414,6 @@ const PublicAdvisoryPage = ({ data }) => {
           </div>
           <AdvisoryFilter filterFunctions={filterFunctions}></AdvisoryFilter>
         </div>
-        }
-
         <div className="mb-3">
           <i className="fa fa-info-circle"></i> <em>Not all advisories are available in beta</em>
         </div>


### PR DESCRIPTION
### Jira Ticket:
BRS-471

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-471

### Description:
This change removes a conditional statement wrapping the advisory filter that would hide the filter if there were no advisories matching the search criteria.
