### PR TITLE
CM-162: Add site template

### DIFF
--- a/src/cms/api/park-operation/models/park-operation.settings.json
+++ b/src/cms/api/park-operation/models/park-operation.settings.json
@@ -12,7 +12,7 @@
   },
   "attributes": {
     "orcsSiteNumber": {
-      "type": "integer"
+      "type": "string"
     },
     "isActive": {
       "type": "boolean"
@@ -152,6 +152,10 @@
     "protectedArea": {
       "model": "protected-area",
       "via": "parkOperation"
+    },
+    "site": {
+      "via": "parkOperation",
+      "model": "site"
     }
   }
 }

--- a/src/cms/api/site/models/site.settings.json
+++ b/src/cms/api/site/models/site.settings.json
@@ -11,6 +11,9 @@
     "draftAndPublish": true
   },
   "attributes": {
+    "slug": {
+      "type": "string"
+    },
     "siteName": {
       "type": "string"
     },

--- a/src/cms/api/site/models/site.settings.json
+++ b/src/cms/api/site/models/site.settings.json
@@ -60,6 +60,19 @@
     },
     "note": {
       "type": "string"
+    },
+    "hasDayUsePass": {
+      "type": "boolean"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "locationNotes": {
+      "type": "richtext"
+    },
+    "parkOperation": {
+      "via": "site",
+      "model": "park-operation"
     }
   }
 }

--- a/src/staging/gatsby-config.js
+++ b/src/staging/gatsby-config.js
@@ -37,6 +37,7 @@ module.exports = {
           "park-operation",
           "access-statuses",
           "park-operation-sub-areas",
+          "sites"
         ],
         queryLimit: -1,
       },

