### PR TITLE
CM-666: updatedBy and createdBy cause errors saving public advisories

### DIFF
--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/lifecycles.js
@@ -32,6 +32,8 @@ const getNextRevisionNumber = async (advisoryNumber) => {
 
 const createPublicAdvisoryAudit = async (data) => {
   delete data.id;
+  delete data.updatedBy;
+  delete data.createdBy;
   data.publishedAt = null;
   data.isLatestRevision = false;
 
@@ -46,6 +48,8 @@ const createPublicAdvisoryAudit = async (data) => {
 };
 
 const savePublicAdvisory = async (publicAdvisory) => {
+  delete publicAdvisory.updatedBy;
+  delete publicAdvisory.createdBy;  
   if (publicAdvisory.advisoryStatus.code === "PUB") {
     publicAdvisory.publishedAt = new Date();
     const isExist = await strapi.db.query('api::public-advisory.public-advisory').findOne({

--- a/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
+++ b/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
@@ -18,6 +18,13 @@ module.exports = createCoreController(
         populate: "*"
       });
 
+      // remove createdBy and updatedBy because it's easier to maintain than 
+      // changing populate: "*" to include everything else but these fields.
+      for (const version of entities.results) {
+        delete version.createdBy;
+        delete version.updatedBy;
+      };
+
       return sanitize.contentAPI.output(entities.results);
     }
   }


### PR DESCRIPTION
### Jira Ticket:
CM-666

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-666

### Description:
On some records, the updatedBy and createdBy fields were causing errors saving public advisories.  These fields are not actually used to track anything for data saved from the staff portal so they are not needed.  The staff portal uses Keycloak users and the audit data is stored in separate fields.
