### PR TITLE
CM-387: Updates to token authentication

### DIFF
--- a/src/cms/api/token/models/token.settings.json
+++ b/src/cms/api/token/models/token.settings.json
@@ -14,7 +14,10 @@
     "token": {
       "type": "string",
       "required": true,
-      "unique": true
+      "unique": true,
+      "minLength": 40,
+      "regex": "^[^\\s]+(\\s+[^\\s]+)*$",
+      "private": true
     },
     "user": {
       "unique": true,

--- a/src/cms/extensions/users-permissions/config/policies/permissions.js
+++ b/src/cms/extensions/users-permissions/config/policies/permissions.js
@@ -46,7 +46,7 @@ module.exports = async (ctx, next) => {
             ctx.state.user = await strapi.plugins[
               "users-permissions"
             ].services.user.fetch({ email: API_USER_EMAIL });
-            strapi.log.warn(`Staff Portal user ${ctx.state.user.email} authenticated with Keycloak`)
+            strapi.log.warn(`Staff Portal user "${keycloakJwtToken.email}" authenticated with Keycloak`)
           } else {
             throw new Error(
               "Invalid token: User role does not have access permissions"
@@ -73,7 +73,10 @@ module.exports = async (ctx, next) => {
             ctx.state.user = await strapi.plugins[
               "users-permissions"
             ].services.user.fetchAuthenticatedUser(id);
-            strapi.log.warn(`${strapiToken.user.email}(user.id=${id}) authenticated with a Strapi token`)
+            strapi.log.warn(
+              `External application user "${strapiToken.user.email
+              }" authenticated with a Strapi token (token_id=${strapiToken.id})`
+            )
           }
         }
       }

--- a/src/cms/extensions/users-permissions/config/policies/permissions.js
+++ b/src/cms/extensions/users-permissions/config/policies/permissions.js
@@ -46,6 +46,7 @@ module.exports = async (ctx, next) => {
             ctx.state.user = await strapi.plugins[
               "users-permissions"
             ].services.user.fetch({ email: API_USER_EMAIL });
+            strapi.log.warn(`Staff Portal user ${ctx.state.user.email} authenticated with Keycloak`)
           } else {
             throw new Error(
               "Invalid token: User role does not have access permissions"

--- a/src/cms/extensions/users-permissions/services/jwt.js
+++ b/src/cms/extensions/users-permissions/services/jwt.js
@@ -38,6 +38,7 @@ module.exports = {
       return new Promise((resolve, reject) => {
         client.getSigningKey(kid, (err, key) => {
           if (err) {
+            strapi.log.warn(`Keycloak signing key error: ${err}`)
             reject("Signing Key Error:", err);
           } else {
             const signingKey = key.publicKey || key.rsaPublicKey;


### PR DESCRIPTION
### Jira Ticket:
CM-387

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-387

### Description:
This change is a prerequisite for CM-14 (loading park operating dates in Strapi)

Token authentication was broken and not working at all. 

I changed the implementation of API authentication using the "Tokens" collection type:
- It's no longer possible to pass a token via request.body or request.query, it must be passed as an authorization header (passing this as a querystring is a security risk because the token is very likely to end up in logs. And passing it as a request.body parameter seems like an unnecessary complication that would never be used anyway)
  - Note that passing tokens as via request.body or request.query was broken, so I am confident that nobody was currently using it.
- When passing a token via the authorization header it doesn't need to be a jwt token. It's just a plain string, but the authorization header value must start with "Bearer "

Note: when testing the staff portal with Keycloak auth, make sure your keycloak settings in both .env files are correct....

**admin**
```
REACT_APP_KEYCLOAK_AUTH_URL=https://dev.loginproxy.gov.bc.ca/auth
REACT_APP_KEYCLOAK_REALM=bcparks-service-transformation
REACT_APP_KEYCLOAK_CLIENT_ID=staff-portal
```

**cms**
```
STRAPI_SSO_AUTH_URL=https://dev.loginproxy.gov.bc.ca/auth
STRAPI_SSO_REALM=bcparks-service-transformation
```