### PR TITLE
CM-248: Fix missing Winter Camping section

### DIFF
--- a/src/cms/data/park-facility-xref.json
+++ b/src/cms/data/park-facility-xref.json
@@ -460,7 +460,7 @@
       "facilityNumber": "1",
       "orcs": "40",
       "orcsSiteNumber": "40",
-      "description": "<p>\n  This park offers vehicle accessible campsites on a first-come, first-served basis - campsite reservations are not accepted. There are 21 gravel sites, one of which is a double site. There are no pull-through sites. There is limited parking for extra vehicles. There is a gate, but no gate house. You can walk in and camp if the gate is closed. If there is no staff available to direct you to a site, find a site that has no camping receipt or reservation tag. Park staff will be around to collect fees. There is a pay phone located at the park entrance. The nearest store is approximately 2 kilometres away in Roberts Creek.\n</p>\n<p>\n  <strong>Generator use</strong>\n  is only permitted between the hours of 9am � 11am, and from 6pm � 8pm.\n  <a href=\"/faq/\" class=\"legacy-link\">\n    View the generator policy</a>\n</p>\n<div>\n  Vehicle Accessible Camping Fee: $20.00 per party / night\n</div>\n<div>\n  BC Senior’s Rate (day after Labour Day to June 14 only): $10.00 per\n  <strong>senior party/</strong>night. Read the\n  <a href=\"/reservations/camping-fees#page-section-218\">\n    User Fees Policy</a>\n  for information on Senior Camping Discounts.</div>",
+      "description": "<p>\n  This park offers vehicle accessible campsites on a first-come, first-served basis - campsite reservations are not accepted. There are 21 gravel sites, one of which is a double site. There are no pull-through sites. There is limited parking for extra vehicles. There is a gate, but no gate house. You can walk in and camp if the gate is closed. If there is no staff available to direct you to a site, find a site that has no camping receipt or reservation tag. Park staff will be around to collect fees. There is a pay phone located at the park entrance. The nearest store is approximately 2 kilometres away in Roberts Creek.\n</p>\n<p>\n  <strong>Generator use</strong>\n  is only permitted between the hours of 9am – 11am, and from 6pm – 8pm.\n  <a href=\"/faq/\" class=\"legacy-link\">\n    View the generator policy</a>\n</p>\n<div>\n  Vehicle Accessible Camping Fee: $20.00 per party / night\n</div>\n<div>\n  BC Senior’s Rate (day after Labour Day to June 14 only): $10.00 per\n  <strong>senior party/</strong>night. Read the\n  <a href=\"/reservations/camping-fees#page-section-218\">\n    User Fees Policy</a>\n  for information on Senior Camping Discounts.</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -1164,7 +1164,7 @@
       "facilityNumber": "1",
       "orcs": "243",
       "orcsSiteNumber": "243",
-      "description": "<p>\n  This park offers vehicle-accessible campsites in a beautiful forest setting.� This campground is ideal for tenters and smaller RVs. Smelt Bay Campground is 100% by reservations only for this season. There is no first-come, first-served camping available. If campsites are not reserved they may be used as first come first served on a nightly basis. There is no overflow camping available.\n  <br>\n</p>\n<div>\n  Vehicle Accessible Camping Fee: $20.00 per party/night\n</div>\n<div>\n  BC Senior’s Rate (day after Labour Day to June 14 only): $10.00 per\n  <strong>senior party/</strong>night. Read the\n  <a href=\"/reservations/camping-fees#page-section-218\">\n    User Fees Policy</a>\n  for information on Senior Camping Discounts.\n</div>",
+      "description": "<p>\n  This park offers vehicle-accessible campsites in a beautiful forest setting.&nbsp; This campground is ideal for tenters and smaller RVs. Smelt Bay Campground is 100% by reservations only for this season. There is no first-come, first-served camping available. If campsites are not reserved they may be used as first come first served on a nightly basis. There is no overflow camping available.\n  <br>\n</p>\n<div>\n  Vehicle Accessible Camping Fee: $20.00 per party/night\n</div>\n<div>\n  BC Senior’s Rate (day after Labour Day to June 14 only): $10.00 per\n  <strong>senior party/</strong>night. Read the\n  <a href=\"/reservations/camping-fees#page-section-218\">\n    User Fees Policy</a>\n  for information on Senior Camping Discounts.\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -3596,7 +3596,7 @@
       "facilityNumber": "3",
       "orcs": "15",
       "orcsSiteNumber": "15",
-      "description": "There is one group campsite at this park which can be reserved. This group site may be booked year-round.\n<a href=\"#Reservations\">\n  Reservation information »</a>\n<br>\nThe group campsite is a short 50m walk from parking lot #1. The site offers a pit toilet, large group shelter with wood stove, five (5) picnic tables, and a single outside group fire pit. Drinking water is available. All wood must be brought in by the party or purchased from Mt. Seymour Resorts.\n<br>\n<div>\n  <strong>Youth group camping charges</strong>\n  per night are $1/person (6+), with a $50 minimum and $150 maximum. Read the\n  <a href=\"/reservations/camping-fees#page-section-217\">\n    Youth Group policy</a>\n  about Criteria for Youth Groups.\n  <br>\n  <br>\n  <strong>Regular group camping charges</strong>\n  per night are the base rate for the site, which is $80.00/group site/night, plus $5/adult (16+, minimum charge for 15 adults), plus $1/child (6-15). Children under 6 are free!\n</div>",
+      "description": "There is one group campsite at this park which can be reserved. This group site is not available for booking during the winter season, due to high visitor volumes and snow conditions.\n<a href=\"#Reservations\">\n  Reservation information »</a>\n<br>\nThe group campsite is a short 50m walk from parking lot #1. The site offers a pit toilet, large group shelter with wood stove, five (5) picnic tables, and a single outside group fire pit. Drinking water is available. All wood must be brought in by the party or purchased from Mt. Seymour Resorts.\n<br>\n<div>\n  <strong>Youth group camping charges</strong>\n  per night are $1/person (6+), with a $50 minimum and $150 maximum. Read the\n  <a href=\"/reservations/camping-fees#page-section-217\">\n    Youth Group policy</a>\n  about Criteria for Youth Groups.\n  <br>\n  <br>\n  <strong>Regular group camping charges</strong>\n  per night are the base rate for the site, which is $80.00/group site/night, plus $5/adult (16+, minimum charge for 15 adults), plus $1/child (6-15). Children under 6 are free!\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -3860,7 +3860,7 @@
       "facilityNumber": "3",
       "orcs": "306",
       "orcsSiteNumber": "306",
