### PR TITLE
CM-360: caddy redirect for www.bcparks.ca

### DIFF
--- a/src/staging/Caddyfile
+++ b/src/staging/Caddyfile
@@ -1,3 +1,12 @@
+www.bcparks.ca:3000 {
+  redir https://bcparks.ca{uri}
+}
+
+#### we need to uncomment this after we do the DNS cutover
+# beta.bcparks.ca:3000 {
+#   redir https://bcparks.ca{uri}
+# }
+
 :3000 {
     header /page-data/* Cache-Control "public, max-age=0, must-revalidate"
     header /static/* Cache-Control "public, max-age=31536000, immutable"


### PR DESCRIPTION
### Jira Ticket:
CM-360

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-360

### Description:

NOTE: These changes won't actually do anything until the DNS is cutover. But we can use www.bcparks.ca now with a hosts file to do testing to ensure that the same pattern will work for beta.bcparks.ca later.  

code changes:
1. Added caddy directive to redirect all requests to www.bcparks.ca to bcparks.ca.  
2. Also added a commented-out version for beta.bcparks.ca, but the comment can't be removed until DNS cutover.


Two new routes were also added to OpenShift PROD. To test them you need to add these entries to your /etc/host file...
- 142.34.194.118  bcparks.ca
- 142.34.194.118  www.bcparks.ca

The new routes are called vanity-bcparks.ca and vanity-www.  Wildcard SSL certificates have been added for both routes.  
- https://console.apps.silver.devops.gov.bc.ca/k8s/ns/61d198-prod/routes/vanity-bcparks.ca
- https://console.apps.silver.devops.gov.bc.ca/k8s/ns/61d198-prod/routes/vanity-www
