### PR TITLE
CM-329: Fix for some filters not working on Find a Park page

### DIFF
--- a/src/staging/src/pages/find-a-park.js
+++ b/src/staging/src/pages/find-a-park.js
@@ -49,14 +49,20 @@ export const query = graphql`
         apiURL
       }
     }
-    allStrapiActivityTypes(sort: { fields: activityName }) {
+    allStrapiActivityTypes(
+      sort: { fields: activityName }
+      filter: { isActive: { eq: true } }
+    ) {
       totalCount
       nodes {
         strapiId
         activityName
       }
     }
-    allStrapiFacilityTypes(sort: { fields: facilityName }) {
+    allStrapiFacilityTypes(
+      sort: { fields: facilityName }
+      filter: { isActive: { eq: true } }      
+    ) {
       totalCount
       nodes {
         strapiId


### PR DESCRIPTION
### Jira Ticket:
CM-329

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-329

### Description:
Hide inactive activity and facility filters from the find a park page. These are being filtered out by the search query, and thus always resulting in no matching parks.
