### PR TITLE
CM-9: Parks without lat/long

### DIFF
--- a/src/staging/src/components/park/mapLocation.js
+++ b/src/staging/src/components/park/mapLocation.js
@@ -60,10 +60,14 @@ export default function MapLocation({ data }) {
     <Grid item xs={12} id="park-map-container" className="anchor-link">
       <Paper elevation={0}>
         <Heading>Maps and location</Heading>
-        <a href="https://governmentofbc.maps.arcgis.com/apps/webappviewer/index.html?id=077ef73a1eae4ca88f2bafbb831215af&query=British_Columbia_Parks_Ecological_Reserves_and_Protected_Areas_8747,ORCS_PRIMARY,0000">
-        <div id="mapDiv" ref={mapRef}></div>
-        </a>
-        <Spacer />
+        {data.latitude && data.longitude && (
+          <div>
+            <a href="https://governmentofbc.maps.arcgis.com/apps/webappviewer/index.html?id=077ef73a1eae4ca88f2bafbb831215af&query=British_Columbia_Parks_Ecological_Reserves_and_Protected_Areas_8747,ORCS_PRIMARY,0000">
+              <div id="mapDiv" ref={mapRef}></div>
+            </a>
+            <Spacer />
+          </div>
+        )}
       </Paper>
     </Grid>
   )

--- a/src/staging/src/templates/park.js
+++ b/src/staging/src/templates/park.js
@@ -208,7 +208,7 @@ export default function ParkTemplate({ data }) {
       sectionIndex: 8,
       display: "Location",
       link: "#park-maps-location-container",
-      visible: true,
+      visible: (park.latitude && park.longitude) || park.locationNotes,
     },
     {
       sectionIndex: 9,


### PR DESCRIPTION
### Jira Ticket:
CM-9

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-9

### Description:
- Hide the map if a park doesn't have a latitude and longitude
- Hide the entire location section if the park doesn't have either a latitude and longitude or a location note
