### PR TITLE
BRS-732: BCparks api maxing out and causing slow - unresponsiveness i…

### DIFF
--- a/src/cms/api/park-access-status-cache/config/routes.json
+++ b/src/cms/api/park-access-status-cache/config/routes.json
@@ -1,0 +1,12 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/park-access-statuses-cache",
+      "handler": "park-access-status-cache.find",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/src/cms/api/park-access-status-cache/controllers/park-access-status-cache.js
+++ b/src/cms/api/park-access-status-cache/controllers/park-access-status-cache.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = {
+  async find(ctx) {
+    console.log("Park access status cache find:", ctx);
+    return strapi.services["park-access-status-cache"].find();
+  },
+};

--- a/src/cms/api/park-access-status-cache/models/park-access-status-cache.js
+++ b/src/cms/api/park-access-status-cache/models/park-access-status-cache.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/src/cms/api/park-access-status-cache/models/park-access-status-cache.settings.json
+++ b/src/cms/api/park-access-status-cache/models/park-access-status-cache.settings.json
@@ -1,0 +1,21 @@
+{
+  "kind": "collectionType",
+  "collectionName": "park_access_statuses-cache",
+  "info": {
+    "name": "ParkAccessStatusCache",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "cacheId": {
+      "type": "integer"
+    },
+    "payload": {
+      "type": "json"
+    }
+  }
+}