-      "description": "<h5>\n  Old group site closed � new group site in Forest Loop now open for use\n</h5>\n<p>\n  The old group campsite located at the north end of Alleyne Lake in the park has been decommissioned and is no longer available for reservations. Visitors are encouraged to book the newly finished group campsite in the Forest Loop of Kentucky-Alleyne Provincial Park. This group site has all brand new facilities and is available throughout the camping season through the BC Parks reservations system. During their stay, visitors will still be permitted to hike to the old group site if they wish.\n</p>\n<ul>\n  <li>\n    <a href=\"kentuckyalleyne.pdf\" target=\"_blank\" class=\"legacy-link\">\n      Park Map\n      <span>\n        [PDF]\n      </span>\n    </a>\n  </li>\n  <li>\n    <a href=\"#Reservations\">\n      How to reserve a group campsite</a>\n  </li>\n</ul>\n<div>\n  <p>\n    <strong>Youth group camping charges</strong>\n    per night are $1/person (6+), with a $50 minimum and $150 maximum. Read the\n    <a href=\"/reservations/camping-fees#page-section-217\">\n      Youth Group policy</a>\n    about Criteria for Youth Groups.\n  </p>\n  <p>\n    <strong>Regular group camping charges</strong>\n    per night are the base rate for the site, which is $80.00/group site/night, plus $5/adult (16+, minimum charge for 15 adults), plus $1/child (6-15). There is no fee for children under 6!\n  </p>\n</div>",
+      "description": "<h5>\n  Old group site closed – new group site in Forest Loop now open for use\n</h5>\n<p>\n  The old group campsite located at the north end of Alleyne Lake in the park has been decommissioned and is no longer available for reservations. Visitors are encouraged to book the newly finished group campsite in the Forest Loop of Kentucky-Alleyne Provincial Park. This group site has all brand new facilities and is available throughout the camping season through the BC Parks reservations system. During their stay, visitors will still be permitted to hike to the old group site if they wish.\n</p>\n<ul>\n  <li>\n    <a href=\"kentuckyalleyne.pdf\" target=\"_blank\" class=\"legacy-link\">\n      Park Map\n      <span>\n        [PDF]\n      </span>\n    </a>\n  </li>\n  <li>\n    <a href=\"#Reservations\">\n      How to reserve a group campsite</a>\n  </li>\n</ul>\n<div>\n  <p>\n    <strong>Youth group camping charges</strong>\n    per night are $1/person (6+), with a $50 minimum and $150 maximum. Read the\n    <a href=\"/reservations/camping-fees#page-section-217\">\n      Youth Group policy</a>\n    about Criteria for Youth Groups.\n  </p>\n  <p>\n    <strong>Regular group camping charges</strong>\n    per night are the base rate for the site, which is $80.00/group site/night, plus $5/adult (16+, minimum charge for 15 adults), plus $1/child (6-15). There is no fee for children under 6!\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -9220,7 +9220,7 @@
       "facilityNumber": "10",
       "orcs": "77",
       "orcsSiteNumber": "77",
-      "description": "A hand pump is available in the park.� Interior Health has issued a permanent “boil water” advisory on this source.",
+      "description": "A hand pump is available in the park.&nbsp; Interior Health has issued a permanent “boil water” advisory on this source.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -9716,7 +9716,7 @@
       "facilityNumber": "10",
       "orcs": "232",
       "orcsSiteNumber": "232",
-      "description": "A hand pump is available in the park.� Interior Health has issued a permanent “boil water” advisory on this source.",
+      "description": "A hand pump is available in the park.&nbsp; Interior Health has issued a permanent “boil water” advisory on this source.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16692,7 +16692,7 @@
       "facilityNumber": "18",
       "orcs": "1",
       "orcsSiteNumber": "1",
-      "description": "",
+      "description": "<p>\n  Winter camping opportunities exist throughout the park. Backcountry camping is permitted year-round; no fee is charged during the winter. Please camp near toilet facilities where possible and follow “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n    Leave No Trace</a>” camping ethics. Fires are not allowed in the backcountry areas of this park; bring a portable stove for cooking.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16708,7 +16708,7 @@
       "facilityNumber": "18",
       "orcs": "7",
       "orcsSiteNumber": "7",
-      "description": "",
+      "description": "Winter camping is allowed but be aware of the extreme winter conditions that can occur at this park. Check the trail report before heading out.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16716,7 +16716,7 @@
       "facilityNumber": "18",
       "orcs": "8",
       "orcsSiteNumber": "8",
