### PR TITLE
CM-555: Propagate campfire bans to ProtectedAreas based on FireBanProhibitions

### DIFF
--- a/src/cms/src/api/fire-ban-prohibition/controllers/fire-ban-prohibition.js
+++ b/src/cms/src/api/fire-ban-prohibition/controllers/fire-ban-prohibition.js
@@ -7,5 +7,36 @@
 const { createCoreController } = require("@strapi/strapi").factories;
 
 module.exports = createCoreController(
-  "api::fire-ban-prohibition.fire-ban-prohibition"
+  "api::fire-ban-prohibition.fire-ban-prohibition",
+  ({ strapi }) => ({
+    async propagate(ctx) {
+
+      try {
+        await strapi
+          .service("api::fire-ban-prohibition.fire-ban-prohibition")
+          .rescindAllProtectedAreaFireBans();
+      } catch (error) {
+        return ctx.internalServerError(
+          "Error in service fire-ban-prohibition:rescindAllProtectedAreaFireBans()",
+          error.message
+        );
+      }
+
+      try {
+        await strapi
+          .service("api::fire-ban-prohibition.fire-ban-prohibition")
+          .generateAllProtectedAreaFireBans();
+      } catch (error) {
+        return ctx.internalServerError(
+          "Error in service fire-ban-prohibition:generateAllProtectedAreaFireBans()",
+          error.message
+        );
+      }
+
+      ctx.send({
+        message: 'Propagation complete!'
+      }, 201);
+
+    }
+  })
 );

--- a/src/cms/src/api/fire-ban-prohibition/controllers/fire-ban-prohibition.js
+++ b/src/cms/src/api/fire-ban-prohibition/controllers/fire-ban-prohibition.js
@@ -36,7 +36,6 @@ module.exports = createCoreController(
       ctx.send({
         message: 'Propagation complete!'
       }, 201);
-
     }
   })
 );

--- a/src/cms/src/api/fire-ban-prohibition/routes/custom.js
+++ b/src/cms/src/api/fire-ban-prohibition/routes/custom.js
@@ -1,0 +1,9 @@
+module.exports = {
+  routes: [
+    {
+      method: "POST",
+      path: "/fire-ban-prohibitions/propagate",
+      handler: "fire-ban-prohibition.propagate",
+    }
+  ],
+};

