### PR TITLE
CM-596: Fix error in public advisory lifecycle hook

### DIFF
--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
@@ -32,7 +32,7 @@ const getNextRevisionNumber = async (advisoryNumber) => {
 
 const createPublicAdvisoryAudit = async (data) => {
   delete data.id;
-  data.published_at = null;
+  data.publishedAt = null;
   data.isLatestRevision = false;
 
   try {
@@ -47,7 +47,7 @@ const createPublicAdvisoryAudit = async (data) => {
 
 const savePublicAdvisory = async (publicAdvisory) => {
   if (publicAdvisory.advisoryStatus.code === "PUB") {
-    publicAdvisory.published_at = new Date();
+    publicAdvisory.publishedAt = new Date();
     const isExist = await strapi.db.query('api::public-advisory.public-advisory').findOne({
       where: {
         advisoryNumber: publicAdvisory.advisoryNumber
@@ -156,7 +156,7 @@ module.exports = {
       data.advisoryNumber = await getNextAdvisoryNumber();
       data.revisionNumber = 1;
       data.isLatestRevision = true;
-      data.published_at = new Date();
+      data.publishedAt = new Date();
     }
   },
   afterCreate: async (ctx) => {
@@ -168,9 +168,9 @@ module.exports = {
   beforeUpdate: async (ctx) => {
     let { data, where } = ctx.params;
     const newPublicAdvisory = data;
-    if (!newPublicAdvisory.published_at) return;
+    if (!newPublicAdvisory.publishedAt) return;
 
-    newPublicAdvisory.published_at = new Date();
+    newPublicAdvisory.publishedAt = new Date();
     newPublicAdvisory.isLatestRevision = true;
     const oldPublicAdvisory = await strapi.entityService.findOne('api::public-advisory-audit.public-advisory-audit', where.id, {
       populate: "*"


### PR DESCRIPTION
### Jira Ticket:
CM-596

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-596

### Description:
Renamed published_at to publishedAt in the public-advisory-audit lifecycle hook.  This fixes an error that was causing the `beforeUpdate` hook to short-circuit because it was checking the truthiness of `published_at` which no longer existed.  I believe it was only working previously because of a bug in the staff portal that was fixed in [CM-609](https://github.com/bcgov/bcparks.ca/pull/646/commits/5385d72a7c3bcdbda0de9b5c51e21d4b04ef82db).