-      "description": "",
+      "description": "<p>\n  Winter camping is available in\n  <strong>Gold Creek Campground\n  </strong>(unless park road is closed due to hazardous conditions). Alouette and North Beach campgrounds are closed in winter season.\n</p>\n<p>\n  During the winter season,\n  <strong>Golden Ears Park main gate is locked from 7:00 p.m. to 7:00 a.m. daily</strong>. A call-out number is posted on the main gate to contact staff\n  <strong>for emergencies only</strong>\n  during closed hours. Campers exiting the park on an emergency basis during closed hours cannot re-enter the park until after 7:00 a.m. the following morning. All campsites are available on a first-come first-serve basis. Reservations are not available. An attendant will collect the fee and complete registration on site. Payment is accepted in cash only.\n</p>\n<div>\n  Winter Camping Fee: $13.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16724,7 +16724,7 @@
       "facilityNumber": "18",
       "orcs": "15",
       "orcsSiteNumber": "15",
-      "description": "",
+      "description": "<p>\n  The group campsite is available year-round for walk-in camping.\n  <a href=\"#Reservations\">\n    Group campsite reservation information »</a>\n</p>\n<p>\n  Specific sites are not designated. Campers should choose locations carefully to avoid environmental damage and be prepared for all weather conditions. Open fires are not permitted in the backcountry. Currently, backcountry camping fees are not being collected.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16732,7 +16732,7 @@
       "facilityNumber": "18",
       "orcs": "25",
       "orcsSiteNumber": "25",
-      "description": "",
+      "description": "During the winter, campers are permitted to camp in the campground areas if accessible. Ministry of Transportation maintains access to the area.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16740,7 +16740,7 @@
       "facilityNumber": "18",
       "orcs": "28",
       "orcsSiteNumber": "28",
-      "description": "",
+      "description": "<p>\n  This park offers winter camping, but no services are available during the off-season.\n</p>\n<div>\n  <p>\n    Winter Vehicle Accessible Camping Fee: $11.00 per party / night\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16748,7 +16748,7 @@
       "facilityNumber": "18",
       "orcs": "31",
       "orcsSiteNumber": "31",
-      "description": "",
+      "description": "<p>\n  This park offers winter camping, but no services are available during the off-season.\n</p>\n<div>\n  <p>\n    Winter Vehicle Accessible Camping Fee: $11.00 per party / night\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16756,7 +16756,7 @@
       "facilityNumber": "18",
       "orcs": "33",
       "orcsSiteNumber": "33",
-      "description": "",
+      "description": "<p>\n  The following areas are set aside for winter camping:\n</p>\n<h5>\n  Lone Duck 1\n</h5>\n<p>\n  Walk–in winter tenting/camping parties can camp at the Lone Duck 1 winter camping area which is located 4 km off Highway 3 on the Gibson Pass ski hill road. This campsite consists of a shelter (currently closed due to COVID-19) with picnic tables, counter top, wood stove; a fire pit, pit toilets, parking area and a large walk-in camping area to set up your tent. You can bring your own firewood or purchase it from Manning Park Resort located just off of Highway #3.\n</p>\n<h5>\n  Lone Duck II group campsite\n</h5>\n<p>\n  This walk-in site is available by reservation only and consists of a shelter complete with picnic tables, wood stove; a fire pit, pit toilets, parking lot and a large walk-in camping area to set up your tents or dig-in.&nbsp; You can bring your own firewood or purchase it from Manning Park Resort located just off of Highway #3.\n</p>\n<h5>\n  Lightning Lake Day-use area (self-contained units)\n</h5>\n<p>\n  Self-contained units can camp in the Lightning Lake day-use area parking lot located 3.7 km off of Highway 3 on the Gibson Pass Ski Hill Road. The pit toilets are open, no fires are permitted, and no potable water or picnic tables are available. Tenting is prohibited in this location.\n</p>\n<div>\n  Winter Camping Fee: $13.00 per party/night\n</div>\n<h5>\n  Cambie Creek (Group Campground)\n</h5>\n<p>\n  Located approximately 5 km west of Manning Park Resort, this area is available for reservations and consists a pit toilet, parking lot and a large walk-in camping area to set up your tent. No fires are permitted.\n</p>\n<h5>\n  E.C. Manning Park Backcountry\n</h5>\n<p>\n  Winter camping is permitted in the backcountry at either developed backcountry sites or elsewhere in Manning Park provided no-trace ethics are practiced. Backcountry is defined as areas of the Park at least 1km from maintained roadways, parking lots or developed winter facilities. A backcountry permit is required year-round.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16764,7 +16764,7 @@
       "facilityNumber": "18",
       "orcs": "45",
       "orcsSiteNumber": "45",
-      "description": "",
+      "description": "<p>\n  Winter camping is offered at this park during a portion of the winter. Check the\n  <a href=\"#hours\">\n    Campground Dates of Operation</a>\n  for the dates available. The nearest campground that has campsites available year-round is Quinsam Campground in\n  <a href=\"../elk_falls/\" class=\"legacy-link\">\n    Elk Falls Provincial Park</a>, located 5 km west of Campbell River on Gold River Hwy 28.\n</p>\n<p>\n  Campers must be self-sufficient.\n</p>\n<div>\n  Winter Camping Fee: $13.00 per party/night</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16772,7 +16772,7 @@
       "facilityNumber": "18",
       "orcs": "48",
       "orcsSiteNumber": "48",
-      "description": "",
+      "description": "This park offers winter camping but no services are available during the off-season; campers must be self-sufficient.\n<div>\n  Winter Camping Fee: $12.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16788,7 +16788,7 @@
       "facilityNumber": "18",
       "orcs": "54",
       "orcsSiteNumber": "54",
-      "description": "",
+      "description": "The\n<strong>South Campground</strong>\nhas sites for winter camping.\n<div>\n  Winter Camping Fee: $13.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16796,7 +16796,7 @@
       "facilityNumber": "18",
       "orcs": "77",
       "orcsSiteNumber": "77",
