### PR TITLE
Cm 272 update kong docs

### DIFF
--- a/.github/workflows/build-public.yaml
+++ b/.github/workflows/build-public.yaml
@@ -33,7 +33,7 @@ jobs:
           elif [[ "${{ github.event.client_payload.env }}" == "prod" || "${{ github.event.inputs.buildEnv }}" == "prod" ]]; then
               echo "ENV_SUFFIX=prod" >> $GITHUB_ENV
               echo "IMAGE_TAG=prod" >> $GITHUB_ENV
-              echo "REACT_APP_CMS_BASE_URL=https://cms.bcparks.ca" >> $GITHUB_ENV
+              echo "REACT_APP_CMS_BASE_URL=https://bcparks.api.gov.bc.ca" >> $GITHUB_ENV
           else
               echo "ENV_SUFFIX=dev" >> $GITHUB_ENV
               echo "IMAGE_TAG=latest" >> $GITHUB_ENV

--- a/src/kong/README.md
+++ b/src/kong/README.md
@@ -13,7 +13,9 @@ Access to the web UI for creating service accounts can be requested in the `#aps
 
 ## Kong Config Update
 
-If there have been changes to the API endpoints available on Strapi, the following steps need to be taken:
+If there have been changes to the API endpoints available on Strapi, the following steps need to be taken.
+
+The importhing thing to note is in step #6 - once you run through the tools, you **will need to revert changes** or publishing the gateway will fail.
 
 1. Visit [Strapi admin](http://localhost:1337/admin/plugins/documentation) and under Plugins -> Documentation,
    click "Regenerate".
@@ -24,14 +26,12 @@ If there have been changes to the API endpoints available on Strapi, the followi
 5. In the src/kong directory, run (for TEST):
 
    ```sh
-   gwa init -T --api-version=2 --namespace=bcparks --client-id=<ClientID> --client-secret=<ClientSecret>
    gwa new public-documentation.json --route-host=bcparks.api.gov.bc.ca --service-url=bcparks-cms.61d198-test.svc --plugins rate-limiting cors  --outfile=public-test.yaml
    ```
 
    (for PROD):
 
    ```sh
-   gwa init -P --api-version=2 --namespace=bcparks --client-id=<ClientID> --client-secret=<ClientSecret>
    gwa new public-documentation.json --route-host=bcparks.api.gov.bc.ca --service-url=bcparks-cms.61d198-prod.svc --plugins rate-limiting cors  --outfile=public-prod.yaml
    ```
 
@@ -46,7 +46,7 @@ If there have been changes to the API endpoints available on Strapi, the followi
 2. Select the BC Parks namespace
 3. Create a service account with `GatewayConfig.Publish` scope and note down the client id and client secret
 4. Download the GWA CLI from https://github.com/bcgov/gwa-cli/releases
-5. In command prompt run the following commands:
+5. In command prompt run the following commands (the first command create a .env file locally, which will need to be deleted if you need to create one for the other environment):
 
    ```sh
    gwa init -T --api-version=2 --namespace=bcparks --client-id=<ClientID> --client-secret=<ClientSecret>
@@ -61,7 +61,7 @@ If there have been changes to the API endpoints available on Strapi, the followi
 2. Select the BC Parks namespace
 3. Create a service account with `GatewayConfig.Publish` scope and note down the client id and client secret
 4. Download the GWA CLI from https://github.com/bcgov/gwa-cli/releases
-5. In command prompt run the following commands:
+5. In command prompt run the following commands (the first command create a .env file locally, which will need to be deleted if you need to create one for the other environment):
 
    ```sh
    gwa init -P --api-version=2 --namespace=bcparks --client-id=<ClientID> --client-secret=<ClientSecret>


### PR DESCRIPTION
### Jira Ticket:
CM-272

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-272

### Description:
This includes updates to the KONG docs as well as an update to the GitHub action to change the build API from Strapi to the BC Gov endpoint.
