### PR TITLE
BRS-457 review of incorrectly cascading intro page styles

### DIFF
--- a/src/staging/src/pages/intro.js
+++ b/src/staging/src/pages/intro.js
@@ -37,7 +37,7 @@ const IntroPage = ({ data }) => {
         <Header mode="internal" content={menuContent} />
       </div>
 
-      {htmlContent && <HTMLArea className="intro-page" isVisible={true}>{htmlContent.HTML}</HTMLArea>}
+      {htmlContent && <div className="intro-page"><HTMLArea isVisible={true}>{htmlContent.HTML}</HTMLArea></div>}
 
       <div className="max-width-override">
         <Footer>{data.strapiWebsites.Footer}</Footer>

--- a/src/staging/src/pages/intro.js
+++ b/src/staging/src/pages/intro.js
@@ -37,7 +37,7 @@ const IntroPage = ({ data }) => {
         <Header mode="internal" content={menuContent} />
       </div>
 
-      {htmlContent && <HTMLArea isVisible={true}>{htmlContent.HTML}</HTMLArea>}
+      {htmlContent && <HTMLArea className="intro-page" isVisible={true}>{htmlContent.HTML}</HTMLArea>}
 
       <div className="max-width-override">
         <Footer>{data.strapiWebsites.Footer}</Footer>

--- a/src/staging/src/styles/betaLanding.scss
+++ b/src/staging/src/styles/betaLanding.scss
@@ -1,177 +1,177 @@
-a.btn {
-  background-color: #fff;
-  border: 2px solid #036;
-  border-radius: 5px;
-  color: #036;
-  text-align: center;
-  text-decoration: none;
-}
+  a.btn {
+    background-color: #fff;
+    border: 2px solid #036;
+    border-radius: 5px;
+    color: #036;
+    text-align: center;
+    text-decoration: none;
+  }
 
-a.btn:hover {
-  background-color: #036;
-  color: #fff;
-}
+  a.btn:hover {
+    background-color: #036;
+    color: #fff;
+  }
 
-.beta-welcome {
-  padding-top: 80px;
-  margin-bottom: 100px;
-  color: #003366;
-  background-image: url("https://nrs.objectstore.gov.bc.ca/kuwyyf/beta_landing_image_background_credit_michael_benz_1408791a9c.jpeg");
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-}
+  .beta-welcome {
+    padding-top: 80px;
+    margin-bottom: 100px;
+    color: #003366;
+    background-image: url("https://nrs.objectstore.gov.bc.ca/kuwyyf/beta_landing_image_background_credit_michael_benz_1408791a9c.jpeg");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
 
-.beta-welcome_content {
-  position: relative;
-  z-index: 1000;
-}
-
-.beta-welcome_main-heading {
-  font-weight: bold;
-  margin-bottom: 16px;
-  font-size: 3rem;
-}
-
-.beta-welcome_screenshots-container {
-  margin-top: -100px;
-
-  img {
+  .beta-welcome_content {
     position: relative;
-    top: 150px;
-    max-width: 100%;
-    height: auto;
-  }
-}
-
-.beta-description {
-  color: #000;
-  max-width: 1100px;
-  text-align: center;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 160px;
-
-  h2 {
-    color: #003366;
-  }
-}
-
-.contents {
-  margin-top: 160px;
-
-  h2 {
-    color: #003366;
+    z-index: 1000;
   }
 
-  p {
-    color: #000;
+  .beta-welcome_main-heading {
+    font-weight: bold;
+    margin-bottom: 16px;
+    font-size: 3rem;
   }
 
-  img {
-    width: 100%;
-  }
-}
-
-.research {
-  background-image: url("https://nrs.objectstore.gov.bc.ca/kuwyyf/beta_landing_research_intake_4e8d49a5bc.png");
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  height: 330px;
-  border-radius: 16px;
-  margin-top: 160px;
-  padding: 32px;
-  color: #fff;
-}
-
-.research_large-screen img {
-  width: 300px;
-  margin-left: -30px;
-}
-
-.research_narrow-screen {
-  display: none;
-}
-
-.research_narrow-screen_flex-container {
-  height: 100%;
-}
-
-.research_narrow-screen_content {
-  width: 100%;
-  background-color: #036;
-  border-radius: 0 0 16px 16px;
-  padding: 48px 32px;
-}
-
-.research_narrow-screen_content a:link {
-  color: #fff;
-  text-decoration: none;
-}
-
-.research_narrow-screen_content a:visited {
-  color: #fff;
-  text-decoration: none;
-}
-
-.research_narrow-screen_content a:hover {
-  color: #fcba19;
-}
-
-.social-media {
-  margin-top: 100px;
-  color: #003366;
-
-  a {
-    margin: 0 8px;
-  }
-}
-
-@media screen and (max-width: 992px) {
-  .contents {
-    margin-top: 80px;
-
-    h2 {
-      margin-top: 32px;
-    }
-  }
-}
-
-@media screen and (max-width: 768px) {
   .beta-welcome_screenshots-container {
-    margin-top: unset;
-  }
+    margin-top: -100px;
 
-  .beta-welcome_screenshots {
-    top: 100px;
+    img {
+      position: relative;
+      top: 150px;
+      max-width: 100%;
+      height: auto;
+    }
   }
 
   .beta-description {
-    margin-top: unset;
-    text-align: unset;
-    margin-left: unset;
-    margin-right: unset;
+    color: #000;
+    max-width: 1100px;
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 160px;
+
+    h2 {
+      color: #003366;
+    }
+  }
+
+  .contents {
+    margin-top: 160px;
+
+    h2 {
+      color: #003366;
+    }
+
+    p {
+      color: #000;
+    }
+
+    img {
+      width: 100%;
+    }
   }
 
   .research {
-    background-image: url("https://nrs.objectstore.gov.bc.ca/kuwyyf/beta_landing_research_intake_narrow_420a361c2e.png");
-    padding: unset;
+    background-image: url("https://nrs.objectstore.gov.bc.ca/kuwyyf/beta_landing_research_intake_4e8d49a5bc.png");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    height: 330px;
+    border-radius: 16px;
+    margin-top: 160px;
+    padding: 32px;
+    color: #fff;
   }
 
-  .research_large-screen {
-    display: none;
+  .research_large-screen img {
+    width: 300px;
+    margin-left: -30px;
   }
 
   .research_narrow-screen {
-    display: unset;
+    display: none;
   }
-}
 
-@media screen and (max-width: 576px) {
-  .beta-welcome_screenshots-container {
-    img {
-      top: 70px;
+  .research_narrow-screen_flex-container {
+    height: 100%;
+  }
+
+  .research_narrow-screen_content {
+    width: 100%;
+    background-color: #036;
+    border-radius: 0 0 16px 16px;
+    padding: 48px 32px;
+  }
+
+  .research_narrow-screen_content a:link {
+    color: #fff;
+    text-decoration: none;
+  }
+
+  .research_narrow-screen_content a:visited {
+    color: #fff;
+    text-decoration: none;
+  }
+
+  .research_narrow-screen_content a:hover {
+    color: #fcba19;
+  }
+
+  .social-media {
+    margin-top: 100px;
+    color: #003366;
+
+    a {
+      margin: 0 8px;
     }
   }
-}
+
+  @media screen and (max-width: 992px) {
+    .contents {
+      margin-top: 80px;
+
+      h2 {
+        margin-top: 32px;
+      }
+    }
+  }
+
+  @media screen and (max-width: 768px) {
+    .beta-welcome_screenshots-container {
+      margin-top: unset;
+    }
+
+    .beta-welcome_screenshots {
+      top: 100px;
+    }
+
+    .beta-description {
+      margin-top: unset;
+      text-align: unset;
+      margin-left: unset;
+      margin-right: unset;
+    }
+
+    .research {
+      background-image: url("https://nrs.objectstore.gov.bc.ca/kuwyyf/beta_landing_research_intake_narrow_420a361c2e.png");
+      padding: unset;
+    }
+
+    .research_large-screen {
+      display: none;
+    }
+
+    .research_narrow-screen {
+      display: unset;
+    }
+  }
+
+  @media screen and (max-width: 576px) {
+    .beta-welcome_screenshots-container {
+      img {
+        top: 70px;
+      }
+    }
+  }

--- a/src/staging/src/styles/betaLanding.scss
+++ b/src/staging/src/styles/betaLanding.scss
@@ -1,3 +1,4 @@
+.intro-page{  
   a.btn {
     background-color: #fff;
     border: 2px solid #036;
@@ -175,3 +176,4 @@
       }
     }
   }
+}


### PR DESCRIPTION
### Jira Ticket:
BRS-457

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-457

### Description:
Some scss styles directly applied to html elements at the root level in `betaLanding.scss` were leaking into other parts of the site. This change wraps the contents of `betaLanding.scss` in a class that can be applied only to the intro page, to properly segregate the styles.

A quick scan of the other scss files did not immediately reveal similar cases where styles may be cascading incorrectly, but if future styling issues are uncovered, they can be specifically addressed quite easily on a case-by-case basis in future tickets.
