### PR TITLE
CM-658: Fix Gatsby caching issue

### DIFF
--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -43,8 +43,8 @@ import { PARK_NAME_TYPE, useStyles } from "../utils/constants";
 const qs = require('qs')
 const AsyncMapLocation =  loadable(() => import("../components/park/mapLocation"));
 
-const loadAdvisories = async (apiBaseUrl, orcsId) => {
-  const params = qs.stringify ({
+const loadAdvisories = (apiBaseUrl, orcsId) => {
+  const params = qs.stringify({
     populate: "*",
     filters: {
       protectedAreas: {

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -35,8 +35,8 @@ import { useStyles } from "../utils/constants"
 
 const qs = require('qs')
 
-const loadAdvisories = async (apiBaseUrl, orcsId) => {
-  const params = qs.stringify ({
+const loadAdvisories = (apiBaseUrl, orcsId) => {
+  const params = qs.stringify({
     populate: "*",
     filters: {
       protectedAreas: {


### PR DESCRIPTION
### Jira Ticket:
CM-658

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-658

### Description:
This is a shot-in-the-dark attempt to fix an issue where Gatsby is serving cached public advisories after they are removed.  
We noticed while debugging the issue that the issue that the `finally` in this code was running before the `then`.  
```
  useEffect(() => {
    setIsLoadingAdvisories(true)
    loadAdvisories(apiBaseUrl, park.orcs)
      .then(response => {
        if (response.status === 200) {
          setAdvisories(response.data.data)
          setAdvisoryLoadError(false)
        } else {
          setAdvisories([])
          setAdvisoryLoadError(true)
        }
      })
      .finally(() => {
        setIsLoadingAdvisories(false)
      })
  }, [apiBaseUrl, park.orcs])
```
This could be caused by an issue with promises, and turned out that `loadAdvisories` was marked as `async` but it did not contain an `await` keyword.  Since `.then()` is used it should not also use `async\await` so this change removes the unnecessary `async` keyword.  

We were not able to reproduce the issue on `localdev`, `dev` or `test` but hopefully this helps on prod. 