### PR TITLE
CM-657: Change implementation of cache clearing hooks

### DIFF
--- a/src/cms/src/api/park-activity/controllers/park-activity.js
+++ b/src/cms/src/api/park-activity/controllers/park-activity.js
@@ -13,7 +13,7 @@ module.exports = createCoreController(
       const cachePlugin = strapi.plugins["rest-cache"];
       if (cachePlugin) {
         // clear the redis rest-cache when updates are made from the staff portal
-        await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area')
+        await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area', {}, true)
       }
       const response = await super.update(ctx);
       return response;

--- a/src/cms/src/api/park-facility/controllers/park-facility.js
+++ b/src/cms/src/api/park-facility/controllers/park-facility.js
@@ -13,7 +13,7 @@ module.exports = createCoreController(
       const cachePlugin = strapi.plugins["rest-cache"];
       if (cachePlugin) {
         // clear the redis rest-cache when updates are made from the staff portal
-        await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area')
+        await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area', {}, true)
       }
       const response = await super.update(ctx);
       return response;

--- a/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
+++ b/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
@@ -10,8 +10,8 @@ const clearRestCache = async function () {
   const cachePlugin = strapi.plugins["rest-cache"];
   if (cachePlugin) {
     // clear the redis rest-cache when updates are made from the staff portal
-    await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area');
-    await cachePlugin.services.cacheStore.clearByUid('api::public-advisory.public-advisory');
+    await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area', {}, true);
+    await cachePlugin.services.cacheStore.clearByUid('api::public-advisory.public-advisory', {}, true);
   }
 }
 


### PR DESCRIPTION
### Jira Ticket:
CM-657

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-657

### Description:
Changed the implementation of cache clearing hooks.  There is no documentation for `clearByUid`, but after reading the source code, I believe our implementation was not working.  
see: https://github.com/strapi-community/strapi-plugin-rest-cache/blob/main/packages/strapi-plugin-rest-cache/server/utils/config/getRouteRegExp.js

We were not passing in a value for `params` , so this code would have been triggered....
```
  if (!params) {
    return [];
  }
```
Passing in an empty object will return false, and furthermore the code above says `// wildcard: clear all routes` so I set wildcard to true.  