### PR TITLE
CM-115: Add aria-label to input field

### DIFF
--- a/src/staging/src/pages/find-a-park.js
+++ b/src/staging/src/pages/find-a-park.js
@@ -564,6 +564,9 @@ export default function FindAPark({ location, data }) {
                               <SearchIcon className="search-icon" />
                             </InputAdornment>
                           ),
+                          inputProps: {
+                            "aria-label": "Park search",
+                          }
                         }}
                       />
                     </div>
@@ -629,6 +632,9 @@ export default function FindAPark({ location, data }) {
                                     <SearchIcon className="search-icon" />
                                   </InputAdornment>
                                 ),
+                                inputProps: {
+                                  "aria-label": "Park search",
+                                }
                               }}
                             />
                           </div>


### PR DESCRIPTION
### Jira Ticket:
CM-115

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-115

### Description:
- The error was because there's no `label` for the `input` field
- Added `aria-label` to `TextField` prop
