### PR TITLE
CM-493: Fix an issue with repeated parkname tags on advisories

### DIFF
--- a/src/staging/src/components/advisories/advisoryCard.js
+++ b/src/staging/src/components/advisories/advisoryCard.js
@@ -8,13 +8,10 @@ import Row from "react-bootstrap/Row"
 import HTMLArea from "../HTMLArea"
 
 import "../../styles/advisories/advisoryCard.scss"
-import { renderHTML } from "../../utils/helpers"
-import { PARK_NAME_TYPE } from "../../utils/constants"
 
 const AdvisoryCard = ({ advisory, index }) => {
   const [open, setOpen] = useState(false)
 
-  const getParkName = item => item.parkNameType === PARK_NAME_TYPE.Escaped
   return (
     <>
       <Row
@@ -127,10 +124,7 @@ const AdvisoryCard = ({ advisory, index }) => {
                                           .replace(/ /g, "-")
                                   }`}
                                 >
-                                  {renderHTML(
-                                    advisory.parkNames.find(getParkName)
-                                      ?.parkName
-                                  ) || par.protectedAreaName}
+                                  {par.protectedAreaName}
                                 </a>
                               </Badge>
                             ))}

--- a/src/staging/src/pages/active-advisories.js
+++ b/src/staging/src/pages/active-advisories.js
@@ -300,19 +300,6 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
   const protectedArea = data.allStrapiProtectedArea?.nodes
 
-  const advisoriesWithParkNames = advisories.map(item => {
-    const parkNamesList = item.protectedAreas.map(park => {
-      const findParkNames = protectedArea.find(
-        i => i.orcs === park.orcs
-      )
-      return findParkNames.parkNames
-    })
-    return {
-      ...item,
-      parkNames: parkNamesList[0],
-    }
-  })
-
   // Page setter exposed to AdvisortyPageNav
   const setPage = p => {
     setPageIndex(p)
@@ -393,7 +380,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
           <AdvisoryLegend />
           <AdvisoryList
-            advisories={advisoriesWithParkNames}
+            advisories={advisories}
             pageIndex={pageIndex}
             pageLen={pageLen}
           ></AdvisoryList>

--- a/src/staging/src/pages/active-advisories.js
+++ b/src/staging/src/pages/active-advisories.js
@@ -298,8 +298,6 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     [pageIndex, apiCall, apiUrl]
   )
 
-  const protectedArea = data.allStrapiProtectedArea?.nodes
-
   // Page setter exposed to AdvisortyPageNav
   const setPage = p => {
     setPageIndex(p)
@@ -429,17 +427,6 @@ export const query = graphql`
         strapiParent {
           id
           title
-        }
-      }
-    }
-    allStrapiProtectedArea(sort: { fields: parent___internal___type }) {
-      nodes {
-        protectedAreaName
-        orcs
-        parkNames {
-          id
-          parkName
-          parkNameType
         }
       }
     }


### PR DESCRIPTION
### Jira Ticket:
CM-493

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-493

### Description:
Fixed an issue where the first parkname was being repeated multiple times on advisories associated with multiple parks.
This issue stems from changes made in BWT-426.  The broken code can now be reverted because protectedAreaName was imported as UTF-8 during the data migration.  

![image](https://user-images.githubusercontent.com/547803/219515399-ef022218-ce00-42ed-8303-20e7b1ef421a.png)

Note: a tech-debt ticket has been created to revert the BWT-426 changes in other places.
https://bcparksdigital.atlassian.net/browse/CM-495

