### PR TITLE
CM-653: Sort advisories by listing rank

### DIFF
--- a/src/admin/src/components/composite/advisoryForm/AdvisoryForm.js
+++ b/src/admin/src/components/composite/advisoryForm/AdvisoryForm.js
@@ -148,7 +148,7 @@ export default function AdvisoryForm({
   const [listingRankError, setListingRankError] = useState("");
 
   const advisoryData = {
-    listingRank: { value: listingRank, setError: setListingRankError },
+    listingRank: { value: listingRank, setError: setListingRankError, text: "listing rank" },
     ticketNumber: { value: ticketNumber, setError: setTicketNumberError },
     headline: { value: headline, setError: setHeadlineError, text: "headline" },
     eventType: {
@@ -228,7 +228,7 @@ export default function AdvisoryForm({
 
   const listingRankInput = {
     id: "listing",
-    required: false,
+    required: true,
     placeholder: "Listing Rank",
   };
 

--- a/src/admin/src/components/page/advisory/Advisory.js
+++ b/src/admin/src/components/page/advisory/Advisory.js
@@ -96,7 +96,7 @@ export default function Advisory({
   const [displayUpdatedDate, setDisplayUpdatedDate] = useState(false);
   const [notes, setNotes] = useState("");
   const [submittedBy, setSubmittedBy] = useState("");
-  const [listingRank, setListingRank] = useState("0");
+  const [listingRank, setListingRank] = useState(0);
   const [ toError, setToError] = useState(false);
   const [toDashboard, setToDashboard] = useState(false);
   const { keycloak, initialized } = useKeycloak();

--- a/src/admin/src/components/page/advisory/Advisory.js
+++ b/src/admin/src/components/page/advisory/Advisory.js
@@ -96,7 +96,7 @@ export default function Advisory({
   const [displayUpdatedDate, setDisplayUpdatedDate] = useState(false);
   const [notes, setNotes] = useState("");
   const [submittedBy, setSubmittedBy] = useState("");
-  const [listingRank, setListingRank] = useState("");
+  const [listingRank, setListingRank] = useState("0");
   const [ toError, setToError] = useState(false);
   const [toDashboard, setToDashboard] = useState(false);
   const { keycloak, initialized } = useKeycloak();

--- a/src/admin/src/validators/AdvisoryValidator.js
+++ b/src/admin/src/validators/AdvisoryValidator.js
@@ -77,7 +77,8 @@ export function validateDate(field) {
 
 export function validAdvisoryData(advisoryData, validateStatus, mode) {
   advisoryData.formError("");
-  const validListingRank = validateOptionalNumber(advisoryData.listingRank);
+  const validListingRankNumber = validateOptionalNumber(advisoryData.listingRank);
+  const validListingRankRequired = validateRequiredText(advisoryData.listingRank);
   const validTicketNumber = validateOptionalNumber(advisoryData.ticketNumber);
   const validHeadline = validateRequiredText(advisoryData.headline);
   const validEventType = validateRequiredSelect(advisoryData.eventType);
@@ -89,7 +90,8 @@ export function validAdvisoryData(advisoryData, validateStatus, mode) {
   const validExpiryDate = validateOptionalDate(advisoryData.expiryDate);
   const validSubmittedBy = validateRequiredText(advisoryData.submittedBy);
   let validData =
-    validListingRank &&
+    validListingRankNumber &&
+    validListingRankRequired &&
     validTicketNumber &&
     validHeadline &&
     validEventType &&

--- a/src/cms/database/migrations/2023.05.23T00.00.00.listing-rank-not-null.js
+++ b/src/cms/database/migrations/2023.05.23T00.00.00.listing-rank-not-null.js
@@ -1,0 +1,11 @@
+'use strict'
+
+async function up(knex) {
+
+    await knex.from('public_advisory_audits').update({ listing_rank: 0 }).whereNull('listing_rank');
+
+    await knex.from('public_advisories').update({ listing_rank: 0 }).whereNull('listing_rank');;
+
+}
+
+module.exports = { up };

--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
@@ -35,7 +35,9 @@
       "type": "boolean"
     },
     "listingRank": {
-      "type": "integer"
+      "type": "integer",
+      "default": 0,
+      "required": true
     },
     "note": {
       "type": "text"

--- a/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
+++ b/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
@@ -34,7 +34,9 @@
       "type": "boolean"
     },
     "listingRank": {
-      "type": "integer"
+      "type": "integer",
+      "default": 0,
+      "required": true
     },
     "note": {
       "type": "text"

--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -102,8 +102,6 @@ module.exports = createCoreController(
             let entities;
             let pagination;
 
-            ctx.query = populateStandardMessages(ctx.query);
-
             ctx.query.populate = {
                 accessStatus: { fields: '*' },
                 eventType: { fields: '*' },
@@ -114,6 +112,7 @@ module.exports = createCoreController(
                 sections: { fields: '*' },
                 managementAreas: { fields: '*' },
                 fireZones: { fields: '*' },
+                standardMessages: { fields: '*' },
                 sites: {
                     fields: [
                         "id", "siteNumber", "siteName", "orcsSiteNumber", "slug", "status"
@@ -144,6 +143,5 @@ module.exports = createCoreController(
                 meta: { pagination: pagination }
             };
         }
-    }
-    )
+    })
 );

--- a/src/cms/src/api/public-advisory/routes/custom.js
+++ b/src/cms/src/api/public-advisory/routes/custom.js
@@ -5,5 +5,10 @@ module.exports = {
       path: "/public-advisories/count",
       handler: "public-advisory.count",
     },
+    {
+      method: "GET",
+      path: "/public-advisories/items",
+      handler: "public-advisory.items",
+    }
   ],
 };

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -14,6 +14,7 @@ import {
 import useScrollSpy from "react-use-scrollspy"
 
 import { capitalizeFirstLetter, renderHTML, isNullOrWhiteSpace } from "../utils/helpers";
+import { loadAdvisories } from '../utils/advisoryHelper';
 
 import Footer from "../components/footer"
 import Header from "../components/header"
@@ -43,27 +44,6 @@ import { PARK_NAME_TYPE, useStyles } from "../utils/constants";
 
 const qs = require('qs')
 const AsyncMapLocation =  loadable(() => import("../components/park/mapLocation"));
-
-const loadAdvisories = (apiBaseUrl, orcsId) => {
-  const params = qs.stringify({
-    populate: "*",
-    filters: {
-      protectedAreas: {
-        orcs: {
-          $eq: orcsId
-        }
-      }
-    },
-    pagination: {
-      limit: 100,
-    },
-    sort: ["urgency.sequence:DESC"],
-  }, {
-    encodeValuesOnly: true,
-  })
-
-  return axios.get(`${apiBaseUrl}/public-advisories?${params}`)
-}
 
 const loadProtectedArea = (apiBaseUrl, orcsId) => {
   const params = qs.stringify({

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useRef } from "react"
-import axios from "axios"
 import { sortBy, truncate } from "lodash"
 import { graphql } from "gatsby"
 import {
@@ -13,6 +12,7 @@ import {
 import useScrollSpy from "react-use-scrollspy"
 
 import { isNullOrWhiteSpace } from "../utils/helpers";
+import { loadAdvisories } from '../utils/advisoryHelper';
 
 import Footer from "../components/footer"
 import Header from "../components/header"
@@ -32,29 +32,6 @@ import ScrollToTop from "../components/scrollToTop"
 import Seo from "../components/seo"
 
 import { useStyles } from "../utils/constants"
-
-const qs = require('qs')
-
-const loadAdvisories = (apiBaseUrl, orcsId) => {
-  const params = qs.stringify({
-    populate: "*",
-    filters: {
-      protectedAreas: {
-        orcs: {
-          $eq: orcsId
-        }
-      }
-    },
-    pagination: {
-      limit: 100,
-    },
-    sort: ["urgency.sequence:DESC"],
-  }, {
-    encodeValuesOnly: true,
-  })
-
-  return axios.get(`${apiBaseUrl}/public-advisories?${params}`)
-}
 
 export default function SiteTemplate({ data }) {
   const classes = useStyles()

--- a/src/gatsby/src/utils/advisoryHelper.js
+++ b/src/gatsby/src/utils/advisoryHelper.js
@@ -1,3 +1,6 @@
+import axios from "axios"
+const qs = require('qs');
+
 const getAdvisoryTypeFromUrl = () => {
     let aType = "all", thisUrl = "", params
   
@@ -12,6 +15,27 @@ const getAdvisoryTypeFromUrl = () => {
     return aType
 }
 
+const loadAdvisories = (apiBaseUrl, orcsId) => {
+  const params = qs.stringify({
+    filters: {
+      protectedAreas: {
+        orcs: {
+          $eq: orcsId
+        }
+      }
+    },
+    pagination: {
+      limit: 100,
+    },
+    sort: ["urgency.sequence:DESC", "listingRank:DESC", "advisoryDate:DESC"],
+  }, {
+    encodeValuesOnly: true,
+  })
+
+  return axios.get(`${apiBaseUrl}/public-advisories/items?${params}`)
+}
+
 export {
+    loadAdvisories,
     getAdvisoryTypeFromUrl
 }


### PR DESCRIPTION
### Jira Ticket:
CM-653

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-653

### Description:
The numeric public-advisory field ‘listingRank’ is used to override the default sort order of advisories on a park page.  Occasionally, an advisory (or advisories) needs to be pinned to the top of the list. A higher number is equivalent to a higher priority on the page.

This was a bit more complicated than expected because there is a bug in the way Strapi sorts nulls on Postgres databases.  As a work-around, I had to ensure that the listingRank is set to zero and is never null.  
https://github.com/strapi/strapi/issues/12593

As part of this change, `loadAdvisories` was also refactored and optimized with the following goals:

1. Reduce code duplication between sites and parks
2. Optimize the JSON payload for public advisories on park pages to eliminate unneeded fields. This included creating a new endpoint called "public-advisories/items" for loading advisories on park pages without loading large text fields like park descriptions.
