### PR TITLE
NOBUG: Wrong access status shown on search result page

### DIFF
--- a/src/cms/api/protected-area/services/protected-area.js
+++ b/src/cms/api/protected-area/services/protected-area.js
@@ -79,7 +79,11 @@ module.exports = {
         knex.raw(
           `array(
             SELECT to_json((
-              SELECT d FROM (SELECT public_advisories."id", public_advisories."urgency") d
+              SELECT j FROM (
+                SELECT public_advisories."id", 
+                public_advisories."urgency", 
+                public_advisories."accessStatus"
+              ) j
             ))
             FROM public_advisories__protected_areas
             JOIN public_advisories


### PR DESCRIPTION
### Jira Ticket:
CM-200 (bugfix)

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-200

### Description:
The status "Open to public access" was showing on parks where the access should have been "Open".  This was caused by removing too many fields from the query when making it faster.  
