### PR TITLE
CM-654: Add eventType to parkAccessStatus api

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-status.js
@@ -59,6 +59,7 @@ const getPublishedPublicAdvisories = async () => {
       populate: {
         protectedAreas: { fields: ["orcs"] },
         accessStatus: {fields: ["accessStatus"]},
+        eventType: { fields: ["eventType"] },
         links: { populate: { type: { fields: ["type"] } } }
       },
 


### PR DESCRIPTION
### Jira Ticket:
CM-654

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-654

### Description:
- Add eventType to parkAccessStatus API
- On PROD, eventType is null: [https://cms.bcparks.ca/api/park-access-statuses/?populate=*&filters[orcs][$eq]=75](https://cms.bcparks.ca/api/park-access-statuses/?populate=%2A&filters%5Borcs%5D%5B$eq%5D=75)
- On local, eventType should be "wildfire": [http://localhost:1337/api/park-access-statuses/?populate=*&filters[orcs][$eq]=75](http://localhost:1337/api/park-access-statuses/?populate=%2A&filters%5Borcs%5D%5B$eq%5D=75)
