### PR TITLE
CM-664: Convert protectedArea lifecyle hooks to Strapi4 syntax

### DIFF
--- a/src/cms/src/api/protected-area/content-types/protected-area/lifecycles.js
+++ b/src/cms/src/api/protected-area/content-types/protected-area/lifecycles.js
@@ -8,20 +8,30 @@
 const validator = require("../../../../helpers/slugValidator.js");
 
 const saveParkAccessStatus = async (data) => {
-  await strapi
-    .service("api::park-access-status.park-access-status")
-    .update({ orcs: data.orcs }, { orcs: data.orcs })
-    .catch(async () => {
-      await strapi
-        .service("api::park-access-status.park-access-status")
-        .create({ orcs: data.orcs })
-        .catch((error) => {
-          strapi.log.error(
-            `error creating park-access-status ${data.id}...`,
-            error
-          );
-        });
-    });
+  const updateResult = await strapi.db
+    .query(
+      "api::park-access-status.park-access-status"
+    )
+    .updateMany(
+      {
+        where: {
+          orcs: data.result.orcs
+        },
+        data: {
+          orcs: data.result.orcs,
+          publishedAt: new Date(),
+          updatedAt: new Date()
+        }
+      });
+  if (updateResult.count === 0) {
+    await strapi.entityService.create(
+      "api::park-access-status.park-access-status", {
+      data: {
+        orcs: data.result.orcs,
+        publishedAt: new Date()
+      }
+    })
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
### Jira Ticket:
CM-664

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-664

### Description:
Two of the lifecycle hooks on protectedAreas were still using Strapi3 code. This was resulting in an error that was causing changes made via Strapi admin to be rolled back.
