### PR TITLE
NOBUG: Fix useEffect warning

### DIFF
--- a/src/gatsby/src/utils/usePreRenderVideo.js
+++ b/src/gatsby/src/utils/usePreRenderVideo.js
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import * as cheerio from "cheerio";
 
+const slugify = require("slugify");
+
 export const usePreRenderVideo = (content) => {
-  const slugify = require("slugify");
   const [list, setList] = useState([]);
   const [htmlContent, setHtmlContent] = useState('');
   let $;


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:
- Fix a warning below:
```
warn /Users/ayumi/Downloads/projects/bcparks/strapi4/src/gatsby/src/utils/usePreRenderVideo.js
56:6 warning React Hook useEffect has a missing dependency: 'slugify'.
Either include it or remove the dependency array react-hooks/exhaustive-deps
```
