### PR TITLE
CM-621: Fix for missing advisories

### DIFF
--- a/src/cms/src/api/protected-area/controllers/protected-area.js
+++ b/src/cms/src/api/protected-area/controllers/protected-area.js
@@ -12,10 +12,10 @@ module.exports = createCoreController(
   ({ strapi }) => ({
     async find(ctx) {
       let entities;
-      // if _q is present in the query params, trigger search mode
+      // if queryText is present in the query params, trigger search mode
       // which has some custom filters and ordering, and returns
       // extra data in the response
-      if (typeof ctx.query._q !== "undefined") {
+      if (typeof ctx.query.queryText !== "undefined") {
         const filters = parseSearchFilters(ctx.query);
         const ordering = parseSearchOrdering(ctx.query);
         const offset = parseSearchOffset(ctx.query);
@@ -35,10 +35,10 @@ module.exports = createCoreController(
       return res;
     },
     async count(ctx) {
-      // if _q is present in the query params, trigger search mode
+      // if queryText is present in the query params, trigger search mode
       // which has some custom filters and ordering, and returns
       // extra data in the response
-      if (typeof ctx.query._q !== "undefined") {
+      if (typeof ctx.query.queryText !== "undefined") {
         const filters = parseSearchFilters(ctx.query);
         return await strapi
           .service("api::protected-area.protected-area")
@@ -74,7 +74,7 @@ module.exports = createCoreController(
 );
 
 function parseSearchFilters(query) {
-  const searchText = query._q;
+  const searchText = query.queryText;
   const typeCode = query.typeCode || query.typeCode_eq;
   const accessStatus = query.accessStatus || query.accessStatus_eq;
   const marineProtectedArea =

--- a/src/cms/src/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-status.js
@@ -117,7 +117,7 @@ const getProtectedAreaStatus = async (ctx) => {
         populate: protectedAreaPopulateSettings,
       }
     );
-  } else if (ctx.query._q) {
+  } else if (ctx.query.queryText) {
     entities = await strapi.entityService.findMany(
       "api::protected-area.protected-area",
       {

--- a/src/cms/src/api/protected-area/services/protected-area-status.js
+++ b/src/cms/src/api/protected-area/services/protected-area-status.js
@@ -76,7 +76,7 @@ const getProtectedAreaStatus = async (ctx) => {
       limit: -1,
       populate: '*',
     });
-  } else if (ctx.query._q) {
+  } else if (ctx.query.queryText) {
     entities = await strapi.entityService.findMany('api::protected-area.protected-area', {
       ...ctx.query, 
       populate: '*',

--- a/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
+++ b/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
@@ -12,9 +12,7 @@
     "increments": true,
     "timestamps": true,
     "draftAndPublish": true,
-    "privateAttributes": [
-      "search_text"
-    ]
+    "privateAttributes": []
   },
   "attributes": {
     "advisoryNumber": {

--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -67,7 +67,7 @@ module.exports = createCoreController(
 
             ctx.query = addStandardMessages(ctx.query);
 
-            if (ctx.query._q !== undefined) {
+            if (ctx.query.queryText !== undefined) {
                 ({ results: entities } = await strapi.service("api::public-advisory.public-advisory").search(ctx.query));
                 pagination = {};
             } else {
@@ -97,7 +97,7 @@ module.exports = createCoreController(
             };
         },
         async count(ctx) {
-            if (ctx.query._q !== undefined) {
+            if (ctx.query.queryText !== undefined) {
                 return await strapi.service("api::public-advisory.public-advisory").countSearch(ctx.query);
             }
             return (await strapi.service("api::public-advisory.public-advisory").find(ctx.query)).pagination.total;

--- a/src/cms/src/api/public-advisory/services/public-advisory.js
+++ b/src/cms/src/api/public-advisory/services/public-advisory.js
@@ -10,22 +10,22 @@ const buildQuery = function (query) {
     let textSearch = {};
     let typeSearch = {};
 
-    if (query._q && query._q.length > 0) {
+    if (query.queryText && query.queryText.length > 0) {
         if (query._searchType === "keyword") {
             textSearch = {
                 $or: [
-                    { title: { $containsi: query._q } },
-                    { description: { $containsi: query._q } }
+                    { title: { $containsi: query.queryText } },
+                    { description: { $containsi: query.queryText } }
                 ]
             };
         } else if (query._searchType === "park") {
-            textSearch = { protectedAreas: { parkNames: { parkName: { $containsi: query._q } } } };
+            textSearch = { protectedAreas: { parkNames: { parkName: { $containsi: query.queryText } } } };
         } else {
             textSearch = {
                 $or: [
-                    { title: { $containsi: query._q } },
-                    { description: { $containsi: query._q } },
-                    { protectedAreas: { parkNames: { parkName: { $containsi: query._q } } } }
+                    { title: { $containsi: query.queryText } },
+                    { description: { $containsi: query.queryText } },
+                    { protectedAreas: { parkNames: { parkName: { $containsi: query.queryText } } } }
                 ]
             };
         }
@@ -39,8 +39,12 @@ const buildQuery = function (query) {
         ...query.filters,
         ...{
             $and: [
-                { protectedAreas: { publishedAt: { $null: false } } },
-                { protectedAreas: { isDisplayed: { $eq: true } } },
+                {
+                    protectedAreas: {
+                        publishedAt: { $null: false },
+                        isDisplayed: { $eq: true }
+                    }
+                },
                 ...[typeSearch],
                 ...[textSearch]
             ]

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -180,7 +180,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       "/public-advisories/count"
 
     if (advisoryType !== "all") {
-      q += `?&_q&_eventType=${advisoryType}`
+      q += `?&queryText&_eventType=${advisoryType}`
     }
 
     const newApiCountCall = apiUrl + q
@@ -197,7 +197,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     advisoryTypeFilter => {
       // Order by date and exclude unpublished parks
       let q =
-        "?populate=*&_q"
+        "?populate=*&queryText"
 
       let useParksFilter = isParksFilter
       let useKeywordFilter = isKeywordFilter
@@ -266,7 +266,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
             // Get count
             let apiCount = apiUrl + "/public-advisories/count" + q
-            if (q === "?populate=*&_q") {
+            if (q === "?populate=*&queryText") {
              apiCount = apiUrl + "/public-advisories/count"
             }
             

--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -368,7 +368,7 @@ export default function FindAPark({ location, data }) {
     const petsActivityId = petsActivity?.strapi_id
 
     const params = {
-      _q: searchText,
+      queryText: searchText,
     }
 
     if (selectedActivities.length > 0) {
@@ -416,7 +416,7 @@ export default function FindAPark({ location, data }) {
   ])
 
   const isActiveSearch =
-    params._q ||
+    params.queryText ||
     (params.activities && params.activities.length) ||
     (params.facilities && params.facilities.length) ||
     params.camping ||


### PR DESCRIPTION
### Jira Ticket:
CM-621

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-621

### Description:
Fixes an issue where some advisories were not appearing on the public advisories search page.  This was happening because the querystring parameter was called `_q` and it was conflicting with an undocumented parameter in the Strapi 4 API (which I believe is actually a remnant from Strapi 3).  `_q` was renamed to `queryText`.  
