### PR TITLE
CM-263: Exclude advisories for other sites at the same park

### DIFF
--- a/src/staging/src/templates/site.js
+++ b/src/staging/src/templates/site.js
@@ -107,7 +107,17 @@ export default function ParkTemplate({ data }) {
     loadAdvisories(apiBaseUrl, park?.orcs)
       .then(response => {
         if (response.status === 200) {
-          setAdvisories([...response.data])
+          // for sites, we want to include all advisories at the park level  
+          // and advisories for this specific site, but we exclude advisories 
+          // for other sites at the same park
+          const advisories = [...response.data].filter(
+            (advisory) => {
+              return advisory.sites.length === 0 ||
+                advisory.sites.some(
+                  (s) => s.orcsSiteNumber === site.orcsSiteNumber
+                )
+            })
+          setAdvisories(advisories)
           setAdvisoryLoadError(false)
         } else {
           setAdvisories([])

--- a/src/staging/src/templates/site.js
+++ b/src/staging/src/templates/site.js
@@ -127,7 +127,7 @@ export default function ParkTemplate({ data }) {
       .finally(() => {
         setIsLoadingAdvisories(false)
       })
-  }, [apiBaseUrl, park?.orcs])
+  }, [apiBaseUrl, park?.orcs, site.orcsSiteNumber])
 
   const parkOverviewRef = useRef("")
   const accessibilityRef = useRef("")


### PR DESCRIPTION
### Jira Ticket:
CM-263

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-263

### Description:
On site pages, we only want to show advisories that are either 
a. At the park level or higher (they don't specify any specific sites)
b. That specify this specific site.
If an advisory specifies a specific site, but it is not the site for the current page, then it should be excluded.
