### PR TITLE
BRS-415 BUG: hasDayUsePass should be imported as boolean

### DIFF
--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -94,7 +94,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
   type StrapiProtectedArea implements Node {
     orcs: Int
-    hasDayUsePass: String
+    hasDayUsePass: Boolean
     isDisplayed: Boolean
     parkContact: String
     urlPath: String @parkPath


### PR DESCRIPTION
### Jira Ticket:
BRS-415

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-415

### Description:
In `gatsby-node.js`, the boolean `hasDayUsePass` was being imported as a string, causing some parks to incorrectly display a "Get Day Use Pass" button.
