### PR TITLE
NOBUG: Fixed relative links issue on park pages

### DIFF
--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -275,7 +275,9 @@ async function createParks({ graphql, actions, reporter }) {
 
   result.data.allStrapiProtectedArea.nodes.forEach(park => {
     actions.createPage({
-      path: park.urlPath,
+      // add a trailing slash park pages so they are treated as folders
+      // when resolving relative urls (so they can link to their child pages)
+      path: park.urlPath.replace(/\/$|$/, `/`),
       component: require.resolve(`./src/templates/park.js`),
       context: { ...park },
     })


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:
Fixed a 'missing trailing slash' issue where park pages were being treated as files instead of folders in the browser, so links to child pages were not working
