### PR TITLE
BWT-377: Passing an ?orcs= filter to /park-access-statuses overwrites park-access-status-cache

### DIFF
--- a/src/cms/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/api/protected-area/custom/protected-area-status.js
@@ -270,23 +270,30 @@ const getProtectedAreaStatus = async (ctx) => {
     };
   });
 
-  // Store payload into a cached location
-  const results = await strapi.services['park-access-status-cache'].find({ cacheId: 1 });
-  if (results.length === 0) {
-    console.log("Creating cache for the first time.")
-    await strapi.services['park-access-status-cache'].create({
+  // Store unfiltered payload into a cached location (unfiltered == no orcs specified)
+  if (!ctx.query.orcs) {
+    const results = await strapi.services["park-access-status-cache"].find({
       cacheId: 1,
-      payload: payload
     });
-  } else {
-    // Update
-    console.log("Updating cache entry.")
-    await strapi.services['park-access-status-cache'].update({
-      cacheId: 1
-    }, {
-      cacheId: 1,
-      payload: payload
-    });
+    if (results.length === 0) {
+      console.log("Creating cache for the first time.");
+      await strapi.services["park-access-status-cache"].create({
+        cacheId: 1,
+        payload: payload,
+      });
+    } else {
+      // Update
+      console.log("Updating cache entry.");
+      await strapi.services["park-access-status-cache"].update(
+        {
+          cacheId: 1,
+        },
+        {
+          cacheId: 1,
+          payload: payload,
+        }
+      );
+    }
   }
   
   return payload;


### PR DESCRIPTION
### Jira Ticket:
BRS-377

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-377

### Description:

When you pass an orcs filter to park-access-statuses, the Strapi value in park-access-status-cache is overwritten.  You have to wait 5 minutes for the cron job to fix it. 

1. go to https://test-cms.bcparks.ca/park-access-statuses-cache (note the size of the response)
2. go to https://test-cms.bcparks.ca/park-access-statuses?orcs=255
3. go to https://test-cms.bcparks.ca/park-access-statuses-cache (the response is much, much smaller)

Note that now the cache only contains data for orcs 255.  It will correct itself within 5 minutes the next time the cron job runs. You can also fix it by going to https://test-cms.bcparks.ca/park-access-statuses with no querystring.
