### PR TITLE
CM-69: added ckeditor5-react back in at project root

### DIFF
--- a/src/cms/package.json
+++ b/src/cms/package.json
@@ -13,6 +13,10 @@
     "seed": "node scripts/seed.js"
   },
   "dependencies": {
+    "@ckeditor/ckeditor5-build-classic": "^29.2.0",
+    "@ckeditor/ckeditor5-react": "^3.0.3",
+    "@ckeditor/ckeditor5-source-editing": "^29.2.0",
+    "@ckeditor/ckeditor5-theme-lark": "^29.2.0",
     "axios": "^0.21.1",
     "jwks-rsa": "^2.0.4",
     "knex": "^0.21.19",


### PR DESCRIPTION
### Jira Ticket:
CM-69

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-69

### Description:
Tiny fix to add dependency back in at the root of the project. This should fix the build error.