-      "description": "",
+      "description": "Camping is permitted in the off season, but as the gates are closed, this would be on a walk in basis as long as the weather allows. Please note, no services are provided.\n<br>\n<div>\n  <p>\n    Winter Vehicle Accessible Camping Fee: $11.00 per party / night\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16804,7 +16804,7 @@
       "facilityNumber": "18",
       "orcs": "92",
       "orcsSiteNumber": "92",
-      "description": "",
+      "description": "<div>\n  <div>\n    <p>\n      Winter Vehicle Accessible Camping Fee: $16.00 per party / night\n    </p>\n  </div>\n  <p>\n    Winter camping fees are charged in the off-season; services may be reduced this time of year.\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16812,7 +16812,7 @@
       "facilityNumber": "18",
       "orcs": "96",
       "orcsSiteNumber": "96",
-      "description": "",
+      "description": "<p>\n  Goldstream Provincial Park is open year-round, however facilities are limited in the winter/off-season. A fee is in place for winter camping.\n</p>\n<div>\n  Winter Camping Fee: $13.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16820,7 +16820,7 @@
       "facilityNumber": "18",
       "orcs": "104",
       "orcsSiteNumber": "104",
-      "description": "",
+      "description": "16 vehicle-accessible sites are available located within the forested area, adjacent to the beach and day-use area and 28 walk-in/cycle-in sites are available to the left as you enter the park, above the parking lot near the wharf. These sites are situated in the forest above Montague Harbour.\n<br>\n<div>\n  Walk/Cycle-in Winter Frontcountry Camping Fee: $13.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16852,7 +16852,7 @@
       "facilityNumber": "18",
       "orcs": "182",
       "orcsSiteNumber": "182",
-      "description": "",
+      "description": "<p>\n  This park offers year-round camping with limited facilities during the off-season in the lower campground only.\n</p>\n<h4>Lower Campground Rates\n  <br>\n</h4>\n<div>\n  Winter Camping Fee: $13.00 per party/night\n</div>\n<div>\n  BC Senior’s Winter Rate: $12.50 per\n  <strong>senior party/</strong>night. Read the\n  <a href=\"/reservations/camping-fees#page-section-218\">\n    User Fees Policy</a>\n  for information on Senior Camping Discounts.</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16860,7 +16860,7 @@
       "facilityNumber": "18",
       "orcs": "193",
       "orcsSiteNumber": "193",
-      "description": "",
+      "description": "This park offers year-round camping with limited facilities during the off-season.\n<br>\n<div>\n  Winter Camping Fee: $13.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16868,7 +16868,7 @@
       "facilityNumber": "18",
       "orcs": "196",
       "orcsSiteNumber": "196",
-      "description": "",
+      "description": "Gibson Provincial Marine Park is accessible year-round. Please practice “<a href=\"../../notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16876,7 +16876,7 @@
       "facilityNumber": "18",
       "orcs": "210",
       "orcsSiteNumber": "210",
-      "description": "",
+      "description": "The park is open year-round with limited services in the off-season.\n<br>\n<div>\n  Winter Camping Fee: $13.00 per party/night</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16884,7 +16884,7 @@
       "facilityNumber": "18",
       "orcs": "215",
       "orcsSiteNumber": "215",
-      "description": "",
+      "description": "There are no designated campsites at this park, however random wilderness camping is allowed. No facilities are provided and there is no fee. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics. This park is accessible year-round; there is no winter camping fee.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16892,7 +16892,7 @@
       "facilityNumber": "18",
       "orcs": "223",
       "orcsSiteNumber": "223",
-      "description": "",
+      "description": "<p>\n  This park is open year-round; there is no fee for winter camping.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16900,7 +16900,7 @@
       "facilityNumber": "18",
       "orcs": "237",
       "orcsSiteNumber": "237",
-      "description": "",
+      "description": "<p>\n  Winter camping is available in this park.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16908,7 +16908,7 @@
       "facilityNumber": "18",
       "orcs": "247",
       "orcsSiteNumber": "247",
-      "description": "",
+      "description": "<p>\n  Winter camping is available depending on the accessibility to the trailhead via the Forest Service access road.\n  <br>\n</p>\n<div>\n  Backcountry Camping Fee: $5.00 per person / night for all persons 6 years of age or older.\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16916,7 +16916,7 @@
       "facilityNumber": "18",
       "orcs": "253",
       "orcsSiteNumber": "253",
-      "description": "",
+      "description": "All designated sites are available for winter camping. You will require equipment suitable for camping in several feet of snow. It is illegal to cut vegetation to create shelters or for insulation.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16924,7 +16924,7 @@
       "facilityNumber": "18",
       "orcs": "262",
       "orcsSiteNumber": "262",
-      "description": "",
+      "description": "<p>\n  The winter fee is in effect during the\n  <a href=\"#hours\">\n    winter/off-season</a>, with no water, no firewood, and no sani-station available.\n</p>\n<div>\n  Winter Camping Fee: $13.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16932,7 +16932,7 @@
       "facilityNumber": "18",
       "orcs": "267",
       "orcsSiteNumber": "267",
-      "description": "",
+      "description": "<p>\n  This park has eight vehicle-accessible campsites, available on a first-come, first-served basis. Campsite reservations are not accepted for the off-season. Facilities include pit toilets, cold water taps and group fire rings.\n</p>\n<div>\n  <p>\n    Winter Vehicle Accessible Camping Fee: $11.00 per party / night\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16940,7 +16940,7 @@
       "facilityNumber": "18",
       "orcs": "283",
       "orcsSiteNumber": "283",
