### PR TITLE
CM-669: Enable GraphQL playground and introspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ bcparks.ca-scrape.laccdb
 **/.env.development.local
 **/.env.test.local
 **/.env.production.local
+**/.env.prod
+**/.env.test
 **/generate-react-cli.json
 **/yarn.lock
 **/npm-debug.log*

--- a/infrastructure/helm/bcparks/templates/cms/cms-deployment.yaml
+++ b/infrastructure/helm/bcparks/templates/cms/cms-deployment.yaml
@@ -117,6 +117,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-{{ .Values.redis.componentName }}-secret
                   key: REDIS_PASSWORD
+            - name: ENABLE_GRAPHQL_PLAYGROUND
+              value: {{ .Values.cms.env.enableGraphQLPlayground | quote }}
           envFrom:
             - secretRef:
                 name: {{ template "bcparks_cms_secret" . }}

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -63,6 +63,7 @@ cms:
     cacheEnabled: true
     cacheType: redis
     cacheTtl: 300000
+    enableGraphQLPlayground: true
 
   service:
     portName: strapi

--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -1,7 +1,16 @@
 module.exports = ({ env }) => {
   return {
     graphql: {
-      amountLimit: 2500,
+      config: {
+        shadowCRUD: true,
+        amountLimit: 500,
+        depthLimit: 7,
+        playgroundAlways: process.env.STRAPI_ADMIN_ENVIRONMENT !== "prod",
+        apolloServer: {
+          tracing: false,
+          introspection: true,
+        },
+      }
     },
     email: {
       provider: "nodemailer",

--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -5,7 +5,7 @@ module.exports = ({ env }) => {
         shadowCRUD: true,
         amountLimit: 500,
         depthLimit: 7,
-        playgroundAlways: process.env.STRAPI_ADMIN_ENVIRONMENT !== "prod",
+        playgroundAlways: process.env.ENABLE_GRAPHQL_PLAYGROUND || false,
         apolloServer: {
           tracing: false,
           introspection: true,

--- a/src/kong/public-prod.yaml
+++ b/src/kong/public-prod.yaml
@@ -810,3 +810,19 @@ services:
           credentials: false
           max_age: null
           preflight_continue: false
+
+  - name: BCPARKS-GRAPHQL
+    host: main-cms.61d198-prod.svc
+    protocol: http
+    port: 1337
+    routes:
+     - name: graphql
+       tags:
+         - ns.bcparks
+       paths:
+         - /graphql
+       strip_path: false
+       hosts:
+         - bcparks.api.gov.bc.ca
+    tags:
+      - ns.bcparks

--- a/src/kong/public-test.yaml
+++ b/src/kong/public-test.yaml
@@ -810,3 +810,19 @@ services:
           credentials: false
           max_age: null
           preflight_continue: false
+
+  - name: BCPARKS-GRAPHQL
+    host: main-cms.61d198-test.svc
+    protocol: http
+    port: 1337
+    routes:
+     - name: graphql
+       tags:
+         - ns.bcparks
+       paths:
+         - /graphql
+       strip_path: false
+       hosts:
+         - bcparks.api.gov.bc.ca
+    tags:
+      - ns.bcparks


### PR DESCRIPTION
### Jira Ticket:
CM-669

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-669

### Description:
Enable the GraphQL playground and introspection for all environments.  
- A new environment variable was also added to OpenShift that allows this setting to be disabled for individual environments.  
- The GraphQL endpoint was also added to Kong for the TEST and PROD environments
