### PR TITLE
CM-145: added Title on Gatsby

### DIFF
--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -224,6 +224,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       nodes {
         id
         Slug
+        Title
         Template
         Content
       }

--- a/src/staging/src/templates/staticContent1.js
+++ b/src/staging/src/templates/staticContent1.js
@@ -1,5 +1,5 @@
 import React, { useRef } from "react"
-import { graphql, useStaticQuery, Link } from "gatsby"
+import { graphql, useStaticQuery } from "gatsby"
 import { Breadcrumbs } from "@material-ui/core"
 import useScrollSpy from "react-use-scrollspy"
 
@@ -9,6 +9,8 @@ import HTMLArea from "../components/HTMLArea"
 import Seo from "../components/seo"
 import PageContent from "../components/pageContent/pageContent"
 import PageMenu from "../components/pageContent/pageMenu"
+
+import { renderBreadcrumbs } from "../utils/helpers";
 
 import "../styles/staticContent1.scss"
 
@@ -74,10 +76,10 @@ export default function StaticContent1({ pageContext }) {
     ) || {}
   const hasPageHeader = headerContent.pageTitle !== undefined
 
-  // Get page title from record
-  // if not there, get from page title, if there is a PageHeader compopnent
+  // Get page title from Title field
+  // if not there, get title from pageTitle, if there is a PageHeader component
   // otherwise, page title & breadcrumb assumed to be in the content
-  let pageTitle = pageContext.page.title
+  let pageTitle = pageContext.page.Title
   if (!pageTitle) {
     pageTitle = headerContent.pageTitle
   }
@@ -249,30 +251,4 @@ export default function StaticContent1({ pageContext }) {
       </div>
     </>
   )
-}
-
-function renderBreadcrumbs(menuContent, pageContext) {
-  // TODO this doesn't work if the page is not in the menu
-  let current = menuContent.find(mc => mc.url === pageContext.Slug)
-  const breadcrumbItems = [
-    <div key={pageContext.id} className="breadcrumb-text">
-      {current?.title}
-    </div>,
-  ]
-
-  let parent = menuContent.find(mc => mc.strapiId === current?.strapiParent?.id)
-  return addItems(parent, menuContent, breadcrumbItems)
-
-  function addItems(parent, menuContent, breadcrumbItems) {
-    if (parent) {
-      breadcrumbItems.push(
-        <Link key={parent.strapiId} to={parent?.url ?? "/"}>
-          {parent.title}
-        </Link>
-      )
-      parent = menuContent.find(mc => mc.strapiId === parent?.strapiParent?.id)
-      return addItems(parent, menuContent, breadcrumbItems)
-    }
-    return breadcrumbItems.reverse()
-  }
 }

--- a/src/staging/src/templates/staticLanding1.js
+++ b/src/staging/src/templates/staticLanding1.js
@@ -1,13 +1,15 @@
 import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import { StaticImage } from "gatsby-plugin-image"
-import { CssBaseline } from "@material-ui/core"
+import { CssBaseline, Breadcrumbs } from "@material-ui/core"
 
 import Footer from "../components/footer"
 import Header from "../components/header"
 import Seo from "../components/seo"
 import MainSearch from "../components/search/mainSearch"
 import PageContent from "../components/pageContent/pageContent"
+
+import { renderBreadcrumbs } from "../utils/helpers";
 
 import "../styles/global.scss"
 import "../styles/staticLanding1.scss"
@@ -98,6 +100,36 @@ const LandingPage = ({ pageContext }) => {
                 </div>
               </div>
             ))}
+          </div>
+        </div>
+      )}
+      {/* This is a temporary attempt not to break the existing hard code HTMLArea */}
+      {/* For the edge case: show breadcrumbs and title if there's no HTMLArea */}
+      {linkContent.length === 0 && (
+        <div className="bcp-landing-intro">
+          <div className="bcp-landing-intro__image">
+            {/* TODO: here should be landing image */}
+          </div>
+          <div className="bcp-landing-intro__text">
+            <div className="container">
+              <div className="row d-none d-lg-block">
+                <div className="col">
+                  <Breadcrumbs separator="›" aria-label="breadcrumb">
+                    {renderBreadcrumbs(menuContent, pageContext?.page)}
+                  </Breadcrumbs>
+                </div>
+              </div>
+              <div className="row">
+                <div className="col">
+                  <h1>{page?.Title}</h1>
+                </div>
+              </div>
+              <div className="row">
+                <div className="col">
+                  {/* TODO: here should be some text */}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/src/staging/src/utils/helpers.js
+++ b/src/staging/src/utils/helpers.js
@@ -1,5 +1,30 @@
 import React from "react"
+import { Link } from "gatsby"
 
 export const capitalizeFirstLetter = (str) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 export const renderHTML = (rawHTML) => React.createElement("div", { dangerouslySetInnerHTML: { __html: rawHTML } });
-  
+export const renderBreadcrumbs = (menuContent, pageContext) => {
+    // TODO this doesn't work if the page is not in the menu
+    let current = menuContent.find(mc => mc.url === pageContext.Slug)
+    const breadcrumbItems = [
+        <div key={pageContext.id} className="breadcrumb-text">
+            {current?.title}
+        </div>,
+    ]
+
+    let parent = menuContent.find(mc => mc.strapiId === current?.strapiParent?.id)
+    return addItems(parent, menuContent, breadcrumbItems)
+
+    function addItems(parent, menuContent, breadcrumbItems) {
+        if (parent) {
+            breadcrumbItems.push(
+                <Link key={parent.strapiId} to={parent?.url ?? "/"}>
+                    {parent.title}
+                </Link>
+            )
+            parent = menuContent.find(mc => mc.strapiId === parent?.strapiParent?.id)
+            return addItems(parent, menuContent, breadcrumbItems)
+        }
+        return breadcrumbItems.reverse()
+    }
+}


### PR DESCRIPTION
### Jira Ticket:
CM-145

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-145

### Description:
- Added `Title` in Gatsby to display on FE
- Updated the logic in `staticContent1.js`. `title` does not exist so replaced it with `Title`
- Move the `renderBreadcrumbs` function to `helpers.js` to be used in other templates
- Added breadcrumbs and title in `staticLanding.js` if the page does not have HTMLArea
- This ^ temp code for the edge case can be changed after https://bcparksdigital.atlassian.net/browse/CM-143