### PR TITLE
hotfix: forced later version of dependency to fix bug with ckeditor init

### DIFF
--- a/src/cms/package.json
+++ b/src/cms/package.json
@@ -14,6 +14,7 @@
     "reimport": "node scripts/reimport.js"
   },
   "dependencies": {
+    "@babel/plugin-transform-block-scoping": "^7.20.11",
     "@ckeditor/ckeditor5-build-classic": "^29.2.0",
     "@ckeditor/ckeditor5-react": "^3.0.3",
     "@ckeditor/ckeditor5-source-editing": "^29.2.0",
@@ -44,9 +45,6 @@
     "npm": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.20.5",
-    "@babel/eslint-parser": "^7.13.10",
-    "@babel/traverse": "7.20.5",
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.3.0",
     "jest": "^27.4.7",


### PR DESCRIPTION
### Description:
Hotfix to solve build errors when using the custom build of CKEditor.

@babel/plugin-transform-block-scoping version 7.20.7 appears to have introduced a bug that causes the build to fail. Updated package.json to require ^7.20.11.