-      "description": "",
+      "description": "For public safety purposes,\n<strong>Schoen Lake campground is closed and the gate is locked from November 1 to April 1,\n</strong>due to the threat of slides during the rainy season. Typically the access road to the campsite is impassable due to snow from late December to late March. There is no winter camping fee.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16948,7 +16948,7 @@
       "facilityNumber": "18",
       "orcs": "287",
       "orcsSiteNumber": "287",
-      "description": "",
+      "description": "Winter camping is permitted in all of the campgrounds in Whiteswan Lake Park; however with the exception of Inlet Creek Campground, the vehicle-accessed campgrounds are gated in the winter season. Winter camping in a gated campground will require a short walk to the campsites.\n<br>\nInlet Creek is a large open area beside the Whiteswan Forest Service Road with picnic tables and fire rings around the perimeter. This area is not regularly plowed so depending on the amount of snow it may not be possible to drive into the campground.\n<br>\nNo fees are charged for camping at Whiteswan Lake Park during the off season if no services are provided.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16964,7 +16964,7 @@
       "facilityNumber": "18",
       "orcs": "300",
       "orcsSiteNumber": "300",
-      "description": "",
+      "description": "<div>\n  <p>\n    Winter Vehicle Accessible Camping Fee: $11.00 per party / night\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16972,7 +16972,7 @@
       "facilityNumber": "18",
       "orcs": "314",
       "orcsSiteNumber": "314",
-      "description": "",
+      "description": "<div>\n  <p>\n    Sites 1-44 are available for camping during the winter season. Walk-in sites 1-6 are also avaialble for winter camping – see Dates of Operation table above for specific dates. The washroom/shower buildings are closed during the winter season. Potable water is available at one standpipe outside the campground washroom, and the sani-station is open unless temperatures drop below freezing.\n  </p>\n  <div>\n    Winter Vehicle-Accessible Camping Fee: $18.00/party/night camping fee plus $8.00 electrical/night = $26.00/party/night\n  </div>\n  <div>\n    BC Senior’s Winter Rate: $17.50 per\n    <strong>senior party/</strong>night plus $8.00 electrical/night = $25.50/party/night. See\n    <a href=\"/reservations/camping-fees#page-section-218\">\n      User Fees Policy</a>\n    for information on Senior Camping Discounts.\n  </div>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16980,7 +16980,7 @@
       "facilityNumber": "18",
       "orcs": "338",
       "orcsSiteNumber": "338",
-      "description": "",
+      "description": "A backcountry campground, with 10 wilderness sawdust tent pads, outhouse and food cache is provided at Akamina Creek. This campground is located just off the main trail 0.9 km from Akamina Pass and 2.4 km from the Akamina Pass Trailhead. Register a trip itinerary with friends; check in and check out. Winter camping is available year-round at Akamina Creek sites.\n<br>\n<div>\n  Backcountry Camping Fee: $5.00 per person / night for all persons 6 years of age or older.\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16988,7 +16988,7 @@
       "facilityNumber": "18",
       "orcs": "339",
       "orcsSiteNumber": "339",
-      "description": "",
+      "description": "This park is accessible year-round. There is no fee for winter camping.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -16996,7 +16996,7 @@
       "facilityNumber": "18",
       "orcs": "348",
       "orcsSiteNumber": "348",
-      "description": "Strathcona-Westmin Provincial Park is accessible year-round; there is no fee for winter camping.",
+      "description": "<p>\n  Strathcona-Westmin Provincial Park is accessible year-round; there is no fee for winter camping.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17004,7 +17004,7 @@
       "facilityNumber": "18",
       "orcs": "351",
       "orcsSiteNumber": "351",
-      "description": "",
+      "description": "<p>\n  Winter camping is allowed but please be aware of the extreme winter conditions that can occur at this Recreation Area. Backcountry skiing and snowshoeing opportunities exist. No facilities are provided. Winter camping has traditionally been occurring at or near Falls Lake.\n</p>\n<p>\n  Be properly equipped with, and experienced in the use of, avalanche safety gear if venturing into avalanche terrain. Coastal winter weather can change rapidly, affecting visibility and travel conditions. Be aware and prepared. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n    Leave No Trace</a>” camping ethics.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17012,7 +17012,7 @@
       "facilityNumber": "18",
       "orcs": "374",
       "orcsSiteNumber": "374",
-      "description": "",
+      "description": "<p>\n  There is one designated wilderness campground in this park, with four individual tent platform sites. A shared cooking shelter and picnic table are close by. Random beach camping is allowed along the western beaches of the park. Visitors are discouraged from camping at the beach areas east of the designated camping area. This park is accessible year-round. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n    Leave No Trace</a>” camping ethics.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17036,7 +17036,7 @@
       "facilityNumber": "18",
       "orcs": "481",
       "orcsSiteNumber": "481",
-      "description": "",
+      "description": "There are winter camping opportunities in this protected area, as it can be accessed all year.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17044,7 +17044,7 @@
       "facilityNumber": "18",
       "orcs": "484",
       "orcsSiteNumber": "484",
-      "description": "",
+      "description": "Winter camping is permitted in the park. The park is accessible year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17052,7 +17052,7 @@
       "facilityNumber": "18",
       "orcs": "489",
       "orcsSiteNumber": "489",
-      "description": "",
+      "description": "There are winter camping opportunities at this park, as it can be accessed year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17068,7 +17068,7 @@
       "facilityNumber": "18",
       "orcs": "1011",
       "orcsSiteNumber": "1011",
-      "description": "",
+      "description": "There are winter camping opportunities in this conservancy as it can be accessed year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17076,7 +17076,7 @@
       "facilityNumber": "18",
       "orcs": "1104",
       "orcsSiteNumber": "1104",
