### PR TITLE
CM-663: Revert docker container to Node.js v14

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: "18"
+          node-version: "14"
 
       - name: npm build
         run: |


### PR DESCRIPTION
### Jira Ticket:
CM-663

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-663

### Description:
Temporary build fix to get around node-sass/node-gyp dependency on Python 2
