### PR TITLE
NOBUG: Downgrade gatsby-plugin-robots-txt

### DIFF
--- a/src/staging/package.json
+++ b/src/staging/package.json
@@ -33,7 +33,7 @@
     "gatsby-plugin-offline": "^4.2.0",
     "gatsby-plugin-react-helmet": "^4.2.0",
     "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
-    "gatsby-plugin-robots-txt": "^1.8.0",
+    "gatsby-plugin-robots-txt": "1.7.1",
     "gatsby-plugin-sass": "^4.13.0",
     "gatsby-plugin-sharp": "^3.11.0",
     "gatsby-plugin-sitemap": "4.11.0",


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:
- @molund found a warning `warn Plugin gatsby-plugin-robots-txt is not compatible with your gatsby version 3.15.0 - It requires gatsby@^5.0.0`
- To fix this, downgraded it to version `1.7.1`
- Tested it by deleting `node_modules` and running `yarn build`