-      "description": "",
+      "description": "There are winter camping opportunities in this conservancy, as it can be accessed year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17092,7 +17092,7 @@
       "facilityNumber": "18",
       "orcs": "4382",
       "orcsSiteNumber": "4382",
-      "description": "",
+      "description": "There is winter camping in the park. The park is accessible year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17132,7 +17132,7 @@
       "facilityNumber": "18",
       "orcs": "6093",
       "orcsSiteNumber": "6093",
-      "description": "",
+      "description": "Winter Wilderness camping is allowed at seven designated camping areas in the park, but no facilities are provided. These areas are accessible by boat only. Camping is not permitted in other areas of the park. This park is open year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17140,7 +17140,7 @@
       "facilityNumber": "18",
       "orcs": "6111",
       "orcsSiteNumber": "6111",
-      "description": "",
+      "description": "This park is accessible year-round; there is no winter camping fee.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17148,7 +17148,7 @@
       "facilityNumber": "18",
       "orcs": "6161",
       "orcsSiteNumber": "6161",
-      "description": "",
+      "description": "<div>\n  <p>\n    Stoltz Pool Campground is open year-round; a winter camping fee is in place.\n  </p>\n  <div>\n    <p>\n      Winter Vehicle Accessible Camping Fee: $11.00 per party / night\n    </p>\n  </div>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17156,7 +17156,7 @@
       "facilityNumber": "18",
       "orcs": "6328",
       "orcsSiteNumber": "6328",
-      "description": "This park has winter camping opportunities; however, the gates are locked in the winter, so camping is walk-in only and no services are provided.",
+      "description": "<p>\n  This park has winter camping opportunities; however, the gates are locked in the winter, so camping is walk-in only and no services are provided.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17164,7 +17164,7 @@
       "facilityNumber": "18",
       "orcs": "8109",
       "orcsSiteNumber": "8109",
-      "description": "",
+      "description": "Winter camping is available to experienced backcountry recreationalists. Visitors to the area can snowshoe or ski in to the area. The cabin at 19.2 km remains open throughout the winter.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17172,7 +17172,7 @@
       "facilityNumber": "18",
       "orcs": "8299",
       "orcsSiteNumber": "8299",
-      "description": "",
+      "description": "Winter camping is available. Access in winter is via snowmobile. As described above, a BC Parks cabin located on the north east side of Redfern Lake is open to the public and free of charge. The cabin is maintained by the local snowmobile club. Please keep it clean and in good shape for the next visitor.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17180,7 +17180,7 @@
       "facilityNumber": "18",
       "orcs": "8345",
       "orcsSiteNumber": "8345",
-      "description": "",
+      "description": "There is winter camping in the park. The park is accessible year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17188,7 +17188,7 @@
       "facilityNumber": "18",
       "orcs": "8350",
       "orcsSiteNumber": "8350",
-      "description": "",
+      "description": "Winter camping is available at Hai Lake, but be prepared to hike or snowshoe in because the access road is not plowed during winter.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17196,7 +17196,7 @@
       "facilityNumber": "18",
       "orcs": "8379",
       "orcsSiteNumber": "8379",
-      "description": "",
+      "description": "There is Winter Camping in the park. The park is accessible year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17204,7 +17204,7 @@
       "facilityNumber": "18",
       "orcs": "8774",
       "orcsSiteNumber": "8774",
-      "description": "",
+      "description": "Please practice “<a href=\"../../notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics. This park is open year-round. There is no fee for winter camping.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17212,7 +17212,7 @@
       "facilityNumber": "18",
       "orcs": "8778",
       "orcsSiteNumber": "8778",
-      "description": "",
+      "description": "Wilderness camping is allowed; no facilities are provided. There is one wilderness, user-maintained beach camping area on the peninsula at Rolling Roadstead. A pit toilet is located at this location. Other good camping areas can be found in the vicinity of the Twin Islands. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics. This park is accessible year-round; there is no winter camping fee.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17220,7 +17220,7 @@
       "facilityNumber": "18",
       "orcs": "8779",
       "orcsSiteNumber": "8779",
-      "description": "",
+      "description": "<p>\n  This park is accessible year-round; there is no fee for winter camping.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17228,7 +17228,7 @@
       "facilityNumber": "18",
       "orcs": "8782",
       "orcsSiteNumber": "8782",
-      "description": "",
+      "description": "White Ridge Provincial Park is open year-round, however access roads may become snowbound in the winter.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17236,7 +17236,7 @@
       "facilityNumber": "18",
       "orcs": "9185",
       "orcsSiteNumber": "9185",
-      "description": "There is winter camping in the park.",
+      "description": "<p>\n  Winter camping is permitted in the park.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17244,7 +17244,7 @@
       "facilityNumber": "18",
       "orcs": "9458",
       "orcsSiteNumber": "9458",
-      "description": "",
+      "description": "<ul>\n  <li>\n    Due to the low snow levels in the Lytton area, there is opportunity for visitors to camp in the lower valley during the winter.\n  </li>\n</ul>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17252,7 +17252,7 @@
       "facilityNumber": "18",
       "orcs": "9459",
       "orcsSiteNumber": "9459",
-      "description": "",
+      "description": "Tahsish-Kwois Provincial Park is open year-round; there is no fee for winter camping.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17260,7 +17260,7 @@
       "facilityNumber": "18",
       "orcs": "9469",
       "orcsSiteNumber": "9469",
-      "description": "",
+      "description": "This park is open year-round; there is no fee for winter camping.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17268,7 +17268,7 @@
       "facilityNumber": "18",
       "orcs": "9471",
       "orcsSiteNumber": "9471",
