### PR TITLE
CM-398: Reduce the cron frequency to once per hour

### DIFF
--- a/src/cms/config/functions/cron.js
+++ b/src/cms/config/functions/cron.js
@@ -15,7 +15,9 @@ const boolToYN = (boolVar) => {
 };
 
 module.exports = {
-  "*/5 * * * *": {
+  // Execute the cron at 2 minutes past every hour.
+  // BCGW replication is hourly at 10 minutes past the hour
+  "2 * * * *": {
     task: async () => {
       console.log("CRON STARTING");
 


### PR DESCRIPTION
### Jira Ticket:
CM-398

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-398

### Description:
Reduced the cron frequency to once per hour, at 2 minutes past the hour.  
BCGW replication is hourly at 10 minutes past the hour.

Strapi cron jobs use "node-schedule". Full documentation for node-schedule is here:
https://www.npmjs.com/package/node-schedule

The change is based on the example _"Execute a cron job when the minute is 42 (e.g. 19:42, 20:42, etc.)."_