### PR TITLE
CM-626: Fix advisory region display bug

### DIFF
--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
@@ -508,7 +508,7 @@ const getCurrentPublishedAdvisories = async (cmsData, setCmsData) => {
       cellStyle: { width: 400 },
       render: (rowData) => {
         const displayCount = 3;
-        const regionsCount = regions?.length; // todo:
+        const regionsCount = rowData.regions?.length;
         if (regionsCount > 0) {
           let regions = rowData?.regions?.slice(0, displayCount);
           return (


### PR DESCRIPTION
### Jira Ticket:
CM-626

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-626

### Description:
Fixed a bug where all advisories were displaying _"plus 4 more regions(s)"_ in the Associated Parks(s) column.
