### PR TITLE
CM-312: trailing slashes for pages, park sub pages and sites

### DIFF
--- a/src/staging/gatsby-node.js
+++ b/src/staging/gatsby-node.js
@@ -393,7 +393,7 @@ async function createParkSubPages({ graphql, actions, reporter }) {
     const parkPath = parkSubPage.protectedArea?.urlPath
     const parkSubPagePath = `${parkPath}/${parkSubPage.slug}`
     actions.createPage({
-      path: parkSubPagePath,
+      path: parkSubPagePath.replace(/\/$|$/, `/`),
       component: require.resolve(`./src/templates/parkSubPage.js`),
       context: {
         protectedAreaSlug: parkSubPage.protectedArea.slug,
@@ -430,7 +430,7 @@ async function createSites({ graphql, actions, reporter }) {
     const parkPath = site.protectedArea?.urlPath ?? "no-protected-area"
     const sitePath = `${parkPath}/${slug}`
     actions.createPage({
-      path: sitePath,
+      path: sitePath.replace(/\/$|$/, `/`),
       component: require.resolve(`./src/templates/site.js`),
       context: { ...site },
     })
@@ -450,7 +450,7 @@ async function createPageSlugs(type, query, { graphql, actions, reporter }) {
   if (type === "static") {
     result.data.allStrapiPages.nodes.forEach(page => {
       actions.createPage({
-        path: page.Slug,
+        path: page.Slug.replace(/\/$|$/, `/`),
         component: require.resolve(`./src/templates/${page.Template}.js`),
         context: { page },
       })


### PR DESCRIPTION
### Jira Ticket:
CM-312

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-312

### Description:
Added the regex we're using for Parks to add trailing slashes to any pages we're creating using `createPage()` in `gatsby-config.js`
