### PR TITLE
CM-360: Fix Caddyfile

### DIFF
--- a/src/staging/Caddyfile
+++ b/src/staging/Caddyfile
@@ -1,9 +1,9 @@
-www.bcparks.ca:3000 {
+http://www.bcparks.ca:3000 {
     redir https://bcparks.ca{uri}
 }
 
 #### we need to uncomment this after we do the DNS cutover
-# beta.bcparks.ca:3000 {
+# http://beta.bcparks.ca:3000 {
 #   redir https://bcparks.ca{uri}
 # }
 


### PR DESCRIPTION
### Jira Ticket:
CM-360

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-360

### Description:
Fixed caddy redirect.  I believe the previous format was trying to bind something to port 80 and getting an error:
```
run: loading initial config: loading new config: http app module: start: tcp: listening on :80: listen tcp :80: bind: permission denied
```
This format has been tested using Docker Desktop and it does do the redirect properly, however I'm still not sure why Port 80 was being used.
