### PR TITLE
CM-596: Fix for advisory relations not saving

### DIFF
--- a/src/cms/src/api/park-activity/controllers/park-activity.js
+++ b/src/cms/src/api/park-activity/controllers/park-activity.js
@@ -7,14 +7,16 @@
 const { createCoreController } = require("@strapi/strapi").factories;
 
 module.exports = createCoreController(
-    "api::park-activity.park-activity",
-    ({ strapi }) => ({
-        async update(ctx) {
-            strapi.plugins[
-                "rest-cache"
-            ].services.cacheStore.clearByUid('api::protected-area.protected-area')
-            const response = await super.update(ctx);
-            return response;
-        }
-    })
+  "api::park-activity.park-activity",
+  ({ strapi }) => ({
+    async update(ctx) {
+      const cachePlugin = strapi.plugins["rest-cache"];
+      if (cachePlugin) {
+        // clear the redis rest-cache when updates are made from the staff portal
+        cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area')
+      }
+      const response = await super.update(ctx);
+      return response;
+    }
+  })
 );

--- a/src/cms/src/api/park-facility/controllers/park-facility.js
+++ b/src/cms/src/api/park-facility/controllers/park-facility.js
@@ -7,14 +7,16 @@
 const { createCoreController } = require("@strapi/strapi").factories;
 
 module.exports = createCoreController(
-    "api::park-facility.park-facility",
-    ({ strapi }) => ({
-        async update(ctx) {
-            strapi.plugins[
-                "rest-cache"
-            ].services.cacheStore.clearByUid('api::protected-area.protected-area')
-            const response = await super.update(ctx);
-            return response;
-        }
-    })
+  "api::park-facility.park-facility",
+  ({ strapi }) => ({
+    async update(ctx) {
+      const cachePlugin = strapi.plugins["rest-cache"];
+      if (cachePlugin) {
+        // clear the redis rest-cache when updates are made from the staff portal
+        cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area')
+      }
+      const response = await super.update(ctx);
+      return response;
+    }
+  })
 );

--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
@@ -56,6 +56,7 @@ const savePublicAdvisory = async (publicAdvisory) => {
 
     if(isExist) {
       try {
+        delete publicAdvisory.id;
         await strapi.db.query('api::public-advisory.public-advisory').updateMany({
           where: {
             advisoryNumber: publicAdvisory.advisoryNumber,
@@ -185,15 +186,7 @@ module.exports = {
     newPublicAdvisory.published_at = new Date();
     newPublicAdvisory.isLatestRevision = true;
     const oldPublicAdvisory = await strapi.entityService.findOne('api::public-advisory-audit.public-advisory-audit', where.id, {
-      populate: { 
-        'advisoryStatus': { "fields": ["code"] },
-        'links': { populate: {
-          'type': { "fields": ["type"] } 
-        }},
-        'protectedAreas': { "fields": ["id"] },
-        'sites': { "fields": ["id"] },
-        'urgency': { "fields": ["code"] },
-      }
+      populate: "*"
     });
 
     if (!oldPublicAdvisory) return;
@@ -234,15 +227,7 @@ module.exports = {
   },
   afterUpdate: async (ctx) => {
     const publicAdvisoryAudit = await strapi.entityService.findOne('api::public-advisory-audit.public-advisory-audit', ctx.result.id, {
-      populate: { 
-        'advisoryStatus': { "fields": ["code"] },
-        'links': { populate: {
-          'type': { "fields": ["type"] } 
-        }},
-        'protectedAreas': { "fields": ["id"] },
-        'sites': { "fields": ["id"] },
-        'urgency': { "fields": ["code"] },
-      }
+      populate: "*"
     });
     copyToPublicAdvisory(publicAdvisoryAudit);
   },

--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
@@ -56,13 +56,8 @@ const savePublicAdvisory = async (publicAdvisory) => {
 
     if(isExist) {
       try {
-        delete publicAdvisory.id;
-        await strapi.db.query('api::public-advisory.public-advisory').updateMany({
-          where: {
-            advisoryNumber: publicAdvisory.advisoryNumber,
-          },
-          data: publicAdvisory,
-        });
+        publicAdvisory.id = isExist.id;
+        await strapi.entityService.update('api::public-advisory.public-advisory', isExist.id, { data: publicAdvisory })
       } catch (error) {
         strapi.log.error(
           `error updating public-advisory advisoryNumber ${publicAdvisory.advisoryNumber}...`,
@@ -166,15 +161,7 @@ module.exports = {
   },
   afterCreate: async (ctx) => {
     const newPublicAdvisoryAudit = await strapi.entityService.findOne('api::public-advisory-audit.public-advisory-audit', ctx.result.id, {
-      populate: { 
-        'advisoryStatus': { "fields": ["code"] },
-        'links': { populate: {
-          'type': { "fields": ["type"] } 
-        }},
-        'protectedAreas': { "fields": ["id"] },
-        'sites': { "fields": ["id"] },
-        'urgency': { "fields": ["code"] },
-      }
+      populate: "*"
     });
     copyToPublicAdvisory(newPublicAdvisoryAudit);
   },

--- a/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
+++ b/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
@@ -11,6 +11,25 @@ const { createCoreController } = require("@strapi/strapi").factories;
 module.exports = createCoreController(
   "api::public-advisory-audit.public-advisory-audit",
   ({ strapi }) => ({
+    async create(ctx) {
+      const cachePlugin = strapi.plugins["rest-cache"];
+      if (cachePlugin) {
+        // clear the redis rest-cache when updates are made from the staff portal
+        cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area');
+      }
+      const response = await super.create(ctx);
+      return response;
+    },
+    async update(ctx) {
+      const cachePlugin = strapi.plugins["rest-cache"];
+      if (cachePlugin) {
+        // clear the redis rest-cache when updates are made from the staff portal
+        cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area');
+        cachePlugin.services.cacheStore.clearByUid('api::public-advisory.public-advisory');
+      }
+      const response = await super.update(ctx);
+      return response;
+    },
     async history(ctx) {
       const { advisoryNumber } = ctx.params;
       const entities = await strapi.service("api::public-advisory-audit.public-advisory-audit").find({

--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -8,7 +8,7 @@ const { sanitize } = require('@strapi/utils')
 const { createCoreController } = require("@strapi/strapi").factories;
 
 const addStandardMessages = function (query) {
-    if (query.populate !== "*" && query.populate !== "deep") {
+    if (query.populate !== "*") {
         query = {
             ...query,
             ...{


### PR DESCRIPTION
### Jira Ticket:
CM-596

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-596

### Description:
Fixed an issue where relations weren't being saved to public advisories in the lifecycle hook on public advisory audits. 