--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -294,8 +294,10 @@ async function createSites({ graphql, actions, reporter }) {
   const result = await strapiApiRequest(graphql, siteQuery)
 
   result.data.allStrapiSites.nodes.forEach(site => {
+    // TODO: slug can be deleted when site.slug has created on all strapi env
     const slug = slugify(site.siteName).toLowerCase()
     const parkPath = site.protectedArea?.urlPath
+    // TODO: change sitePath `${parkPath}/${slug}` to `${parkPath}/${site.slug}` when site.slug has created on all strapi env
     const sitePath = `${parkPath}/${slug}`
     actions.createPage({
       path: sitePath,

--- a/src/staging/src/templates/park.js
+++ b/src/staging/src/templates/park.js
@@ -11,7 +11,6 @@ import {
   Link,
   Breadcrumbs,
 } from "@material-ui/core"
-import { makeStyles } from "@material-ui/core/styles"
 import useScrollSpy from "react-use-scrollspy"
 
 import { capitalizeFirstLetter, renderHTML } from "../utils/helpers";
@@ -38,21 +37,7 @@ import SafetyInfo from "../components/park/safetyInfo"
 import ScrollToTop from "../components/scrollToTop"
 
 import "../styles/parks.scss"
-import { PARK_NAME_TYPE } from "../utils/constants";
-
-const drawerWidth = 230
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: "flex",
-  },
-  parkContent: {
-    [theme.breakpoints.up("sm")]: {
-      width: `calc(100% - ${drawerWidth}px)`,
-    },
-  },
-  appBarOffset: theme.mixins.toolbar,
-}))
+import { PARK_NAME_TYPE, useStyles } from "../utils/constants";
 
 const loadAdvisories = async (apiBaseUrl, orcs) => {
   const params = {

--- a/src/staging/src/templates/site.js
+++ b/src/staging/src/templates/site.js
@@ -11,7 +11,6 @@ import {
   Link,
   Breadcrumbs,
 } from "@material-ui/core"
-import { makeStyles } from "@material-ui/core/styles"
 import useScrollSpy from "react-use-scrollspy"
 
 import Footer from "../components/footer"
@@ -30,20 +29,7 @@ import MapLocation from "../components/park/mapLocation"
 import ScrollToTop from "../components/scrollToTop"
 
 import "../styles/parks.scss"
-
-const drawerWidth = 230
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: "flex",
-  },
-  parkContent: {
-    [theme.breakpoints.up("sm")]: {
-      width: `calc(100% - ${drawerWidth}px)`,
-    },
-  },
-  appBarOffset: theme.mixins.toolbar,
-}))
+import { useStyles } from "../utils/constants"
 
 const loadAdvisories = async (apiBaseUrl, orcs) => {
   const params = {

--- a/src/staging/src/templates/site.js
+++ b/src/staging/src/templates/site.js
@@ -1,0 +1,500 @@
+import React, { useEffect, useState, useRef } from "react"
+import axios from "axios"
+import { sortBy } from "lodash"
+import { graphql } from "gatsby"
+import { Helmet } from "react-helmet"
+import {
+  Box,
+  Container,
+  Grid,
+  CssBaseline,
+  Link,
+  Breadcrumbs,
+} from "@material-ui/core"
+import { makeStyles } from "@material-ui/core/styles"
+import useScrollSpy from "react-use-scrollspy"
+
+import Footer from "../components/footer"
+import Header from "../components/header"
+import PageMenu from "../components/pageContent/pageMenu"
+
+import AccessibilityDetails from "../components/park/accessibilityDetails"
+import AdvisoryDetails from "../components/park/advisoryDetails"
+import Heading from "../components/park/heading.js"
+import ParkActivity from "../components/park/parkActivity"
+import ParkFacility from "../components/park/parkFacility"
+import ParkHeader from "../components/park/parkHeader"
+import ParkOverview from "../components/park/parkOverview"
+import ParkPhotoGallery from "../components/park/parkPhotoGallery"
+import MapLocation from "../components/park/mapLocation"
+import ScrollToTop from "../components/scrollToTop"
+
+import "../styles/parks.scss"
+
+const drawerWidth = 230
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: "flex",
+  },
+  parkContent: {
+    [theme.breakpoints.up("sm")]: {
+      width: `calc(100% - ${drawerWidth}px)`,
+    },
+  },
+  appBarOffset: theme.mixins.toolbar,
+}))
+
+const loadAdvisories = async (apiBaseUrl, orcs) => {
+  const params = {
+    "protectedAreas.orcs_in": orcs,
+    _limit: 100,
+    _sort: "urgency.sequence:DESC",
+  }
+
+  return axios.get(`${apiBaseUrl}/public-advisories`, { params })
+}
+
+export default function ParkTemplate({ data }) {
+  const classes = useStyles()
+
+  const apiBaseUrl = data.site.siteMetadata.apiURL
+
+  const site = data.strapiSites
+  const park = site.protectedArea
+  const activities = site.parkActivities
+  const facilities = site.parkFacilities
+  const operations = site.parkOperation || {}
+  const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]
+
+  const activeActivities = sortBy(
+    activities.filter(
+      activity => activity.isActive && activity.activityType.isActive
+    ),
+    ["activityType.rank", "activityType.activityName"],
+    ["asc"]
+  )
+  const activeFacilities = sortBy(
+    facilities.filter(
+      facility => facility.isActive && facility.facilityType.isActive
+    ),
+    ["facilityType.rank", "facilityType.facilityName"],
+    ["asc"]
+  )
+
+  const hasReservations = operations.hasReservations
+  // TODO: change park.hasDayUsePass to site.hasDayUsePass when site.hasDayUsePass has created on all strapi env
+  const hasDayUsePass = park.hasDayUsePass
+
+  // Use hasCamping if camping section is needed
+  // const hasCamping = activeFacilities.some(facility =>
+  //   facility.facilityType.facilityName.toLowerCase().includes("camping")
+  // )
+
+  const menuContent = data?.allStrapiMenus?.nodes || []
+
+  const [advisoryLoadError, setAdvisoryLoadError] = useState(false)
+  const [isLoadingAdvisories, setIsLoadingAdvisories] = useState(true)
+  const [advisories, setAdvisories] = useState([])
+
+  useEffect(() => {
+    setIsLoadingAdvisories(true)
+
+    loadAdvisories(apiBaseUrl, park.orcs)
+      .then(response => {
+        if (response.status === 200) {
+          setAdvisories([...response.data])
+          setAdvisoryLoadError(false)
+        } else {
+          setAdvisories([])
+          setAdvisoryLoadError(true)
+        }
+      })
+      .finally(() => {
+        setIsLoadingAdvisories(false)
+      })
+  }, [apiBaseUrl, park.orcs])
+
+  const parkOverviewRef = useRef("")
+  const accessibilityRef = useRef("")
+  const advisoryRef = useRef("")
+  const parkDatesRef = useRef("")
+  const safetyRef = useRef("")
+  const campingRef = useRef("")
+  const facilityRef = useRef("")
+  const activityRef = useRef("")
+  const mapLocationRef = useRef("")
+  const activityMapRef = useRef("")
+  const aboutRef = useRef("")
+  const reconciliationRef = useRef("")
+
+  const sectionRefs = [
+    parkOverviewRef,
+    accessibilityRef,
+    advisoryRef,
+    parkDatesRef,
+    safetyRef,
+    campingRef,
+    facilityRef,
+    activityRef,
+    mapLocationRef,
+    activityMapRef,
+    aboutRef,
+    reconciliationRef,
+  ]
+
+  const activeSection = useScrollSpy({
+    sectionElementRefs: sectionRefs,
+    defaultValue: 0,
+    offsetPx: -250,
+  })
+
+  const menuItems = [
+    {
+      sectionIndex: 0,
+      display: "Site overview",
+      link: "#park-overview-container",
+      // TODO: change park.description to site.description when site.description has created on all strapi env
+      visible: park.description,
+    },
+    {
+      sectionIndex: 1,
+      display: "Accessibility",
+      link: "#accessibility-details-container",
+      visible: park.accessibility,
+    },
+    {
+      sectionIndex: 2,
+      display:
+        !isLoadingAdvisories && !advisoryLoadError
+          ? `Advisories (${advisories.length})`
+          : "Advisories",
+      link: "#park-advisory-details-container",
+      visible: true,
+    },
+    {
+      sectionIndex: 3,
+      display: "Facilities",
+      link: "#park-facility-container",
+      visible: activeFacilities.length > 0,
+    },
+    {
+      sectionIndex: 4,
+      display: "Activities",
+      link: "#park-activity-container",
+      visible: activeActivities.length > 0,
+    },
+    {
+      sectionIndex: 5,
+      display: "Location",
+      link: "#park-maps-location-container",
+      // TODO: change park.locationNotes to site.locationNotes when site.locationNotes has created on all strapi env
+      visible: (site.latitude && site.longitude) || park.locationNotes,
+    },
+  ]
+
+  const mapData = {
+    latitude: site.latitude,
+    longitude: site.longitude,
+    mapZoom: site.mapZoom,
+    parkOrcs: site.orcsSiteNumber
+  }
+
+  const breadcrumbs = [
+    <Link key="1" href="/">
+      Home
+    </Link>,
+    <Link key="2" href="/find-a-park">
+      Find a Park
+    </Link>,
+    <Link key="3" href={`/${park.slug}`}>
+      {park.protectedAreaName}
+    </Link>,
+    <div key="4" className="breadcrumb-text">
+      {site.siteName}
+    </div>,
+  ]
+
+  return (
+    <div className="grey-background">
+      <Helmet>
+          <title>{park.protectedAreaName}: {site.siteName} | BC Parks</title>
+      </Helmet>
+      <Header mode="internal" content={menuContent} />
+      <ScrollToTop />
+      <CssBaseline />
+
+      <div className="d-block d-sm-block d-xs-block d-md-block d-lg-none d-xl-none">
+        <Grid item xs={12} sm={12}>
+          <ParkPhotoGallery photos={photos} />
+        </Grid>
+      </div>
+      <div className="container parks-container">
+        <Container className="park-info-container" maxWidth={false}>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={12}>
+              <div className="p30t d-none d-xl-block d-lg-block d-md-none d-sm-none d-xs-none" />
+              <Breadcrumbs
+                separator="›"
+                aria-label="breadcrumb"
+                className="p20t"
+              >
+                {breadcrumbs}
+              </Breadcrumbs>
+            </Grid>
+            <Grid item xs={12} sm={12}>
+              <ParkHeader
+                parkName={`${park.protectedAreaName}: ${site.siteName}`}
+                hasReservations={hasReservations}
+                hasDayUsePass={hasDayUsePass}
+                isLoadingAdvisories={isLoadingAdvisories}
+                advisoryLoadError={advisoryLoadError}
+                advisories={advisories}
+              />
+            </Grid>
+          </Grid>
+        </Container>
+      </div>
+      <div className="page-menu--mobile">
+        <div className="d-block d-md-none">
+          <PageMenu
+            pageSections={menuItems}
+            activeSection={activeSection}
+            menuStyle="select"
+          />
+        </div>
+      </div>
+      <div className="container parks-container">
+        <Container className="park-info-container" maxWidth={false}>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={12}>
+              <div className="d-none d-xl-block d-lg-block d-md-none d-sm-none d-xs-none">
+                <ParkPhotoGallery photos={photos} />
+              </div>
+            </Grid>
+            <Grid
+              item
+              xs={12}
+              sm={12}
+              md={3}
+              lg={3}
+              className="page-menu--desktop d-none d-xl-block d-lg-block d-md-none d-sm-none d-xs-none"
+            >
+              <PageMenu
+                pageSections={menuItems}
+                activeSection={activeSection}
+                menuStyle="nav"
+              />
+            </Grid>
+            <Grid
+              item
+              xs={12}
+              sm={12}
+              md={9}
+              lg={9}
+              className={classes.parkContent}
+            >
+              {menuItems[0].visible && (
+                <div ref={parkOverviewRef} className="full-width">
+                  {/* TODO: change park.description to site.description when site.description has created on all strapi env */}
+                  <ParkOverview data={park.description} type="site" />
+                </div>
+              )}
+              {menuItems[1].visible && (
+                <div ref={accessibilityRef} className="full-width">
+                  <AccessibilityDetails />
+                </div>
+              )}
+              {menuItems[2].visible && (
+                <div ref={advisoryRef} className="full-width">
+                  {isLoadingAdvisories && (
+                    <div className="mb-5">
+                      <Heading>{`Advisories`}</Heading>
+                      <div className="spinner-border" role="status">
+                        <span className="sr-only">Loading...</span>
+                      </div>
+                    </div>
+                  )}
+                  {!isLoadingAdvisories && advisoryLoadError && (
+                    <div className="mb-5">
+                      <div className="alert alert-danger" role="alert">
+                        An error occurred while loading current public
+                        advisories.
+                      </div>
+                    </div>
+                  )}
+                  {!isLoadingAdvisories && !advisoryLoadError && (
+                    <AdvisoryDetails advisories={advisories} />
+                  )}
+                </div>
+              )}
+              {menuItems[3].visible && (
+                <div ref={facilityRef} className="full-width">
+                  <ParkFacility data={activeFacilities} />
+                </div>
+              )}
+              {menuItems[4].visible && (
+                <div ref={activityRef} className="full-width">
+                  <ParkActivity data={activeActivities} />
+                </div>
+              )}
+              {menuItems[5].visible && (
+                <div ref={mapLocationRef} className="full-width">
+                  <div id="park-maps-location-container" className="anchor-link">
+                    <MapLocation data={mapData} />
+                    {/* TODO: change park.locationNotes to site.locationNotes when site.locationNotes has created on all strapi env */}
+                    {park.locationNotes && (
+                      <Grid item xs={12} id="park-location-notes-container">
+                        <Box mb={8}>
+                          <div
+                            dangerouslySetInnerHTML={{
+                              __html: park.locationNotes,
+                            }}
+                          ></div>
+                        </Box>
+                      </Grid>
+                    )}
+                  </div>
+                </div>
+              )}
+              <br />
+              <br />
+              <br />
+            </Grid>
+          </Grid>
+        </Container>
+      </div>
+      <Footer>{data?.strapiWebsites.Footer}</Footer>
+    </div>
+  )
+}
+
+export const query = graphql`
+  query SiteDetails($orcsSiteNumber: String) {
+    strapiSites(orcsSiteNumber: { eq: $orcsSiteNumber }) {
+      siteName
+      siteNumber
+      orcsSiteNumber
+      mapZoom
+      longitude
+      latitude
+      isUnofficialSite
+      protectedArea {
+        orcs
+        slug
+        protectedAreaName
+        locationNotes
+        description
+        hasDayUsePass
+      }
+      parkActivities {
+        isActive
+        isActivityOpen
+        description
+        activityType {
+          activityName
+          activityCode
+          isActive
+          icon
+          iconNA
+          rank
+        }
+      }
+      parkFacilities {
+        isActive
+        isFacilityOpen
+        description
+        facilityType {
+          facilityName
+          facilityCode
+          isActive
+          icon
+          iconNA
+          rank
+        }
+      }
+      parkOperation {
+        hasReservations
+      }
+
+    }
+    # Site photos are split into featured and non-featured in order to sort correctly,
+    # with null values last.
+    featuredPhotos: allStrapiParkPhoto(
+      filter: {
+        orcsSiteNumber: { eq: $orcsSiteNumber }
+        isFeatured: { eq: true }
+        isActive: { eq: true }
+      }
+      sort: {
+        order: [ASC, DESC, DESC]
+        fields: [sortOrder, dateTaken, strapiId]
+      }
+    ) {
+      nodes {
+        imageUrl
+        caption
+      }
+    }
+    regularPhotos: allStrapiParkPhoto(
+      filter: {
+        orcsSiteNumber: { eq: $orcsSiteNumber }
+        isFeatured: { ne: true }
+        isActive: { eq: true }
+      }
+      sort: {
+        order: [ASC, DESC, DESC]
+        fields: [sortOrder, dateTaken, strapiId]
+      }
+    ) {
+      nodes {
+        imageUrl
+        caption
+      }
+    }
+    strapiWebsites(Name: { eq: "BCParks.ca" }) {
+      Footer
+      Header
+      Name
+      Navigation
+      id
+      homepage {
+        id
+        Template
+        Content {
+          id
+          strapi_component
+        }
+      }
+    }
+    allStrapiMenus(
+      sort: { fields: order, order: ASC }
+      filter: { show: { eq: true } }
+    ) {
+      nodes {
+        strapiId
+        title
+        url
+        order
+        id
+        imgUrl
+        strapiChildren {
+          id
+          title
+          url
+          order
+          parent
+        }
+        strapiParent {
+          id
+          title
+        }
+      }
+    }
+    site {
+      siteMetadata {
+        apiURL
+      }
+    }
+  }
+`

