### PR TITLE
CM-314: Change site slug fallback

### DIFF
--- a/src/cms/api/page/models/page.settings.json
+++ b/src/cms/api/page/models/page.settings.json
@@ -12,7 +12,8 @@
   },
   "attributes": {
     "Slug": {
-      "type": "string"
+      "type": "string",
+      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$|^$"
     },
     "Title": {
       "type": "string",

--- a/src/cms/api/park-sub-page/models/park-sub-page.settings.json
+++ b/src/cms/api/park-sub-page/models/park-sub-page.settings.json
@@ -13,7 +13,8 @@
   "attributes": {
     "slug": {
       "type": "string",
-      "required": true
+      "required": true,
+      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
     "title": {
       "type": "string",

--- a/src/cms/api/protected-area/models/protected-area.settings.json
+++ b/src/cms/api/protected-area/models/protected-area.settings.json
@@ -163,7 +163,8 @@
       "type": "richtext"
     },
     "slug": {
-      "type": "string"
+      "type": "string",
+      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$|^$"
     },
     "isDisplayed": {
       "type": "boolean",

--- a/src/cms/api/site/models/site.settings.json
+++ b/src/cms/api/site/models/site.settings.json
@@ -12,7 +12,8 @@
   },
   "attributes": {
     "slug": {
-      "type": "string"
+      "type": "string",
+      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$|^$"
     },
     "siteName": {
       "type": "string",

--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -422,7 +422,7 @@ async function createSites({ graphql, actions, reporter }) {
 
   result.data.allStrapiSites.nodes.forEach(site => {
     // fallback in case site doesn't have a slug
-    const slug = site.slug ? site.slug : slugify(site.siteName).toLowerCase()
+    const slug = site.slug || slugify(site.siteName).toLowerCase()
     // fallback in case site doesn't have a relation with protectedArea
     const parkPath = site.protectedArea?.urlPath ?? "no-protected-area"
     const sitePath = `${parkPath}/${slug}`

--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -422,7 +422,7 @@ async function createSites({ graphql, actions, reporter }) {
 
   result.data.allStrapiSites.nodes.forEach(site => {
     // fallback in case site doesn't have a slug
-    const slug = site.slug ?? slugify(site.siteName).toLowerCase()
+    const slug = site.slug ? site.slug : slugify(site.siteName).toLowerCase()
     // fallback in case site doesn't have a relation with protectedArea
     const parkPath = site.protectedArea?.urlPath ?? "no-protected-area"
     const sitePath = `${parkPath}/${slug}`


### PR DESCRIPTION
### Jira Ticket:
CM-314

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-314

### Description:
- Change site slug fallback logic
- If there's only `siteName`: `siteName` will be used as a path
- If there's both `slug` and `siteName`: `slug` will be used as a path
- Note: Since `siteName` is a required field, there's always `siteName`
- Added regex to all `slug` fields to prevent editors to add any whitespaces
-  `^[a-z0-9]+(?:-[a-z0-9]+)*$` accepts all special characters but whitespace 
- `^[a-z0-9]+(?:-[a-z0-9]+)*$|^$` accepts all special characters but whitespace, or an empty string because some of the slug fields are not required