### PR TITLE
CM-372: Not display empty camping section

### DIFF
--- a/src/staging/src/components/park/campingDetails.js
+++ b/src/staging/src/components/park/campingDetails.js
@@ -107,7 +107,7 @@ export default function CampingDetails({ data }) {
           {activeCampings.map((camping, index) => (
             <Accordion
               key={"camping" + index}
-              className="park-details mb-2"
+              className={`park-details mb-2 ${!camping.description && "park-details--disabled"}`}
             >
               <Accordion.Toggle
                 as={Container}
@@ -123,6 +123,7 @@ export default function CampingDetails({ data }) {
                       {camping?.activityType?.activityName || camping?.facilityType?.facilityName}
                     </HtmlContent>
                   </div>
+                  {camping.description && (
                   <div className="d-flex align-items-center expand-icon">
                     <i
                       className={
@@ -131,13 +132,16 @@ export default function CampingDetails({ data }) {
                       }
                     ></i>
                   </div>
+                  )}
                 </div>
               </Accordion.Toggle>
+              {camping.description && (
               <Accordion.Collapse eventKey="0">
                 <div className="p-4">
                   <HtmlContent>{camping.description}</HtmlContent>
                 </div>
               </Accordion.Collapse>
+              )}
             </Accordion>
           ))}
         </Col>

--- a/src/staging/src/components/park/campingDetails.js
+++ b/src/staging/src/components/park/campingDetails.js
@@ -5,6 +5,8 @@ import Col from "react-bootstrap/Col"
 import Container from "react-bootstrap/Container"
 import Row from "react-bootstrap/Row"
 
+import { isNullOrWhiteSpace } from "../../utils/helpers";
+
 import Heading from "./heading"
 import HtmlContent from "./htmlContent"
 import StaticIcon from "./staticIcon"
@@ -104,10 +106,12 @@ export default function CampingDetails({ data }) {
       </Row>
       <Row>
         <Col>
-          {activeCampings.map((camping, index) => (
+          {activeCampings.map((camping, index) => {
+          const isDescription = !isNullOrWhiteSpace(camping.description)
+          return (
             <Accordion
               key={"camping" + index}
-              className={`park-details mb-2 ${!camping.description && "park-details--disabled"}`}
+              className={`park-details mb-2 ${!isDescription && "park-details--disabled"}`}
             >
               <Accordion.Toggle
                 as={Container}
@@ -123,7 +127,7 @@ export default function CampingDetails({ data }) {
                       {camping?.activityType?.activityName || camping?.facilityType?.facilityName}
                     </HtmlContent>
                   </div>
-                  {camping.description && (
+                  {isDescription && (
                   <div className="d-flex align-items-center expand-icon">
                     <i
                       className={
@@ -135,7 +139,7 @@ export default function CampingDetails({ data }) {
                   )}
                 </div>
               </Accordion.Toggle>
-              {camping.description && (
+              {isDescription && (
               <Accordion.Collapse eventKey="0">
                 <div className="p-4">
                   <HtmlContent>{camping.description}</HtmlContent>
@@ -143,7 +147,7 @@ export default function CampingDetails({ data }) {
               </Accordion.Collapse>
               )}
             </Accordion>
-          ))}
+          )})}
         </Col>
       </Row>
     </div>

--- a/src/staging/src/components/park/parkActivity.js
+++ b/src/staging/src/components/park/parkActivity.js
@@ -4,6 +4,8 @@ import Col from "react-bootstrap/Col"
 import Container from "react-bootstrap/Container"
 import Row from "react-bootstrap/Row"
 
+import { isNullOrWhiteSpace } from "../../utils/helpers";
+
 import Heading from "./heading"
 import HtmlContent from "./htmlContent"
 import StaticIcon from "./staticIcon"
@@ -64,11 +66,13 @@ export default function ParkActivity({ data }) {
       </Row>
       <Row>
         <Col>
-          {activityData.map((activity, index) => (
+          {activityData.map((activity, index) => {
+            const isDescription = !isNullOrWhiteSpace(activity.description)
+            return (
             <Accordion
               key={"parkActivity" + index}
               activeKey={expanded[index] ? "parkActivity" + index : null}
-              className="park-details mb-2"
+              className={`park-details mb-2 ${!isDescription && "park-details--disabled"}`}
             >
               <Accordion.Toggle
                 as={Container}
@@ -87,6 +91,7 @@ export default function ParkActivity({ data }) {
                       {activity.activityType.activityName}
                     </HtmlContent>
                   </div>
+                  {isDescription && (
                   <div className="d-flex align-items-center expand-icon">
                     <i
                       className={
@@ -95,15 +100,18 @@ export default function ParkActivity({ data }) {
                       }
                     ></i>
                   </div>
+                  )}
                 </div>
               </Accordion.Toggle>
+              {isDescription && (
               <Accordion.Collapse eventKey={"parkActivity" + index}>
                 <div className="p-4">
                   <HtmlContent>{activity.description}</HtmlContent>
                 </div>
               </Accordion.Collapse>
+              )}
             </Accordion>
-          ))}
+          )})}
         </Col>
       </Row>
     </div>

--- a/src/staging/src/components/park/parkFacility.js
+++ b/src/staging/src/components/park/parkFacility.js
@@ -5,6 +5,8 @@ import Col from "react-bootstrap/Col"
 import Accordion from "react-bootstrap/Accordion"
 import Container from "react-bootstrap/Container"
 
+import { isNullOrWhiteSpace } from "../../utils/helpers";
+
 import Heading from "./heading"
 import HtmlContent from "./htmlContent"
 import StaticIcon from "./staticIcon"
@@ -65,11 +67,13 @@ export default function ParkFacility({ data }) {
       </Row>
       <Row>
         <Col>
-          {facilityData.map((facility, index) => (
+          {facilityData.map((facility, index) => {
+          const isDescription = !isNullOrWhiteSpace(facility.description)
+          return (
             <Accordion
               key={"parkFacility" + index}
               activeKey={expanded[index] ? "parkFacility" + index : null}
-              className="park-details mb-2"
+              className={`park-details mb-2 ${!isDescription && "park-details--disabled"}`}
             >
               <Accordion.Toggle
                 as={Container}
@@ -88,6 +92,7 @@ export default function ParkFacility({ data }) {
                       {facility.facilityType.facilityName}
                     </HtmlContent>
                   </div>
+                  {isDescription && (
                   <div className="d-flex align-items-center expand-icon">
                     <i
                       className={
@@ -96,15 +101,18 @@ export default function ParkFacility({ data }) {
                       }
                     ></i>
                   </div>
+                  )}
                 </div>
               </Accordion.Toggle>
+              {isDescription && (
               <Accordion.Collapse eventKey={"parkFacility" + index}>
                 <div className="p-4">
                   <HtmlContent>{facility.description}</HtmlContent>
                 </div>
               </Accordion.Collapse>
+              )}
             </Accordion>
-          ))}
+          )})}
         </Col>
       </Row>
     </div>

--- a/src/staging/src/styles/cmsSnippets/parkInfoPage.scss
+++ b/src/staging/src/styles/cmsSnippets/parkInfoPage.scss
@@ -44,6 +44,16 @@
   &:hover{
     border: 1px solid $colorGold;
   }
+
+  &--disabled {
+    &:hover {
+      border: 1px solid $colorBlue;
+    }
+    
+    .accordion-toggle {
+      cursor: default;
+    }
+  }
 }
 
 .accordion-toggle {

--- a/src/staging/src/templates/park.js
+++ b/src/staging/src/templates/park.js
@@ -12,7 +12,7 @@ import {
 } from "@material-ui/core"
 import useScrollSpy from "react-use-scrollspy"
 
-import { capitalizeFirstLetter, renderHTML } from "../utils/helpers";
+import { capitalizeFirstLetter, renderHTML, isNullOrWhiteSpace } from "../utils/helpers";
 
 import Footer from "../components/footer"
 import Header from "../components/header"
@@ -57,9 +57,6 @@ export default function ParkTemplate({ data }) {
 
   const park = data.strapiProtectedArea
   const parkType = park.type ?? "park"
-
-  // function to check if a string contains anything besides html tags and whitespace characters
-  const isNullOrWhiteSpace = (str) => !str || !str.toString().replace(/(<([^>]+)>)|^\s+|\s+$|\s+/g, "");
 
   const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]
   const operations = park.parkOperation || {}

--- a/src/staging/src/templates/site.js
+++ b/src/staging/src/templates/site.js
@@ -12,6 +12,8 @@ import {
 } from "@material-ui/core"
 import useScrollSpy from "react-use-scrollspy"
 
+import { isNullOrWhiteSpace } from "../utils/helpers";
+
 import Footer from "../components/footer"
 import Header from "../components/header"
 import PageMenu from "../components/pageContent/pageMenu"
@@ -51,9 +53,6 @@ export default function ParkTemplate({ data }) {
   const activities = site.parkActivities
   const facilities = site.parkFacilities
   const operations = site.parkOperation || {}
-
-  // function to check if a string contains anything besides html tags and whitespace characters
-  const isNullOrWhiteSpace = (str) => !str || !str.toString().replace(/(<([^>]+)>)|^\s+|\s+$|\s+/g, "");
 
   const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]
 

--- a/src/staging/src/utils/helpers.js
+++ b/src/staging/src/utils/helpers.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { Link } from "gatsby"
 
+// function to check if a string contains anything besides html tags and whitespace characters
+export const isNullOrWhiteSpace = (str) => !str || !str.toString().replace(/(<([^>]+)>)|^\s+|\s+$|\s+/g, "");
 export const capitalizeFirstLetter = (str) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 export const renderHTML = (rawHTML) => React.createElement("div", { dangerouslySetInnerHTML: { __html: rawHTML } });
 export const renderBreadcrumbs = (menuContent, pageContext) => {


### PR DESCRIPTION
### Jira Ticket:
CM-372

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-372

### Description:
- Moved `isNullOrWhiteSpace` to `helpers.js`
- Hid arrow icon if `description` is null, empty, or having only whitespace
- Hid accordion if `description` is null, empty, or having only whitespace
- Added conditional class/styling to indicate the accordion is not clickable
- Applied these changes to the activities, facilities, and camping section