### PR TITLE
CM-246: Apply new Strapi fields to Gatsby site template

### DIFF
--- a/src/cms/api/site/models/site.settings.json
+++ b/src/cms/api/site/models/site.settings.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "siteName": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "siteNumber": {
       "type": "integer"
@@ -48,7 +49,8 @@
     },
     "protectedArea": {
       "via": "sites",
-      "model": "protected-area"
+      "model": "protected-area",
+      "required": true
     },
     "parkActivities": {
       "via": "site",

--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -359,7 +359,7 @@ async function createSites({ graphql, actions, reporter }) {
     // fallback in case site doesn't have a slug
     const slug = site.slug ?? slugify(site.siteName).toLowerCase()
     // fallback in case site doesn't have a relation with protectedArea
-    const parkPath = site.protectedArea?.urlPath ?? "parks/protected-area"
+    const parkPath = site.protectedArea?.urlPath ?? "no-protected-area"
     const sitePath = `${parkPath}/${slug}`
     actions.createPage({
       path: sitePath,

--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -237,9 +237,13 @@ exports.createSchemaCustomization = ({ actions }) => {
   }
 
   type StrapiSites implements Node {
+    slug: String
     siteName: String
     siteNumber: Int
     orcsSiteNumber: String
+    locationNotes: String
+    description: String
+    hasDayUsePass: Boolean
     protectedArea: StrapiProtectedArea
     parkActivities: [StrapiParkActivities]
     parkFacilities: [StrapiParkFacilities]
@@ -337,6 +341,7 @@ async function createSites({ graphql, actions, reporter }) {
     allStrapiSites {
       nodes {
         id
+        slug
         siteName
         siteNumber
         orcsSiteNumber
@@ -351,15 +356,11 @@ async function createSites({ graphql, actions, reporter }) {
   const result = await strapiApiRequest(graphql, siteQuery)
 
   result.data.allStrapiSites.nodes.forEach(site => {
-    // TODO: slug can be deleted when site.slug has created on all strapi env
-    const slug = slugify(site.siteName).toLowerCase()
-    const parkPath = site.protectedArea?.urlPath
-    // TODO: change sitePath `${parkPath}/${slug}` to `${parkPath}/${site.slug}` when site.slug has created on all strapi env
-    let sitePath = `${parkPath}/${slug}`
-    // If site doesn't have a relation with protectedArea, its path will be `parks/protected-area/${slug}`
-    if (!parkPath) {
-      sitePath = `parks/protected-area/${slug}`
-    }
+    // fallback in case site doesn't have a slug
+    const slug = site.slug ?? slugify(site.siteName).toLowerCase()
+    // fallback in case site doesn't have a relation with protectedArea
+    const parkPath = site.protectedArea?.urlPath ?? "parks/protected-area"
+    const sitePath = `${parkPath}/${slug}`
     actions.createPage({
       path: sitePath,
       component: require.resolve(`./src/templates/site.js`),

--- a/src/staging/src/templates/site.js
+++ b/src/staging/src/templates/site.js
@@ -69,8 +69,7 @@ export default function ParkTemplate({ data }) {
   )
 
   const hasReservations = operations.hasReservations
-  // TODO: change park.hasDayUsePass to site.hasDayUsePass when site.hasDayUsePass has created on all strapi env
-  const hasDayUsePass = park?.hasDayUsePass
+  const hasDayUsePass = site.hasDayUsePass
 
   // Use hasCamping if camping section is needed
   // const hasCamping = activeFacilities.some(facility =>
@@ -140,8 +139,7 @@ export default function ParkTemplate({ data }) {
       sectionIndex: 0,
       display: "Site overview",
       link: "#park-overview-container",
-      // TODO: change park.description to site.description when site.description has created on all strapi env
-      visible: park?.description,
+      visible: site.description,
     },
     {
       sectionIndex: 1,
@@ -174,8 +172,7 @@ export default function ParkTemplate({ data }) {
       sectionIndex: 5,
       display: "Location",
       link: "#park-maps-location-container",
-      // TODO: change park.locationNotes to site.locationNotes when site.locationNotes has created on all strapi env
-      visible: (site.latitude && site.longitude) || park?.locationNotes,
+      visible: (site.latitude && site.longitude) || site.locationNotes,
     },
   ]
 
@@ -282,8 +279,7 @@ export default function ParkTemplate({ data }) {
             >
               {menuItems[0].visible && (
                 <div ref={parkOverviewRef} className="full-width">
-                  {/* TODO: change park.description to site.description when site.description has created on all strapi env */}
-                  <ParkOverview data={park?.description} type="site" />
+                  <ParkOverview data={site.description} type="site" />
                 </div>
               )}
               {menuItems[1].visible && (
@@ -328,13 +324,12 @@ export default function ParkTemplate({ data }) {
                 <div ref={mapLocationRef} className="full-width">
                   <div id="park-maps-location-container" className="anchor-link">
                     <MapLocation data={mapData} />
-                    {/* TODO: change park.locationNotes to site.locationNotes when site.locationNotes has created on all strapi env */}
-                    {park?.locationNotes && (
+                    {site.locationNotes && (
                       <Grid item xs={12} id="park-location-notes-container">
                         <Box mb={8}>
                           <div
                             dangerouslySetInnerHTML={{
-                              __html: park?.locationNotes,
+                              __html: site.locationNotes,
                             }}
                           ></div>
                         </Box>
@@ -364,14 +359,14 @@ export const query = graphql`
       mapZoom
       longitude
       latitude
+      locationNotes
+      description
+      hasDayUsePass
       isUnofficialSite
       protectedArea {
         orcs
         slug
         protectedAreaName
-        locationNotes
-        description
-        hasDayUsePass
       }
       parkActivities {
         isActive


### PR DESCRIPTION
### Jira Ticket:
CM-246

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-246

### Description:
- Made `siteName` and `protectedArea` relation as required since they’re necessary for the URL path
- TODO: `slug` also should be a required field, after the data import
- Changed URL path using `slug`, if there's no `slug`, `siteName` will be used
- Applied new fields `locationNotes`, `description`, and `hasDayUsePass` to `site.js`
