### PR TITLE
CM-659: Fix error re-publishing an inactive advisory

### DIFF
--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
@@ -66,6 +66,7 @@ const savePublicAdvisory = async (publicAdvisory) => {
       }
     } else {
       try {
+        delete publicAdvisory.id;
         await strapi.db.query('api::public-advisory.public-advisory').create({
           data: publicAdvisory
         });


### PR DESCRIPTION
### Jira Ticket:
CM-659

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-659

### Description:
Fixed a duplicate key error when re-publishing an inactive public advisory. 
