### PR TITLE
NOBUG: Fix gatsby build error

### DIFF
--- a/src/gatsby/package.json
+++ b/src/gatsby/package.json
@@ -4,7 +4,7 @@
   "description": "BC Parks - public site",
   "version": "0.1.0",
   "dependencies": {
-    "@arcgis/core": "~4.26.5",
+    "@arcgis/core": "~4.25.5",
     "@bcgov/bc-sans": "^1.0.1",
     "@bcgov/bootstrap-theme": "https://github.com/bcgov/bootstrap-theme/releases/download/v1.1.1/bcgov-bootstrap-theme-1.1.1.tgz",
     "@emotion/react": "^11.1.5",


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:
- Fix Gatsby build error
```
SplitChunksPlugin
Cache group "shared" conflicts with existing chunk.
Both have the same name "380d42e81165839365c4703ae67985f785a96bdc" and existing chunk is not a parent of the selected modules.
Use a different name for the cache group or make sure that the existing chunk is a parent (e. g. via dependOn).
HINT: You can omit "name" to automatically create a name.
BREAKING CHANGE: webpack < 5 used to allow to use an entrypoint as splitChunk. This is no longer allowed when the entrypoint is not a parent of the selected modules.
Remove this entrypoint and add modules to cache group's 'test' instead. If you need modules to be evaluated on startup, add them to the existing entrypoints (make them arrays). See migration guide of more info.
not finished Running gatsby-plugin-sharp.IMAGE_PROCESSING jobs - 263.422s
Error: Process completed with exit code 1.
```
