### PR TITLE
CM-113: header color override, CM-132 tables full width

### DIFF
--- a/src/staging/src/styles/betaLanding.scss
+++ b/src/staging/src/styles/betaLanding.scss
@@ -84,6 +84,9 @@
     margin-top: 160px;
     padding: 32px;
     color: #fff;
+    h2 {
+      color: #fff;
+    }
   }
 
   .research_large-screen img {

--- a/src/staging/src/styles/global.scss
+++ b/src/staging/src/styles/global.scss
@@ -2,6 +2,7 @@ $colorGold: #fcba19;
 $colorWhite: #fff;
 $colorWhiteOpacity: #ffffff90;
 $colorGrey: #eef1f5;
+$colorLightGrey: #f2f2f2;
 $colorBlue: #003366;
 $colorBlueMed: #2464a4;
 $desktopBreakpoint: 576px;
@@ -117,6 +118,17 @@ figure.media div[data-oembed-url] {
 }
 
 img { max-width: 100%; }
+
+// This is temp as we should be rendering <table class="table"> through CKEditor
+// so that tables pick up standard boostrap styles
+figure.table {
+  table {
+    width: 100%;
+    thead {
+      background: $colorLightGrey;
+  }
+  }
+}
 
 
 /* end CKEeditor added styles */


### PR DESCRIPTION
### Jira Ticket:
CM-113, CM-132

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-113
https://bcparksdigital.atlassian.net/browse/CM-132

### Description:
Minor CSS fix to make headers white inside of the homepage feature box.
Minor CSS fix to ensure tables render full-width and that header rows are light grey for contrast.
