### PR TITLE
NOBUG: Fix broken static image on safari

### DIFF
--- a/src/gatsby/src/styles/footer.scss
+++ b/src/gatsby/src/styles/footer.scss
@@ -55,6 +55,12 @@
     }
   }
   .footer-logo {
+    &.gatsby-image-wrapper {
+      width: 164px;
+      @include media-breakpoint-up(md) {
+        width: 246px;
+      }
+    }
     img {
       height: 60px;
       margin-bottom: 1.5rem;

--- a/src/gatsby/src/styles/megaMenu/megaMenu.scss
+++ b/src/gatsby/src/styles/megaMenu/megaMenu.scss
@@ -45,11 +45,17 @@
     }
 
     .bc-parks-logo--desktop {
+      &.gatsby-image-wrapper {
+        width: 148px;
+      }
       img {
         height: 45px;
       }
     }
     .bc-parks-logo--mobile {
+      &.gatsby-image-wrapper {
+        width: 136px;
+      }
       img {
         height: 50px;
       }


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:
- Foley found out that the BC parks logos in the header and the footer are rendered weirdly on Safari. 
  Access to https://alpha-dev.bcparks.ca 
- It was because of the Gatsby static image change in this ticket.
  https://bcparksdigital.atlassian.net/browse/CM-454
- Add fix to keep image size both on Safari/Chrome