--- a/src/staging/src/utils/constants.js
+++ b/src/staging/src/utils/constants.js
@@ -1,3 +1,5 @@
+import { makeStyles } from "@material-ui/core/styles"
+
 export const PARK_NAME_TYPE = {
   Legal: 1,
   Escaped: 2,
@@ -6,3 +8,17 @@ export const PARK_NAME_TYPE = {
   Alias: 5,
   Historic: 6,
 }
+
+// for stylings
+const drawerWidth = 230
+export const useStyles = makeStyles(theme => ({
+  root: {
+    display: "flex",
+  },
+  parkContent: {
+    [theme.breakpoints.up("sm")]: {
+      width: `calc(100% - ${drawerWidth}px)`,
+    },
+  },
+  appBarOffset: theme.mixins.toolbar,
+}))


### PR DESCRIPTION
### Jira Ticket:
CM-162

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-162

### Description:
- Added new fields and a new relation: `slug`, `hasDayUsePass`, `description`, `locationNotes`, and `parkOperation`
- Added a new path for site page: `/protectedArea.slug/site.siteName` eg. `/parks/mount-robson/berg-lake-trail`
- Added a site template based on the design mockup.
- Those new fields  `slug`, `hasDayUsePass`, `description`, and `locationNotes` are available on Strapi, but won't be available on Gatsby (front-end) at this moment to avoid the build error. 