-      "description": "",
+      "description": "Woss Lake Provincial Park is open year-round; there is no fee for winter backcountry camping.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17284,7 +17284,7 @@
       "facilityNumber": "18",
       "orcs": "9495",
       "orcsSiteNumber": "9495",
-      "description": "",
+      "description": "Sydney Inlet Park is accessible year-round; there is no winter backcountry camping fee.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17292,7 +17292,7 @@
       "facilityNumber": "18",
       "orcs": "9497",
       "orcsSiteNumber": "9497",
-      "description": "",
+      "description": "Flores Island is accessible year-round; there is no winter camping fee at this time.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17300,7 +17300,7 @@
       "facilityNumber": "18",
       "orcs": "9498",
       "orcsSiteNumber": "9498",
-      "description": "",
+      "description": "There are no designated campsites at this park, however wilderness camping is allowed. No facilities are provided other than six pit toilets and five food caches, located in popular camping areas. Vargas Island is accessible year-round; there is currently no winter camping fee, however a fee may be implemented in the future. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17308,7 +17308,7 @@
       "facilityNumber": "18",
       "orcs": "9500",
       "orcsSiteNumber": "9500",
-      "description": "",
+      "description": "There are no designated campsites at this park, however random wilderness camping is permitted year-round. No facilities are provided and there is no fee. Please practice “<a href=\"../../notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17316,7 +17316,7 @@
       "facilityNumber": "18",
       "orcs": "9501",
       "orcsSiteNumber": "9501",
-      "description": "",
+      "description": "There are no designated campsites at this park, however random wilderness camping is allowed. No facilities are provided and there is no fee. Tranquil Creek Park is accessible year-round; there is no winter backcountry camping fee at this time. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17324,7 +17324,7 @@
       "facilityNumber": "18",
       "orcs": "9506",
       "orcsSiteNumber": "9506",
-      "description": "",
+      "description": "This park is accessible by boat only. Random camping is allowed, although there are no developed sites and no facilities are provided. This park is accessible year-round. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17332,7 +17332,7 @@
       "facilityNumber": "18",
       "orcs": "9507",
       "orcsSiteNumber": "9507",
-      "description": "",
+      "description": "This park is open year-round, however roads may become inaccessible due to snowfall. There is no fee for backcountry camping. Please practice “<a href=\"../../notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17340,7 +17340,7 @@
       "facilityNumber": "18",
       "orcs": "9508",
       "orcsSiteNumber": "9508",
-      "description": "",
+      "description": "<p>\n  Backcountry/walk-in camping is allowed. The backcountry of the park is open to year-round. Please use the food cache provided at Widgeon Creek campsite to prevent bear/human conflicts. Campfires are not permitted within the park. Users must be prepared for winter conditions during the off-season.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17348,7 +17348,7 @@
       "facilityNumber": "18",
       "orcs": "9512",
       "orcsSiteNumber": "9512",
-      "description": "",
+      "description": "<p>\n  This park is open year-round.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17356,7 +17356,7 @@
       "facilityNumber": "18",
       "orcs": "9532",
       "orcsSiteNumber": "9532",
-      "description": "",
+      "description": "While fires are allowed, we encourage visitors to conserve the environment by minimizing the use of fire and using stoves instead. If you must use a campfire, please practice “<a href=\"../../notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17364,7 +17364,7 @@
       "facilityNumber": "18",
       "orcs": "9601",
       "orcsSiteNumber": "9601",
-      "description": "",
+      "description": "There is winter camping in the park. The park is accessible year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17372,7 +17372,7 @@
       "facilityNumber": "18",
       "orcs": "9746",
       "orcsSiteNumber": "9746",
-      "description": "",
+      "description": "This park is open year-round; however the roads may become inaccessible in the winter due to snowfall.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17380,7 +17380,7 @@
       "facilityNumber": "18",
       "orcs": "9747",
       "orcsSiteNumber": "9747",
-      "description": "",
+      "description": "This park is open year-round, depending on road access. There is no fee for winter camping.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17388,7 +17388,7 @@
       "facilityNumber": "18",
       "orcs": "9749",
       "orcsSiteNumber": "9749",
-      "description": "",
+      "description": "Wilderness, backcountry or walk-in camping is allowed on the northwest tip of Nootka Island and the many small island groups within the park. There are some small developed sites accessible by kayaks and smaller boats at Rosa Island. Undeveloped but useable areas are scattered throughout the island groups and on the northwest coast of Nootka Island. Pit toilets are located at Rosa Island and at some of these other sites. This park is accessible year-round; there is no fee for winter camping.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17396,7 +17396,7 @@
       "facilityNumber": "18",
       "orcs": "9750",
       "orcsSiteNumber": "9750",
-      "description": "",
+      "description": "There are no designated campsites at this park, however random wilderness camping is allowed. No facilities are provided and there is no fee. Read Island is accessible year-round. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17412,7 +17412,7 @@
       "facilityNumber": "18",
       "orcs": "9752",
       "orcsSiteNumber": "9752",
-      "description": "",
+      "description": "Weymer Creek Provincial Park is open year-round, however access roads may become snowbound in the winter.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17420,7 +17420,7 @@
       "facilityNumber": "18",
       "orcs": "9754",
       "orcsSiteNumber": "9754",
-      "description": "",
+      "description": "There are no designated campsites at this park, however random wilderness camping is allowed. No facilities are provided and there is no fee. Please practice “<a href=\"/explore/notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics. Small Inlet Marine is accessible year-round; there is no camping fee.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -17428,7 +17428,7 @@
       "facilityNumber": "18",
       "orcs": "9767",
       "orcsSiteNumber": "9767",