--- a/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
+++ b/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
@@ -11,7 +11,7 @@ module.exports = createCoreService(
   ({ strapi }) => ({
     /* Sets the protectedArea.hasCampfireBan to false for all protectedAreas where it is 
      * currently set to true, and sets the campfireBanRescindedDate to now on all records 
-     * being updated.  Protected Areas with hasCampfireBanOverride==true are skipped.
+     * being updated. Protected Areas with hasCampfireBanOverride==true are skipped.
      */
     async rescindAllProtectedAreaFireBans() {
       return await strapi.db.query("api::protected-area.protected-area")
@@ -31,13 +31,13 @@ module.exports = createCoreService(
         });
     },
     /* Loops through all fire-ban-prohibition records and sets the protectedArea.hasCampfireBan
-     * to true for all Protected Areas in firezones associated with a fire ban.   Protected Areas 
+     * to true for all Protected Areas in firezones associated with a fire ban. Protected Areas 
      * with hasCampfireBanOverride==true are skipped.
      * 
      */
     async generateAllProtectedAreaFireBans() {
-      // sort the bans in descending order so the oldest one will be last and the earliest date 
-      // will be applied to the protectedArea when there are multiple bans
+      // sort the bans in descending order so the oldest one will be last and the earliest
+      // date  will be applied to the protectedArea when there are multiple bans
       const allBans = await strapi.entityService.findMany(
         "api::fire-ban-prohibition.fire-ban-prohibition", {
         sort: { effectiveDate: 'DESC' },
@@ -93,7 +93,6 @@ module.exports = createCoreService(
           rowsUpdated += count;
         }
       }
-
       return { count: rowsUpdated };
     }
   })

--- a/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
+++ b/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
@@ -7,5 +7,94 @@
 const { createCoreService } = require("@strapi/strapi").factories;
 
 module.exports = createCoreService(
-  "api::fire-ban-prohibition.fire-ban-prohibition"
+  "api::fire-ban-prohibition.fire-ban-prohibition",
+  ({ strapi }) => ({
+    /* Sets the protectedArea.hasCampfireBan to false for all protectedAreas where it is 
+     * currently set to true, and sets the campfireBanRescindedDate to now on all records 
+     * being updated.  Protected Areas with hasCampfireBanOverride==true are skipped.
+     */
+    async rescindAllProtectedAreaFireBans() {
+      return await strapi.db.query("api::protected-area.protected-area")
+        .updateMany({
+          where: {
+            hasCampfireBan: true,
+            $or: [
+              { hasCampfireBanOverride: false },
+              { hasCampfireBanOverride: { $null: true } }
+            ]
+          },
+          data: {
+            campfireBanRescindedDate: (new Date()).toISOString().split('T')[0],
+            campfireBanEffectiveDate: null,
+            hasCampfireBan: false
+          },
+        });
+    },
+    /* Loops through all fire-ban-prohibition records and sets the protectedArea.hasCampfireBan
+     * to true for all Protected Areas in firezones associated with a fire ban.   Protected Areas 
+     * with hasCampfireBanOverride==true are skipped.
+     * 
+     */
+    async generateAllProtectedAreaFireBans() {
+      // sort the bans in descending order so the oldest one will be last and the earliest date 
+      // will be applied to the protectedArea when there are multiple bans
+      const allBans = await strapi.entityService.findMany(
+        "api::fire-ban-prohibition.fire-ban-prohibition", {
+        sort: { effectiveDate: 'DESC' },
+        filter: { prohibitionDescription: { $containsi: 'campfire' } },
+        populate: '*',
+      });
+
+      let rowsUpdated = 0;
+
+      for (const ban of allBans) {
+
+        let fireZones = [];
+        if (ban.fireZone) {
+          fireZones = [ban.fireZone.id];
+        } else if (ban.fireCentre) {
+          // turn fireCentre into an array of firezones
+          const zones = await strapi.db.query("api::fire-zone.fire-zone")
+            .findMany({
+              where: { fireCentre: ban.fireCentre.id },
+            })
+          fireZones = zones.map(z => z.id);
+        }
+
+        if (fireZones.length) {
+          // get a list of protectedAreaIds to have firebans added. This needs to 
+          // be 2 parts because updateMany can't use deep filtering in the "where" criteria, 
+          // but findMany can.
+          const protectedAreas = await strapi.db.query("api::protected-area.protected-area")
+            .findMany({
+              where: {
+                fireZones: {
+                  id: { $in: fireZones },
+                },
+                $or: [
+                  { hasCampfireBanOverride: false },
+                  { hasCampfireBanOverride: { $null: true } }
+                ]
+              }
+            });
+          const protectedAreaIds = protectedAreas.map(p => p.id);
+
+          // add the campfire ban to all protectedAreas matching the firezones
+          const { count } = await strapi.db.query("api::protected-area.protected-area")
+            .updateMany({
+              where: {
+                id: { $in: protectedAreaIds }
+              },
+              data: {
+                campfireBanEffectiveDate: ban.effectiveDate?.split('T')[0],
+                hasCampfireBan: true
+              },
+            });
+          rowsUpdated += count;
+        }
+      }
+
+      return { count: rowsUpdated };
+    }
+  })
 );


### PR DESCRIPTION
### Jira Ticket:
CM-555

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-555

### Description:
This change adds a new REST endpoint that will be called by a cron script to propagate campfire bans to ProtectedAreas based on FireBanProhibitions.

The new endpoint can be tested from Postman using a bearer token (API Token) that is generated from the Strapi admin interface.  The token type should be "custom" or "full access". Custom tokens must be granted access to the propagate endpoint. 

**Postman Settings**
request method: POST
test url:  [server url]/api/fire-ban-prohibitions/propagate
Authorization Type: Bearer Token
Token:  [the token you generated]

**Testing Notes**
- Add firebans manually through the Strapi admin interface to test
- Only firebans with the word 'campfire' (case insensitve) in the descriptions will be propagated
- Protected area with a campfire ban override will be skipped.
- If there are multiple campfire bans for the same protected area, the effective date will reflect the oldest campfire ban.
- Campfire bans are expected to always have an effective date.
- Campfire bans are expected to always have a Firecentre or a Firezone specified, but NEVER BOTH.
