### PR TITLE
NOBUG: Fix incorrect sitemap location in robots.txt

### DIFF
--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -146,6 +146,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-robots-txt`,
       options: {
+        sitemap: "https://bcparks.ca/sitemap-index.xml",
         resolveEnv: () => process.env.ENV_SUFFIX || 'dev',
         env: {
           'dev': {


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:

1. Hard-code the sitemap location to the prod sitemap on all environments
2. Remove incorrect subdirectory `/sitemap/` from sitemap path in robots.txt file