-      "description": "",
+      "description": "There are no designated campsites at this park, however random wilderness camping is allowed. No facilities are provided and there is no fee. This park is accessible year-round. Please practice “<a href=\"../../notrace.html\" class=\"legacy-link\">\n  Leave No Trace</a>” camping ethics.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -18044,7 +18044,7 @@
       "facilityNumber": "18",
       "orcs": "1105",
       "orcsSiteNumber": "1105",
-      "description": "",
+      "description": "There are winter camping opportunities in this conservancy, as it can be accessed year-round.",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -18188,7 +18188,7 @@
       "facilityNumber": "18",
       "orcs": "77",
       "orcsSiteNumber": "77",
-      "description": "",
+      "description": "Camping is permitted in the off season, but as the gates are closed, this would be on a walk in basis as long as the weather allows. Please note, no services are provided.\n<br>\n<div>\n  <p>\n    Winter Vehicle Accessible Camping Fee: $11.00 per party / night\n  </p>\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -18380,7 +18380,7 @@
       "facilityNumber": "18",
       "orcs": "485",
       "orcsSiteNumber": "485",
-      "description": "",
+      "description": "<p>\n  Winter camping is permitted in the park. The park is accessible year-round.</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -18676,7 +18676,7 @@
       "facilityNumber": "18",
       "orcs": "1113",
       "orcsSiteNumber": "1113",
-      "description": "",
+      "description": "<p>\n  There are winter camping opportunities in this conservancy, as it can be accessed year-round.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -21180,7 +21180,7 @@
       "facilityNumber": "18",
       "orcs": "122",
       "orcsSiteNumber": "122",
-      "description": "",
+      "description": "<p>\n  Winter camping is available at\n  <strong>Rolley Lake Provincial Park</strong>\n  (unless park road is closed due to hazardous conditions).\n</p>\n<p>\n  Campsites are available on a first-come, first-served basis. Reservations are not available. An attendant will collect the fee and complete registration on site. Payment is accepted in cash, only.\n</p>\n<div>\n  Winter Camping Fee: $18.00 per party/night\n</div>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -21420,7 +21420,7 @@
       "facilityNumber": "18",
       "orcs": "163",
       "orcsSiteNumber": "163",
-      "description": "",
+      "description": "<p>\n  Winter camping is available in this park – fees apply.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -21436,7 +21436,7 @@
       "facilityNumber": "18",
       "orcs": "9034",
       "orcsSiteNumber": "9034",
-      "description": "",
+      "description": "<p>\n  Winter camping is allowed, but no facilites are provided.\n</p>",
       "isFacilityOpen": false,
       "isActive": true
     },
@@ -22421,6 +22421,94 @@
       "orcs": "8297",
       "orcsSiteNumber": "8297",
       "description": "<p>\n  Wilderness camping is allowed; no facilities are provided.\n</p>",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "89",
+      "orcsSiteNumber": "89",
+      "description": "<div>\n  Winter Frontcountry Camping Fee: $13.00 per party/night</div>",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "190",
+      "orcsSiteNumber": "190",
+      "description": "This park is open year-round. Campers must be self-sufficient.\n<div>\n  Winter Camping Fee: $11.00 per party/night</div>",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "117",
+      "orcsSiteNumber": "117",
+      "description": "<p>\n  Bamberton Provincial Park is open year-round, with limited facilities in the off-season.\n</p>\n<div>\n  Winter Camping Fee: $11.00 per party / night\n</div>",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1031",
+      "orcsSiteNumber": "1031",
+      "description": "Winter camping is permitted in the park. Visitors must be fully prepared and self-sufficient to camp in this Conservancy.",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1007",
+      "orcsSiteNumber": "1007",
+      "description": "There are winter camping opportunities in this conservancy but access may be a problem if the lake is frozen over.",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1092",
+      "orcsSiteNumber": "1092",
+      "description": "<p>\n  There are winter camping opportunities in this conservancy but access may be a problem if the lake is frozen over.</p>",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1014",
+      "orcsSiteNumber": "1014",
+      "description": "There are winter camping opportunities in this conservancy, as it can be accessed year-round.",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1001",
+      "orcsSiteNumber": "1001",
+      "description": "There are winter camping opportunities in this conservancy, as it can be accessed year-round.",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1006",
+      "orcsSiteNumber": "1006",
+      "description": "There are winter camping opportunities in this conservancy, as it can be accessed year-round.",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1009",
+      "orcsSiteNumber": "1009",
+      "description": "There are winter camping opportunities in this conservancy, as it can be accessed year-round.",
+      "isFacilityOpen": false,
+      "isActive": true
+    },
+    {
+      "facilityNumber": "18",
+      "orcs": "1018",
+      "orcsSiteNumber": "1018",
+      "description": "There are winter camping opportunities in this conservancy, as it can be accessed year-round.",
       "isFacilityOpen": false,
       "isActive": true
     }

--- a/tools/legacy-scrape/visitor-services-patches/ScrapePatch -- ContentScrape line 961.vb
+++ b/tools/legacy-scrape/visitor-services-patches/ScrapePatch -- ContentScrape line 961.vb
@@ -1,0 +1,2 @@
+              'Call UpdateActFac(orcs, 18, sWinterCamping, "Activity")
+              Call UpdateActFac(orcs, 18, sWinterCamping, "Facility")


### PR DESCRIPTION
### Jira Ticket:
CM-248

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-248

### Description:
- Fixed a bug in the visitor services MS-Access db that was breaking the export of Winter Camping
- Re-scraped ParkActivityXref data

* there are some other changes in the JSON file to do updates to how UTF-8 characters are handled (via CM-231)
