### PR TITLE
CM-657: Disable caching for public advisories

### DIFF
--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -68,7 +68,7 @@ module.exports = ({ env }) => {
           contentTypes: [
             // list of Content-Types UID to cache
             "api::protected-area.protected-area",
-            "api::public-advisory.public-advisory",
+            //"api::public-advisory.public-advisory",
             "api::park-access-status.park-access-status",
           ],
         },


### PR DESCRIPTION
### Jira Ticket:
CM-657

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-657

### Description:
Temporarily disabling caching for public advisories until we can determine the right configuration.
