### PR TITLE
CM-655: Fix missing advisory links on gatsby

### DIFF
--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -148,26 +148,26 @@ export default function AdvisoryDetails({ advisories }) {
                 </Accordion.Toggle>
                 <Accordion.Collapse eventKey={advisory.id}>
                   <div className="advisory-content p-3">
-                    {advisory.description && (
-                      <>
+                    <>
+                      {advisory.description && (
                         <HtmlContent className="mb-2">
                           {advisory.description}
                         </HtmlContent>
-                        {advisory.links?.map(({ title, url, id }) => (
-                            <p>
-                              <a
-                                href={url}
-                                style={{display: 'block'}}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                key={id}
-                              >
-                                {title}
-                              </a>
-                            </p>
-                            ))}
-                      </>
-                    )}
+                      )}
+                      {advisory.links?.map(({ title, url, id }) => (
+                          <p>
+                            <a
+                              href={url}
+                              style={{display: 'block'}}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              key={id}
+                            >
+                              {title}
+                            </a>
+                          </p>
+                        ))}
+                    </>
                     {advisory.isEffectiveDateDisplayed &&
                       advisory.formattedEffectiveDate && (
                         <p>


### PR DESCRIPTION
### Jira Ticket:
CM-655

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-655

### Description:
- Fix missing advisory links on the park pages
- Changed range of the condition `advisory.description && ()`