### PR TITLE
CM-60: Updated syncdb scripts to use 'cp' instead of 'rsync'

### DIFF
--- a/tools/syncdb/README.md
+++ b/tools/syncdb/README.md
@@ -21,6 +21,10 @@ and [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/i
 
 Users will require access to the appropriate OpenShift project, and will need to login via ``oc login`` prior to import/export.
 
+Note: Windows users need to run the PowerShell scripts from Windows Subsystem for Linux for 
+these instructions to work. Depending on your git checkout config you may also also have to convert CRLF 
+to CR in the PowerShell scripts (using notepad++) before it will work on WSL.
+
 ## Export data
 
 Running the following command will copy a data dump to the db-export subfolder of the current directory
@@ -44,6 +48,9 @@ This script syncs a local export.sql file to a temporary directory on the leader
 it using psql.
 
 ## Import data to your local PostgreSQL database (Docker Desktop)
+
+Note: If you are on Windows, run this from the real PowerShell, not from Windows Subsystem for Linux 
+(assuming you have Docker Desktop running on Windows and not on WSL)
 
 ```
 docker cp ./export.sql postgres-docker:/tmp/db-export.sql

--- a/tools/syncdb/README.md
+++ b/tools/syncdb/README.md
@@ -34,11 +34,10 @@ This script dumps data to a temporary folder on one of the Patroni OpenShift pod
 
 ## Import data
 
-Running the following command will update the dev db with a previously generated export (note the trailing
-slash is required for rsync to copy the data to the expected path):
+Running the following command will update the dev db with a previously generated export:
 
 ```shell
-pwsh import-db.ps1 -Project 61d198-dev -InputPath ./db-export/
+pwsh import-db.ps1 -Project 61d198-dev
 ```
 
 This script syncs a local export.sql file to a temporary directory on the leader Patroni pod, and imports

--- a/tools/syncdb/README.md
+++ b/tools/syncdb/README.md
@@ -42,3 +42,11 @@ pwsh import-db.ps1 -Project 61d198-dev
 
 This script syncs a local export.sql file to a temporary directory on the leader Patroni pod, and imports
 it using psql.
+
+## Import data to your local PostgreSQL database (Docker Desktop)
+
+```
+docker cp ./export.sql postgres-docker:/tmp/db-export.sql
+docker exec postgres-docker /bin/bash -c "PGUSER=postgres PGPASSWORD=postgres psql cms < /tmp/db-export.sql"
+```
+

--- a/tools/syncdb/export-db.ps1
+++ b/tools/syncdb/export-db.ps1
@@ -34,7 +34,7 @@ if (!$?) {
    Exit 1
 }
 
-oc rsync bcparks-patroni-0:$remoteTempPath $OutputPath
+oc cp $Project/bcparks-patroni-0:$remoteTempPath/$exportFilename $OutputPath/$exportFilename > /dev/null
 
 if (!$?) {
    Write-Host "An error occurred."

--- a/tools/syncdb/import-db.ps1
+++ b/tools/syncdb/import-db.ps1
@@ -1,8 +1,6 @@
 Param (
   [Parameter(Mandatory)]
-  $Project,
-  [Parameter(Mandatory)]
-  $InputPath
+  $Project
 )
 
 $remoteTempPath="/tmp/db-import"
@@ -34,7 +32,7 @@ Write-Host "Current patroni leader: ${leaderName}"
 
 oc exec ${leaderName}  -- /bin/bash -c "mkdir -p ${remoteTempPath}"
 
-oc rsync $InputPath ${leaderName}:${remoteTempPath}
+oc cp ./$exportFilename $Project/${leaderName}:$remoteTempPath/$exportFilename
 
 if (!$?) {
    Write-Host "An error occurred."


### PR DESCRIPTION
### Jira Ticket:
CM-60

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-60

### Description:
 1. Updated syncdb scripts to use 'cp' instead of 'rsync'.  This fixes the error `cannot use rsync: rsync not available in container`
 2. Added instructions for importing into Docker Desktop
