### PR TITLE
CM-529: Skip park overview by tabbing

### DIFF
--- a/src/staging/package.json
+++ b/src/staging/package.json
@@ -18,6 +18,7 @@
     "@material-ui/styles": "^4.11.4",
     "axios": "^0.22.0",
     "bootstrap": "~4.3.1",
+    "cheerio": "^1.0.0-rc.12",
     "date-fns": "^2.28.0",
     "gatsby": "^4.25.5",
     "gatsby-plugin-canonical-urls": "^4.25.0",
@@ -86,8 +87,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "overrides": {
-    "gatsby-plugin-material-ui":
-    {
+    "gatsby-plugin-material-ui": {
       "gatsby": "$gatsby"
     }
   }

--- a/src/staging/src/components/park/parkOverview.js
+++ b/src/staging/src/components/park/parkOverview.js
@@ -8,6 +8,8 @@ import Heading from "./heading"
 import HtmlContent from "./htmlContent"
 import Spacer from "./spacer"
 
+import * as cheerio from 'cheerio';
+
 // when rewriting this to bootstrap, let's measure the height of the
 // container and animate the window changing size
 const useStyles = makeStyles(theme => ({
@@ -38,6 +40,10 @@ export default function ParkOverview({ data: parkOverview, type }) {
 
   const isLong = height >= 260
 
+  const $ = cheerio.load(parkOverview);
+  $('a').attr('tabindex', '-1')
+  const collapsedParkOverview = $.html()
+
   return (
     <div id="park-overview-container" className="anchor-link">
       <Grid item xs={12} className="anchor-link">
@@ -45,7 +51,7 @@ export default function ParkOverview({ data: parkOverview, type }) {
           <Box className={expanded ? classes.expanded : classes.collapsed} ref={ref}>
             <Heading>{capitalizeFirstLetter(`${type} overview`)}</Heading>
             <HtmlContent className="park-overview-html">
-              {parkOverview}
+              {expanded ? parkOverview : collapsedParkOverview}
             </HtmlContent>
           </Box>
           {isLong && 


### PR DESCRIPTION
### Jira Ticket:
CM-529

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-529

### Description:
- Added tabindex to skip <a> element by tabbing when the section is not expanded
