### PR TITLE
CM-657: Reduce Redis cache time from 1 hour to 5 minutes

### DIFF
--- a/infrastructure/helm/bcparks/templates/cms/cms-deployment.yaml
+++ b/infrastructure/helm/bcparks/templates/cms/cms-deployment.yaml
@@ -106,8 +106,6 @@ spec:
               value: {{ .Values.cms.env.cacheType }}
             - name: STRAPI_CACHE_TTL
               value: {{ .Values.cms.env.cacheTtl | quote }}
-            - name: STRAPI_CACHE_TIMEOUT
-              value: {{ .Values.cms.env.cacheTimeout | quote }}
             - name: STRAPI_ADMIN_ENVIRONMENT
               value: {{ .Values.cms.env.environment }}
             - name: REDIS_HOST

--- a/infrastructure/helm/bcparks/values-test.yaml
+++ b/infrastructure/helm/bcparks/values-test.yaml
@@ -44,7 +44,7 @@ patroni:
   replicas: 1
 
   pvc:
-    size: 10Gi
+    size: 5Gi
 
 backup:
   enabled: true

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -60,7 +60,6 @@ cms:
     cacheEnabled: true
     cacheType: redis
     cacheTtl: 300000
-    cacheTimeout: 10000
 
   service:
     portName: strapi

--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -64,7 +64,7 @@ module.exports = ({ env }) => {
           enableEtagSupport: true,
           logs: true,
           clearRelatedCache: true,
-          maxAge: 3600000,
+          maxAge: env.int("STRAPI_CACHE_TTL", 300000),
           contentTypes: [
             // list of Content-Types UID to cache
             "api::protected-area.protected-area",


### PR DESCRIPTION
### Jira Ticket:
CM-657

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-657

### Description:
I discovered we had an Openshift environment variable called STRAPI_CACHE_TTL that was not being used.  It was set to 300000 milliseconds on OpenShift (5 minutes).  We had our maxAge set to 3600000 (1 hour).  I have adjusted the Strapi config to use this variable.  

I also removed another variable that wasn’t being used by Strapi4 from OpenShift (STRAPI_CACHE_TIMEOUT was set to 10000). Strapi3 was using a different plugin called strapi-middleware-cache and the cacheTimeout setting is not applicable in the new Strapi4 plugin (strapi-plugin-rest-cache / strapi-provider-rest-cache-redis)