--- a/src/cms/api/park-access-status-cache/services/park-access-status-cache.js
+++ b/src/cms/api/park-access-status-cache/services/park-access-status-cache.js
@@ -1,0 +1,8 @@
+"use strict";
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/src/cms/api/park-access-status/controllers/park-access-status.js
+++ b/src/cms/api/park-access-status/controllers/park-access-status.js
@@ -9,8 +9,13 @@ const customStatus = require("../../protected-area/custom/protected-area-status"
 
 module.exports = {
   async find(ctx) {
-    console.log("Park access status find:", ctx);
-    const parkAccessStatuses = await customStatus.getProtectedAreaStatus(ctx);
+    console.log("Park access status find:", ctx.request.query);
+    let parkAccessStatuses;
+    // Performance checking to prevent falling down - there's a cached endpoint to use instead.  See /park-access-statuses-cache
+    if (ctx?.request?.query?._limit > 10) {
+      ctx.request.query._limit = 10;
+    }
+    parkAccessStatuses = await customStatus.getProtectedAreaStatus(ctx);
     return parkAccessStatuses;
   },
 };

--- a/src/cms/config/functions/cron.js
+++ b/src/cms/config/functions/cron.js
@@ -9,14 +9,21 @@
  *
  * See more details here: https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#cron-tasks
  */
+const _ = require("lodash");
+const boolToYN = (boolVar) => {
+  return boolVar ? "Y" : "N";
+};
 
 module.exports = {
   "*/5 * * * *": {
     task: async () => {
+      console.log("CRON STARTING");
+
       // fetch advisory statuses
       const advisoryStatus = await strapi.api["advisory-status"].services[
         "advisory-status"
       ].find();
+
       if (advisoryStatus.length > 0) {
         const advisoryStatusMap = {};
         advisoryStatus.map((a) => {
@@ -84,9 +91,295 @@ module.exports = {
             });
         });
       }
+
+      // Update the cache version of park access statuses
+      await updateProtectedAreaStatusCache();
+
+      console.log("CRON FINISHED");
     },
     options: {
       tz: "America/Vancouver",
     },
   },
+};
+
+const getHasCampfiresFacility = (parkFacilities) => {
+  return parkFacilities.some((f) => f.name.toLowerCase().includes("campfires"));
+};
+
+const getPublicAdvisory = (publishedAdvisories, orcs) => {
+  const filteredByOrcs = publishedAdvisories.filter((f) =>
+    f.protectedAreas.some((o) => o.orcs === orcs)
+  );
+  let publicAdvisories = [];
+
+  const publicAdvisoryDefaultValues = {
+    id: 0,
+    advisoryNumber: null,
+    advisoryTitle: null,
+    effectiveDate: null,
+    endDate: null,
+    eventType: null,
+    accessStatus: "Open",
+    precedence: 99,
+    reservationsAffected: null,
+    links: [],
+  };
+
+  filteredByOrcs.map((p) => {
+    const data = {
+      id: p.id,
+      advisoryNumber: p.advisoryNumber,
+      advisoryTitle: p.title,
+      effectiveDate: p.effectiveDate,
+      endDate: p.endDate,
+      eventType: p.eventType ? p.eventType.eventType : null,
+      accessStatus: p.accessStatus ? p.accessStatus.accessStatus : null,
+      precedence: p.accessStatus ? p.accessStatus.precedence : null,
+      reservationsAffected: p.reservationsAffected,
+      links: p.links,
+    };
+    publicAdvisories = [...publicAdvisories, data];
+  });
+
+  if (publicAdvisories.length === 0)
+    publicAdvisories = [publicAdvisoryDefaultValues];
+
+  return _.sortBy(publicAdvisories, ["precedence"])[0];
+};
+
+const getPublishedPublicAdvisories = async () => {
+  return await strapi.services["public-advisory"].find({
+    _publicationState: "live",
+    "accessStatus.precedence_lt": 99,
+    _sort: "id",
+    _limit: -1,
+  });
+};
+
+const updateProtectedAreaStatusCache = async (ctx) => {
+  let entities = await strapi.services["protected-area"].find();
+
+  const regionsData = await strapi.services["region"].find({ _limit: -1 });
+  const sectionsData = await strapi.services["section"].find({ _limit: -1 });
+  const fireCentresData = await strapi.services["fire-centre"].find({
+    _limit: -1,
+  });
+  const activityTypesData = await strapi.services["activity-type"].find({
+    _limit: -1,
+  });
+  const facilityTypesData = await strapi.services["facility-type"].find({
+    _limit: -1,
+  });
+  const linkTypesData = await strapi.services["link-type"].find({ _limit: -1 });
+  const parkNamesAliases = await strapi.services["park-name"].find({
+    _limit: -1,
+    "parkNameType.nameType": "Alias",
+  });
+
+  const campfireBanData = await strapi.services["fire-ban-prohibition"].find({
+    _limit: -1,
+    prohibitionDescription_contains: "campfire",
+    fireCentre_null: false,
+  });
+
+  const publicAdvisories = await getPublishedPublicAdvisories();
+
+  const payload = entities.map((protectedArea) => {
+    let publicAdvisory = getPublicAdvisory(
+      publicAdvisories,
+      protectedArea.orcs
+    );
+
+    const regions = [
+      ...new Set(
+        protectedArea.managementAreas.map(
+          (m) =>
+            regionsData.find((region) => region.id === m.region && m.region)
+              .regionName
+        )
+      ),
+    ];
+
+    const sections = [
+      ...new Set(
+        protectedArea.managementAreas.map(
+          (m) =>
+            sectionsData.find(
+              (section) => section.id === m.section && m.section
+            ).sectionName
+        )
+      ),
+    ];
+
+    const fireCentres = [
+      ...new Set(
+        protectedArea.fireZones.map((fireZone) => {
+          const fireCentre = fireCentresData.find(
+            (f) => f.fireZones.length > 0 && f.id === fireZone.fireCentre
+          );
+          if (fireCentre) return fireCentre.fireCentreName;
+        })
+      ),
+    ];
+
+    const fireZones = [
+      ...new Set(
+        protectedArea.fireZones.map((fireZone) => fireZone.fireZoneName)
+      ),
+    ];
+
+    const parkActivities = protectedArea.parkActivities.map((a) => {
+      const activity = activityTypesData.find(
+        (f) => f.id === a.activityType && a.isActive
+      );
+      if (activity) {
+        return {
+          activityName: activity.activityName,
+          activityCode: activity.activityCode,
+          description: a.description,
+          icon: activity.icon,
+          iconNA: activity.iconNA,
+          rank: activity.rank,
+        };
+      }
+    });
+
+    const parkFacilities = protectedArea.parkFacilities.map((a) => {
+      const facility = facilityTypesData.find(
+        (f) => f.id === a.facilityType && a.isActive
+      );
+      if (facility) {
+        return {
+          facilityName: facility.facilityName,
+          facilityCode: facility.facilityCode,
+          description: a.description,
+          icon: facility.icon,
+          iconNA: facility.iconNA,
+          rank: facility.rank,
+        };
+      }
+    });
+
+    const links = publicAdvisory.links.map((link) => {
+      return {
+        title: link.title,
+        type: linkTypesData.find((lt) => lt.id === link.type).type,
+        url: link.url,
+      };
+    });
+
+    // bans and prohibitions
+    let hasCampfireBan;
+    let campfireBanNote = "";
+    let campfireBanEffectiveDate = null;
+    if (protectedArea.hasCampfireBanOverride) {
+      hasCampfireBan = protectedArea.hasCampfireBan;
+      campfireBanNote = "campfire ban set via manual override";
+    } else {
+      for (const fireZone of protectedArea.fireZones) {
+        const fireBan = campfireBanData.find(
+          (f) => f.fireCentre.id === fireZone.fireCentre
+        );
+
+        if (fireBan) {
+          hasCampfireBan = true;
+          campfireBanEffectiveDate = fireBan.effectiveDate;
+          campfireBanNote = "campfire ban set via wildfire service";
+          break;
+        }
+      }
+    }
+
+    let hasSmokingBan;
+    if (protectedArea.hasSmokingBanOverride) {
+      hasSmokingBan = protectedArea.hasSmokingBan;
+    } else {
+      for (const fireZone of protectedArea.fireZones) {
+        const fireBan = campfireBanData.find(
+          (f) => f.fireCentre.id === fireZone.fireCentre
+        );
+
+        if (fireBan) {
+          hasSmokingBan = true;
+          break;
+        }
+      }
+    }
+
+    return {
+      id: protectedArea.id,
+      orcs: protectedArea.orcs,
+      orcsSiteNumber: null,
+      protectedAreaName: protectedArea.protectedAreaName,
+      protectedAreaNameAliases: parkNamesAliases
+        .filter(
+          (p) => p.protectedArea && +p.protectedArea.orcs === protectedArea.orcs
+        )
+        .map((d) => d.parkName),
+      type: protectedArea.type,
+      typeCode: protectedArea.typeCode,
+      accessStatus: publicAdvisory.accessStatus,
+      accessDetails: publicAdvisory.advisoryTitle,
+      isReservationsAffected: boolToYN(publicAdvisory.reservationsAffected),
+      eventType: publicAdvisory.eventType,
+      hasCampfiresFacility: boolToYN(
+        getHasCampfiresFacility(protectedArea.parkFacilities)
+      ),
+
+      hasCampfireBan: boolToYN(hasCampfireBan),
+      hasSmokingBan: boolToYN(hasSmokingBan),
+      hasCampfireBanOverride: boolToYN(protectedArea.hasCampfireBanOverride),
+      hasSmokingBanOverride: boolToYN(protectedArea.hasSmokingBanOverride),
+      campfireBanEffectiveDate: campfireBanEffectiveDate,
+      campfireBanRescindedDate: protectedArea.campfireBanRescindedDate,
+      campfireBanNote: campfireBanNote,
+      accessStatusEffectiveDate: publicAdvisory.effectiveDate,
+      accessStatusRescindedDate: publicAdvisory.endDate,
+      fireCentres: fireCentres,
+      fireZones: fireZones,
+      isFogZone: boolToYN(protectedArea.isFogZone),
+      regions: regions,
+      sections: sections,
+      managementAreas: protectedArea.managementAreas.map(
+        (m) => m.managementAreaName
+      ),
+      parkActivities: parkActivities,
+      parkFacilities: parkFacilities,
+      orderUrl: links
+        .filter((f) => f.type.toLowerCase().includes("order"))
+        .map((m) => m.url),
+      mapUrl: links
+        .filter((f) => f.type.toLowerCase().includes("map"))
+        .map((m) => m.url),
+      informationBulletinUrl: links
+        .filter((f) => f.type.toLowerCase().includes("bulletin"))
+        .map((m) => m.url),
+      parkWebsiteUrl: protectedArea.url,
+      pepRegionId: null,
+      pepRegionName: null,
+      publicAdvisoryId: publicAdvisory.id,
+    };
+  });
+
+  // Store payload into a cached location
+  const results = await strapi.services['park-access-status-cache'].find({ cacheId: 1 });
+  if (results.length === 0) {
+    console.log("Creating cache for the first time.")
+    await strapi.services['park-access-status-cache'].create({
+      cacheId: 1,
+      payload: payload
+    });
+  } else {
+    // Update
+    console.log("Updating cache entry.")
+    await strapi.services['park-access-status-cache'].update({
+      cacheId: 1
+    }, {
+      cacheId: 1,
+      payload: payload
+    });
+  }
+
+  console.log("done:", payload);
 };


### PR DESCRIPTION
…n alerts/advisories

### Jira Ticket:
BRS-732

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-732

### Description:
This changes the way park-access-statues api call works.  It used to be a large and expensive operation.  Now, it is done in a cron once every 5 minutes, instead of every time a pageload of https://bcparks.ca/wildfire or the https://bcparks.ca/explore/parks page (or others).   The cron saves this cached payload into a new record type in strapi.  There is a new endpoint created to pull the cached data that the cron created.  The old endpoint is now force limited to `_limit: 10` to avoid any future performance issues.  Consumers of the old endpoint should use the new cached endpoint.

New endpoint:
```[2022-07-28T17:14:45.031Z] debug GET /park-access-statuses-cache (52 ms)``` 200

Old endpoint:
```[2022-07-28T17:15:18.373Z] debug GET /park-access-statuses?_limit=1200 (1940 ms) 200```
