### PR TITLE
CM-658: Fix issues invalidating the publicAdvisory rest cache

### DIFF
--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -65,10 +65,11 @@ module.exports = ({ env }) => {
           logs: true,
           clearRelatedCache: true,
           maxAge: env.int("STRAPI_CACHE_TTL", 300000),
+          hitpass: false, // don't bypass the cache for requests with a cookie or authorization header
           contentTypes: [
             // list of Content-Types UID to cache
             "api::protected-area.protected-area",
-            //"api::public-advisory.public-advisory",
+            "api::public-advisory.public-advisory",
             "api::park-access-status.park-access-status",
           ],
         },

--- a/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
+++ b/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
@@ -6,28 +6,9 @@
 const { sanitize } = require('@strapi/utils');
 const { createCoreController } = require("@strapi/strapi").factories;
 
-const clearRestCache = async function () {
-  const cachePlugin = strapi.plugins["rest-cache"];
-  if (cachePlugin) {
-    // clear the redis rest-cache when updates are made from the staff portal
-    await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area');
-    await cachePlugin.services.cacheStore.clearByUid('api::public-advisory.public-advisory');
-  }
-}
-
 module.exports = createCoreController(
   "api::public-advisory-audit.public-advisory-audit",
   ({ strapi }) => ({
-    async create(ctx) {
-      await clearRestCache();
-      const response = await super.create(ctx);
-      return response;
-    },
-    async update(ctx) {
-      await clearRestCache();
-      const response = await super.update(ctx);
-      return response;
-    },
     async history(ctx) {
       const { advisoryNumber } = ctx.params;
       const entities = await strapi.service("api::public-advisory-audit.public-advisory-audit").find({

--- a/src/cms/src/api/public-advisory/content-types/public-advisory/lifecycles.js
+++ b/src/cms/src/api/public-advisory/content-types/public-advisory/lifecycles.js
@@ -5,4 +5,33 @@
  * to customize this model
  */
 
-module.exports = {};
+const clearRestCache = async function () {
+    const cachePlugin = strapi.plugins["rest-cache"];
+    if (cachePlugin) {
+        await cachePlugin.services.cacheStore.clearByUid('api::public-advisory.public-advisory');
+        await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area');
+        await cachePlugin.services.cacheStore.clearByUid('api::park-access-status.park-access-status');
+    }
+}
+
+// clear the public advisories from the rest cache after all crud operations
+module.exports = {
+    afterCreate: async (ctx) => {
+        await clearRestCache();
+    },
+    afterUpdate: async (ctx) => {
+        await clearRestCache();
+    },
+    afterDelete: async (ctx) => {
+        await clearRestCache();
+    },
+    afterCreateMany: async (ctx) => {
+        await clearRestCache();
+    },
+    afterUpdateMany: async (ctx) => {
+        await clearRestCache();
+    },
+    afterDeleteMany: async (ctx) => {
+        await clearRestCache();
+    },
+};

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -62,7 +62,7 @@ const loadAdvisories = (apiBaseUrl, orcsId) => {
     encodeValuesOnly: true,
   })
 
-  return axios.get(`${apiBaseUrl}/public-advisories/?${params}`)
+  return axios.get(`${apiBaseUrl}/public-advisories?${params}`)
 }
 
 export default function ParkTemplate({ data }) {

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -53,7 +53,7 @@ const loadAdvisories = (apiBaseUrl, orcsId) => {
     encodeValuesOnly: true,
   })
 
-  return axios.get(`${apiBaseUrl}/public-advisories/?${params}`)
+  return axios.get(`${apiBaseUrl}/public-advisories?${params}`)
 }
 
 export default function SiteTemplate({ data }) {


### PR DESCRIPTION
### Jira Ticket:
CM-658

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-658

### Description:

1. Hooks on the publicAdvisoryAudit controller were being used to trigger the cache to be cleared for publicAdvisory. These hooks were moved to the publicAdvisory model and implemented for all crud operations. _(The previous implementation was later determined to be working, but the new implementation eliminates a possible race condition)_
2. Set hitpass to false in the rest-cache plugin configuration because the default setting led to confusion and made it much harder to debug from a web browser.
3. Modify Axios calls to remove the redundant trailing slash from public-advisories because this was causing cache invalidation to fail.
4. Re-enable caching for publicAdvisory

See comments in the Jira ticket for further details.
