### PR TITLE
CM-437: Add approved management plans page

### DIFF
--- a/src/cms/src/api/management-document-type/content-types/management-document-type/schema.json
+++ b/src/cms/src/api/management-document-type/content-types/management-document-type/schema.json
@@ -1,0 +1,20 @@
+{
+  "kind": "collectionType",
+  "collectionName": "management_document_types",
+  "info": {
+    "singularName": "management-document-type",
+    "pluralName": "management-document-types",
+    "displayName": "Management-document-type"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "documentCode": {
+      "type": "string"
+    },
+    "documentType": {
+      "type": "string"
+    }
+  }
+}

--- a/src/cms/src/api/management-document-type/content-types/management-document-type/schema.json
+++ b/src/cms/src/api/management-document-type/content-types/management-document-type/schema.json
@@ -19,6 +19,12 @@
     },
     "description": {
       "type": "text"
+    },
+    "managementDocuments": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::management-document.management-document",
+      "mappedBy": "documentType"
     }
   }
 }

--- a/src/cms/src/api/management-document-type/content-types/management-document-type/schema.json
+++ b/src/cms/src/api/management-document-type/content-types/management-document-type/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "management-document-type",
     "pluralName": "management-document-types",
-    "displayName": "Management-document-type"
+    "displayName": "Management-document-type",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -15,6 +16,9 @@
     },
     "documentType": {
       "type": "string"
+    },
+    "description": {
+      "type": "text"
     }
   }
 }

--- a/src/cms/src/api/management-document-type/controllers/management-document-type.js
+++ b/src/cms/src/api/management-document-type/controllers/management-document-type.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * management-document-type controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::management-document-type.management-document-type');

--- a/src/cms/src/api/management-document-type/routes/management-document-type.js
+++ b/src/cms/src/api/management-document-type/routes/management-document-type.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * management-document-type router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::management-document-type.management-document-type');

--- a/src/cms/src/api/management-document-type/services/management-document-type.js
+++ b/src/cms/src/api/management-document-type/services/management-document-type.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * management-document-type service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::management-document-type.management-document-type');

--- a/src/cms/src/api/management-document/content-types/management-document/schema.json
+++ b/src/cms/src/api/management-document/content-types/management-document/schema.json
@@ -1,0 +1,41 @@
+{
+  "kind": "collectionType",
+  "collectionName": "management_documents",
+  "info": {
+    "singularName": "management-document",
+    "pluralName": "management-documents",
+    "displayName": "Management-document",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "text"
+    },
+    "documentDate": {
+      "type": "date"
+    },
+    "documentType": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::management-document-type.management-document-type"
+    },
+    "protectedAreas": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::protected-area.protected-area",
+      "inversedBy": "managementDocuments"
+    },
+    "sites": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::site.site",
+      "inversedBy": "managementDocuments"
+    }
+  }
+}

--- a/src/cms/src/api/management-document/content-types/management-document/schema.json
+++ b/src/cms/src/api/management-document/content-types/management-document/schema.json
@@ -14,6 +14,9 @@
     "title": {
       "type": "string"
     },
+    "url": {
+      "type": "string"
+    },
     "description": {
       "type": "text"
     },

--- a/src/cms/src/api/management-document/content-types/management-document/schema.json
+++ b/src/cms/src/api/management-document/content-types/management-document/schema.json
@@ -25,8 +25,9 @@
     },
     "documentType": {
       "type": "relation",
-      "relation": "oneToOne",
-      "target": "api::management-document-type.management-document-type"
+      "relation": "manyToOne",
+      "target": "api::management-document-type.management-document-type",
+      "inversedBy": "managementDocuments"
     },
     "protectedAreas": {
       "type": "relation",

--- a/src/cms/src/api/management-document/controllers/management-document.js
+++ b/src/cms/src/api/management-document/controllers/management-document.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * management-document controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::management-document.management-document');

--- a/src/cms/src/api/management-document/routes/management-document.js
+++ b/src/cms/src/api/management-document/routes/management-document.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * management-document router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::management-document.management-document');

--- a/src/cms/src/api/management-document/services/management-document.js
+++ b/src/cms/src/api/management-document/services/management-document.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * management-document service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::management-document.management-document');

--- a/src/cms/src/api/protected-area/content-types/protected-area/schema.json
+++ b/src/cms/src/api/protected-area/content-types/protected-area/schema.json
@@ -267,6 +267,12 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::park-photo.park-photo"
+    },
+    "managementDocuments": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::management-document.management-document",
+      "mappedBy": "protectedAreas"
     }
   }
 }

