### PR TITLE
NOBUG: Use alternate URL endpoint for environments with Kong

### DIFF
--- a/.github/workflows/publish-gatsby.yaml
+++ b/.github/workflows/publish-gatsby.yaml
@@ -57,6 +57,7 @@ jobs:
           if [[ "${{ github.event.client_payload.env }}" == "prod" || "${{ github.event.inputs.buildEnv }}" == "prod" ]]; then
               echo "ENV_SUFFIX=prod" >> $GITHUB_ENV
               echo "IMAGE_TAG=prod" >> $GITHUB_ENV
+              echo "STRAPI_SOURCE_URL=https://cms.bcparks.ca" >> $GITHUB_ENV
               echo "REACT_APP_CMS_BASE_URL=https://bcparks.api.gov.bc.ca" >> $GITHUB_ENV
               echo "REACT_APP_SITE_URL=https://bcparks.ca" >> $GITHUB_ENV
               echo "STRAPI_TOKEN=${{ secrets.GATSBY_STRAPI_API_TOKEN__MAIN_PROD }}" >> $GITHUB_ENV
@@ -64,6 +65,7 @@ jobs:
               echo "ENV_SUFFIX=test" >> $GITHUB_ENV
               echo "IMAGE_TAG=test" >> $GITHUB_ENV
               if [[ "${{ github.event.client_payload.branch }}" == "main" || "${{ github.event.inputs.branchName }}" == "main" ]]; then
+                  echo "STRAPI_SOURCE_URL=https://test-cms.bcparks.ca" >> $GITHUB_ENV              
                   echo "REACT_APP_CMS_BASE_URL=https://bcparks-api-gov-bc-ca.test.api.gov.bc.ca" >> $GITHUB_ENV
                   echo "REACT_APP_SITE_URL=https://test.bcparks.ca" >> $GITHUB_ENV
                   echo "STRAPI_TOKEN=${{ secrets.GATSBY_STRAPI_API_TOKEN__MAIN_TEST }}" >> $GITHUB_ENV


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:
In the first request where it uses the API token, gatsby-source-strapi calls a non-pubic content manager route that isn't available to Kong
