### PR TITLE
CM-209: disabled click event on arcgis maps

### DIFF
--- a/src/staging/src/components/park/mapLocation.js
+++ b/src/staging/src/components/park/mapLocation.js
@@ -53,6 +53,13 @@ export default function MapLocation({ data }) {
       })
       view.ui.add(fullscreen, "top-left")
 
+      // As per CM-209. Currently the map layers point back to the legacy URLs
+      // This can be removed when the layers are updated in the arcgis instance
+      view.on("click", (event) => {
+        event.stopPropagation()
+      });
+
+
     }
   }, [data.latitude, data.longitude, data.mapZoom])
 


### PR DESCRIPTION
### Jira Ticket:
CM-209

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-209

### Description:
When you click on a park layer in the embedded ArcGIS map, it reveals a pop with an URL to the parks page. 
This is both incorrect, as it's a legacy url, and not useful since the user is on the page. I've disable click events as none are needed. Click and drag continues to work.