--- a/src/cms/src/api/site/content-types/site/schema.json
+++ b/src/cms/src/api/site/content-types/site/schema.json
@@ -104,6 +104,12 @@
       "relation": "oneToOne",
       "target": "api::park-operation.park-operation",
       "mappedBy": "site"
+    },
+    "managementDocuments": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::management-document.management-document",
+      "mappedBy": "sites"
     }
   }
 }

--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -47,16 +47,8 @@ module.exports = {
           "park-operation-sub-area",
           "park-sub-page",
           "legacy-redirect",
-          {
-            singularName: "management-document",
-            queryParams: {
-              populate: {
-                documentType: {
-                  fields: "*"
-                }
-              }
-            }
-          },
+          "management-document",
+          "management-document-type",
           {
             singularName: "page",
             queryParams: {

--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -48,6 +48,22 @@ module.exports = {
           "park-sub-page",
           "legacy-redirect",
           {
+            singularName: "management-document",
+            queryParams: {
+              populate: {
+                documentType: {
+                  fields: "*"
+                },
+                protectedAreas: {
+                  fields: "*"
+                },
+                sites: {
+                  fields: "*"
+                }
+              }
+            }
+          },
+          {
             singularName: "page",
             queryParams: {
               populate: {

--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -53,12 +53,6 @@ module.exports = {
               populate: {
                 documentType: {
                   fields: "*"
-                },
-                protectedAreas: {
-                  fields: "*"
-                },
-                sites: {
-                  fields: "*"
                 }
               }
             }

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -62,6 +62,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     url: String
     description: String
     documentDate: Date
+    documentType: STRAPI_MANAGEMENT_DOCUMENT_TYPE
   }
   `
   createTypes(typeDefs)

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -51,18 +51,11 @@ exports.createSchemaCustomization = ({ actions }) => {
     parkOperation: STRAPI_PARK_OPERATION
   }
 
-  type STRAPI_MANAGEMENT_DOCUMENT_TYPE implements Node {
-    documentCode: String
-    documentType: String
-    description: String
-  }
-
   type STRAPI_MANAGEMENT_DOCUMENT implements Node {
     title: String
     url: String
     description: String
     documentDate: Date
-    documentType: STRAPI_MANAGEMENT_DOCUMENT_TYPE
   }
   `
   createTypes(typeDefs)

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -51,11 +51,18 @@ exports.createSchemaCustomization = ({ actions }) => {
     parkOperation: STRAPI_PARK_OPERATION
   }
 
+  type STRAPI_MANAGEMENT_DOCUMENT_TYPE implements Node {
+    documentCode: String
+    documentType: String
+    description: String
+  }
+
   type STRAPI_MANAGEMENT_DOCUMENT implements Node {
     title: String
     url: String
     description: String
     documentDate: Date
+    documentType: STRAPI_MANAGEMENT_DOCUMENT_TYPE @link(by: "id", from: "documentType___NODE")
   }
   `
   createTypes(typeDefs)

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -50,6 +50,19 @@ exports.createSchemaCustomization = ({ actions }) => {
   type STRAPI_SITE implements Node {
     parkOperation: STRAPI_PARK_OPERATION
   }
+
+  type STRAPI_MANAGEMENT_DOCUMENT_TYPE implements Node {
+    documentCode: String
+    documentType: String
+    description: String
+  }
+
+  type STRAPI_MANAGEMENT_DOCUMENT implements Node {
+    title: String
+    url: String
+    description: String
+    documentDate: Date 
+  }
   `
   createTypes(typeDefs)
 }

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -61,7 +61,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     title: String
     url: String
     description: String
-    documentDate: Date 
+    documentDate: Date
   }
   `
   createTypes(typeDefs)

--- a/src/gatsby/src/pages/about/park-management-plans/approved.js
+++ b/src/gatsby/src/pages/about/park-management-plans/approved.js
@@ -12,7 +12,7 @@ import "../../../styles/listPage.scss"
 const DocumentLink = ({ doc }) => {
   const year = doc.documentDate.split('-').shift()
   return (
-    <p key={doc.id}>
+    <p>
       <a href={doc.url}>
         {`${doc.title} - ${doc.documentType?.documentCode}(${year}) [PDF]`}
       </a>
@@ -20,7 +20,7 @@ const DocumentLink = ({ doc }) => {
   )
 }
 
-const ApprovedListPage = ({ data }) => {
+const ApprovedListPage = () => {
   const queryData = useStaticQuery(graphql`
     query {
       allStrapiManagementDocument(sort: {fields: title, order: ASC}) {
@@ -135,16 +135,16 @@ const ApprovedListPage = ({ data }) => {
               filters.map((filter, index) => (
                 <div key={index} className="list">
                   {filter !== "All" && <h3>{filter}</h3>}
-                  {filtering(filter).map(doc => (
-                    <DocumentLink doc={doc} />
+                  {filtering(filter).map((doc, index) => (
+                    <DocumentLink doc={doc} key={index} />
                   ))}
                 </div>
               ))
             ) : (
               <div className="list">
                 <h3>{currentFilter}</h3>
-                {filtering(currentFilter).map(doc => (
-                  <DocumentLink doc={doc} />
+                {filtering(currentFilter).map((doc, index) => (
+                  <DocumentLink doc={doc} key={index} />
                 ))}
               </div>
             )}

--- a/src/gatsby/src/pages/about/park-management-plans/approved.js
+++ b/src/gatsby/src/pages/about/park-management-plans/approved.js
@@ -9,10 +9,31 @@ import ScrollToTop from "../../../components/scrollToTop"
 
 import "../../../styles/listPage.scss"
 
+const DocumentLink = ({ doc }) => {
+  const year = doc.documentDate.split('-').shift()
+  return (
+    <p key={doc.id}>
+      <a href={doc.url}>
+        {`${doc.title} - ${doc.documentType.documentCode}(${year}) [PDF]`}
+      </a>
+    </p>
+  )
+}
+
 const ApprovedListPage = ({ data }) => {
   const menuContent = data?.allStrapiMenu?.nodes || []
   const documents = data.allStrapiManagementDocument.nodes
-  const filters = ["All", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+  const filters = [
+    "All", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L",
+    "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
+  ]
+  const [currentFilter, setCurrentFilter] = useState("All")
+  const handleClick = (e) => {
+    setCurrentFilter(e.target.value)
+  }
+  const filtering = (char) =>
+    documents.filter(doc => doc.title.charAt(0) === char)
+
   const breadcrumbs = [
     <Link key="1" href="/">
       Home
@@ -27,13 +48,6 @@ const ApprovedListPage = ({ data }) => {
       Approved management plans
     </div>,
   ]
-
-  const [currentFilter, setCurrentFilter] = useState("All")
-  const handleClick = (e) => {
-    setCurrentFilter(e.target.value)
-  }
-  const filtering = (char) =>
-    documents.filter(doc => doc.title.charAt(0) === char)
 
   return (
     <>
@@ -57,55 +71,39 @@ const ApprovedListPage = ({ data }) => {
           <div>
             <h3>Filter</h3>
             <div className="filters">
-              {filters.map((filter, index) => {
-                return (
-                  <button
-                    key={index}
-                    value={filter}
-                    onClick={(e) => handleClick(e, filter)}
-                    className={
-                      `btn btn-selected--${
-                        currentFilter === filter ? 'true' : 'false'
-                      }`
-                    }
-                  >
-                    {filter}
-                  </button>
-                )
-              })}
+              {filters.map((filter, index) => (
+                <button
+                  key={index}
+                  value={filter}
+                  onClick={(e) => handleClick(e, filter)}
+                  className={
+                    `btn btn-selected--${
+                      currentFilter === filter ? 'true' : 'false'
+                    }`
+                  }
+                >
+                  {filter}
+                </button>
+              ))}
             </div>
           </div>
 
           <div className="lists">
             {currentFilter === "All" ? (
-              filters.map((filter, index) => {
-                return (
-                  <div key={index} className="list">
-                    {filter !== "All" &&
-                      <h3>{filter}</h3>
-                    }
-                    {filtering(filter).map(doc => (
-                      <p key={doc.id}>
-                        <a href={`/${doc.protectedAreas[0].slug}`}>
-                          {doc.title} - {doc.documentType.documentCode} - {doc.documentDate}
-                        </a>
-                      </p>
-                    ))}
-                  </div>
-                )
-              })
+              filters.map((filter, index) => (
+                <div key={index} className="list">
+                  {filter !== "All" && <h3>{filter}</h3>}
+                  {filtering(filter).map(doc => (
+                    <DocumentLink doc={doc} />
+                  ))}
+                </div>
+              ))
             ) : (
               <div className="list">
                 <h3>{currentFilter}</h3>
-                {filtering(currentFilter).map(doc => {
-                  return (
-                    <p key={doc.id}>
-                      <a href={`/${doc.protectedAreas[0].slug}`}>
-                        {doc.title} - {doc.documentType.documentCode} - {doc.documentDate}
-                      </a>
-                    </p>
-                  )
-                })}
+                {filtering(currentFilter).map(doc => (
+                  <DocumentLink doc={doc} />
+                ))}
               </div>
             )}
           </div>
@@ -129,14 +127,15 @@ export const query = graphql`
     allStrapiManagementDocument(sort: {fields: title, order: ASC}) {
       nodes {
         title
+        url
         description
         documentDate
         documentType {
           documentCode
           documentType
+          description
         }
         protectedAreas {
-          slug
           protectedAreaName
         }
         sites {

--- a/src/gatsby/src/pages/about/park-management-plans/approved.js
+++ b/src/gatsby/src/pages/about/park-management-plans/approved.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { graphql } from "gatsby"
+import { graphql, useStaticQuery } from "gatsby"
 import { Breadcrumbs, Link } from "@material-ui/core"
 
 import Header from "../../../components/header"
@@ -21,19 +21,67 @@ const DocumentLink = ({ doc }) => {
 }
 
 const ApprovedListPage = ({ data }) => {
-  const menuContent = data?.allStrapiMenu?.nodes || []
-  const documents = data.allStrapiManagementDocument.nodes
-  const filters = [
-    "All", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L",
-    "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
-  ]
+  const queryData = useStaticQuery(graphql`
+    query {
+      allStrapiManagementDocument(sort: {fields: title, order: ASC}) {
+        nodes {
+          title
+          url
+          description
+          documentDate
+          documentType {
+            documentCode
+            documentType
+            description
+          }
+          protectedAreas {
+            protectedAreaName
+          }
+          sites {
+            siteName
+          }
+        }
+      }
+      allStrapiMenu(
+        sort: { fields: order, order: ASC }
+        filter: { show: { eq: true } }
+      ) {
+        nodes {
+          strapi_id
+          title
+          url
+          order
+          id
+          strapi_children {
+            id
+            title
+            url
+            order
+          }
+          strapi_parent {
+            id
+            title
+          }
+        }
+      }
+    }
+  `)
+
+  const menuContent = queryData?.allStrapiMenu?.nodes || []
+  const documents = queryData?.allStrapiManagementDocument?.nodes || []
+
   const [currentFilter, setCurrentFilter] = useState("All")
+
   const handleClick = (e) => {
     setCurrentFilter(e.target.value)
   }
   const filtering = (char) =>
     documents.filter(doc => doc.title.charAt(0) === char)
-
+  
+  const filters = [
+    "All", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L",
+    "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
+  ]
   const breadcrumbs = [
     <Link key="1" href="/">
       Home
@@ -121,49 +169,3 @@ export default ApprovedListPage
 export const Head = () => (
   <Seo title="Approved management plans" />
 )
-
-export const query = graphql`
-  {
-    allStrapiManagementDocument(sort: {fields: title, order: ASC}) {
-      nodes {
-        title
-        url
-        description
-        documentDate
-        documentType {
-          documentCode
-          documentType
-          description
-        }
-        protectedAreas {
-          protectedAreaName
-        }
-        sites {
-          siteName
-        }
-      }
-    }
-    allStrapiMenu(
-      sort: { fields: order, order: ASC }
-      filter: { show: { eq: true } }
-    ) {
-      nodes {
-        strapi_id
-        title
-        url
-        order
-        id
-        strapi_children {
-          id
-          title
-          url
-          order
-        }
-        strapi_parent {
-          id
-          title
-        }
-      }
-    }
-  }
-`

--- a/src/gatsby/src/pages/about/park-management-plans/approved.js
+++ b/src/gatsby/src/pages/about/park-management-plans/approved.js
@@ -1,0 +1,159 @@
+import React, { useState } from "react"
+import { graphql } from "gatsby"
+import { Breadcrumbs, Link } from "@material-ui/core"
+
+import Header from "../../../components/header"
+import Footer from "../../../components/footer"
+import Seo from "../../../components/seo"
+import ScrollToTop from "../../../components/scrollToTop"
+
+import "../../../styles/listPage.scss"
+
+const ApprovedListPage = ({ data }) => {
+  const menuContent = data?.allStrapiMenu?.nodes || []
+  const parks = data.allStrapiProtectedArea.nodes
+  const filters = ["All", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+  const breadcrumbs = [
+    <Link key="1" href="/">
+      Home
+    </Link>,
+    <Link key="2" href="/about">
+      About
+    </Link>,
+    <Link key="3" href="/about/park-management-plans">
+      Management plans
+    </Link>,
+    <div key="4" className="breadcrumb-text">
+      Approved management plans
+    </div>,
+  ]
+
+  const [currentFilter, setCurrentFilter] = useState("All")
+  const handleClick = (e) => {
+    setCurrentFilter(e.target.value)
+  }
+  const filtering = (char) =>
+    parks.filter(park => park.protectedAreaName.charAt(0) === char)
+
+  return (
+    <>
+      <ScrollToTop />
+      <div className="max-width-override">
+        <Header mode="internal" content={menuContent} />
+      </div>
+      <div id="sr-content" className="d-none d-md-block static-content-container page-breadcrumbs">
+        <Breadcrumbs separator="›" aria-label="breadcrumb">
+          {breadcrumbs}
+        </Breadcrumbs>
+      </div>
+      <div className="static-content--header">
+        <h1 className="header-title">
+          Approved management plans
+        </h1>
+      </div>
+
+      <div className="static-content-container">
+        <div className="page-content-wrapper">
+          <div>
+            <h3>Filter</h3>
+            <div className="filters">
+              {filters.map((filter, index) => {
+                return (
+                  <button
+                    key={index}
+                    value={filter}
+                    onClick={(e) => handleClick(e, filter)}
+                    className={
+                      `btn btn-selected--${
+                        currentFilter === filter ? 'true' : 'false'
+                      }`
+                    }
+                  >
+                    {filter}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="lists">
+            {currentFilter === "All" ? (
+              filters.map((filter, index) => {
+                return (
+                  <div key={index} className="list">
+                    {filter !== "All" &&
+                      <h3>{filter}</h3>
+                    }
+                    {filtering(filter).map(park => (
+                      <p key={park.id}>
+                        <a href={`/${park.slug}`}>
+                          {park.protectedAreaName}
+                        </a>
+                      </p>
+                    ))}
+                  </div>
+                )
+              })
+            ) : (
+              <div className="list">
+                <h3>{currentFilter}</h3>
+                {filtering(currentFilter).map(park => {
+                  return (
+                    <p key={park.id}>
+                      <a href={`/${park.slug}`}>
+                        {park.protectedAreaName}
+                      </a>
+                    </p>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="max-width-override">
+        <Footer />
+      </div>
+    </>
+  )
+}
+
+export default ApprovedListPage
+
+export const Head = () => (
+  <Seo title="Approved management plans" />
+)
+
+export const query = graphql`
+  {
+    allStrapiProtectedArea(filter: {isDisplayed: {eq: true}}, sort: { fields: protectedAreaName }) {
+      nodes {
+        id
+        slug
+        protectedAreaName
+      }
+    }
+    allStrapiMenu(
+      sort: { fields: order, order: ASC }
+      filter: { show: { eq: true } }
+    ) {
+      nodes {
+        strapi_id
+        title
+        url
+        order
+        id
+        strapi_children {
+          id
+          title
+          url
+          order
+        }
+        strapi_parent {
+          id
+          title
+        }
+      }
+    }
+  }
+`

--- a/src/gatsby/src/pages/about/park-management-plans/approved.js
+++ b/src/gatsby/src/pages/about/park-management-plans/approved.js
@@ -14,7 +14,7 @@ const DocumentLink = ({ doc }) => {
   return (
     <p key={doc.id}>
       <a href={doc.url}>
-        {`${doc.title} - ${doc.documentType.documentCode}(${year}) [PDF]`}
+        {`${doc.title} - ${doc.documentType?.documentCode}(${year}) [PDF]`}
       </a>
     </p>
   )
@@ -33,12 +33,6 @@ const ApprovedListPage = ({ data }) => {
             documentCode
             documentType
             description
-          }
-          protectedAreas {
-            protectedAreaName
-          }
-          sites {
-            siteName
           }
         }
       }

--- a/src/gatsby/src/pages/about/park-management-plans/approved.js
+++ b/src/gatsby/src/pages/about/park-management-plans/approved.js
@@ -11,7 +11,7 @@ import "../../../styles/listPage.scss"
 
 const ApprovedListPage = ({ data }) => {
   const menuContent = data?.allStrapiMenu?.nodes || []
-  const parks = data.allStrapiProtectedArea.nodes
+  const documents = data.allStrapiManagementDocument.nodes
   const filters = ["All", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
   const breadcrumbs = [
     <Link key="1" href="/">
@@ -33,7 +33,7 @@ const ApprovedListPage = ({ data }) => {
     setCurrentFilter(e.target.value)
   }
   const filtering = (char) =>
-    parks.filter(park => park.protectedAreaName.charAt(0) === char)
+    documents.filter(doc => doc.title.charAt(0) === char)
 
   return (
     <>
@@ -84,10 +84,10 @@ const ApprovedListPage = ({ data }) => {
                     {filter !== "All" &&
                       <h3>{filter}</h3>
                     }
-                    {filtering(filter).map(park => (
-                      <p key={park.id}>
-                        <a href={`/${park.slug}`}>
-                          {park.protectedAreaName}
+                    {filtering(filter).map(doc => (
+                      <p key={doc.id}>
+                        <a href={`/${doc.protectedAreas[0].slug}`}>
+                          {doc.title} - {doc.documentType.documentCode} - {doc.documentDate}
                         </a>
                       </p>
                     ))}
@@ -97,11 +97,11 @@ const ApprovedListPage = ({ data }) => {
             ) : (
               <div className="list">
                 <h3>{currentFilter}</h3>
-                {filtering(currentFilter).map(park => {
+                {filtering(currentFilter).map(doc => {
                   return (
-                    <p key={park.id}>
-                      <a href={`/${park.slug}`}>
-                        {park.protectedAreaName}
+                    <p key={doc.id}>
+                      <a href={`/${doc.protectedAreas[0].slug}`}>
+                        {doc.title} - {doc.documentType.documentCode} - {doc.documentDate}
                       </a>
                     </p>
                   )
@@ -126,11 +126,22 @@ export const Head = () => (
 
 export const query = graphql`
   {
-    allStrapiProtectedArea(filter: {isDisplayed: {eq: true}}, sort: { fields: protectedAreaName }) {
+    allStrapiManagementDocument(sort: {fields: title, order: ASC}) {
       nodes {
-        id
-        slug
-        protectedAreaName
+        title
+        description
+        documentDate
+        documentType {
+          documentCode
+          documentType
+        }
+        protectedAreas {
+          slug
+          protectedAreaName
+        }
+        sites {
+          siteName
+        }
       }
     }
     allStrapiMenu(

--- a/src/gatsby/src/styles/listPage.scss
+++ b/src/gatsby/src/styles/listPage.scss
@@ -1,0 +1,42 @@
+@import "variables.scss";
+
+.filters {
+  .btn {
+    width: 42px;
+    height: 42px;
+    color: $colorBlue;
+    font-weight: 700;
+    font-size: 0.75rem;
+    border: 1px solid $colorBlue;
+    border-radius: 0;
+    box-shadow: inset 0px 0px 0px 3px $colorWhite;
+    margin-top: 12px;
+    margin-left: -1px;
+    &:first-child {
+      border-radius: 4px 0 0 4px;
+    }
+    &:last-child {
+      border-radius: 0 4px 4px 0;
+    }
+    &:hover {
+      color: $colorBlue;
+    }
+    &:focus {
+      box-shadow: inset 0px 0px 0px 3px $colorWhite;
+    }
+
+    &-selected--true {
+      color: $colorWhite;
+      background-color: $colorBlue;
+      &:hover {
+        color: $colorWhite;
+      }
+    }
+  }
+}
+
+.lists {
+  .list {
+    margin-top: 48px;
+  }
+}


### PR DESCRIPTION
### Jira Ticket:
- CM-437
- CM-636

### Jira Ticket URL:
- https://bcparksdigital.atlassian.net/browse/CM-437
- https://bcparksdigital.atlassian.net/browse/CM-636

### Description:
- Add the approved management plans page at `/about/park-management-plans/approved`
- Add new collections `managementDocument` and `managementDocumentType`

### Issue:
- Could not query `managementDocument.documentType`
- `managementDocument.documentType` is null on at `http://localhost:8000/___graphql` even there's data on Strapi
 