### PR TITLE
CM-289: Fix youtube url in RTE error

### DIFF
--- a/src/cms/config/middlewares.js
+++ b/src/cms/config/middlewares.js
@@ -7,6 +7,7 @@ module.exports = [
         useDefaults: true,
         directives: {
           "connect-src": ["'self'", "https:"],
+          "script-src": ["'self'", "'unsafe-inline'"],
           "img-src": [
             "'self'",
             "data:",
@@ -23,7 +24,7 @@ module.exports = [
             "market-assets.strapi.io",
             "nrs.objectstore.gov.bc.ca"
           ],
-          'frame-src': [
+          "frame-src": [
             "'self'",
             "youtube.com",
             "www.youtube.com"


### PR DESCRIPTION
### Jira Ticket:
CM-289

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-289

### Description:
- Fix this warning below when editors enter the YouTube URL in the RTE field
```
Refused to execute inline script because it violates the following Content Security Policy directive:
"script-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256FDyPg8CqqIpPAfGVKx1YeKduyLs0ghNYWII21wL+7HM='),
or a nonce ('nonce-...') is required to enable inline execution.
```
