### PR TITLE
CM-279: Change api endpoint for counter

### DIFF
--- a/src/staging/src/pages/active-advisories.js
+++ b/src/staging/src/pages/active-advisories.js
@@ -161,10 +161,10 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
     // exclude unpublished parks
     let q =
-      "/public-advisories/count?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true"
+      "/public-advisories/count"
 
     if (advisoryType !== "all") {
-      q += `&eventType.eventType_contains=${advisoryType}`
+      q += `?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true&eventType.eventType_contains=${advisoryType}`
     }
 
     const newApiCountCall = apiUrl + q
@@ -250,6 +250,10 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
             // Get count
             let apiCount = apiUrl + "/public-advisories/count" + q
+            if (q === "?_sort=advisoryDate:DESC&protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true") {
+             apiCount = apiUrl + "/public-advisories/count"
+            }
+            
             axios
               .get(apiCount)
               .then(function (data) {

--- a/src/staging/src/pages/active-advisories.js
+++ b/src/staging/src/pages/active-advisories.js
@@ -160,11 +160,15 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     // unfiltered count for the header
 
     // exclude unpublished parks
+    // this filter has been removed as a temporary workaround for a Strapi bug.
+    // see https://github.com/bcgov/bcparks.ca/pull/505/files#r1067160153
+
+    // let q = "/public-advisories/count?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true"
     let q =
       "/public-advisories/count"
 
     if (advisoryType !== "all") {
-      q += `?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true&eventType.eventType_contains=${advisoryType}`
+      q += `?&eventType.eventType_contains=${advisoryType}`
     }
 
     const newApiCountCall = apiUrl + q


### PR DESCRIPTION
### Jira Ticket:
CM-279

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-279

### Description:
- There are 455 `PublicAdvisories` on [TEST](https://test-cms.bcparks.ca/admin/plugins/content-manager/collectionType/application::public-advisory.public-advisory?page=1&pageSize=10&_sort=title:ASC)
- [Previous endpoint](https://test-cms.bcparks.ca/public-advisories/count?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true) `/public-advisories/count?protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true` has 550 `PublicAdvisories`
- Changed endpoint to `/public-advisories/count` to get proper data
- ^ [New endpoint](https://test-cms.bcparks.ca/public-advisories/count?) has 455 `PublicAdvisories`
#### Issues:
- Somehow filtered endpoint count doesn't work properly 🥲
- However, filtered endpoint and additional query works (e.g. [Example with search query](https://test-cms.bcparks.ca/public-advisories/count?_sort=advisoryDate:DESC&protectedAreas.published_at_null=false&protectedAreas.isDisplayed=true&_q=Sproat) has 2 `PublicAdvisories`)