### PR TITLE
NOBUG: Fix staff portal create/edit screen crash

### DIFF
--- a/src/admin/src/components/page/advisory/Advisory.js
+++ b/src/admin/src/components/page/advisory/Advisory.js
@@ -445,7 +445,7 @@ export default function Advisory({
           setManagementAreas([...managementAreas]);
           const siteData = res[4];
           const sites = siteData.map((s) => ({
-            label: s?.attributes.protectedArea?.data.attributes.protectedAreaName + ": " + s.attributes.siteName,
+            label: s?.attributes.protectedArea?.data?.attributes.protectedAreaName + ": " + s.attributes.siteName,
             value: s.id,
             type: "site",
             obj: s,


### PR DESCRIPTION
### Jira Ticket:
None (discovered while testing CM-663)

### Jira Ticket URL:
None

### Description:
Fixes a bug where the staff portal create/edit advisory form gets an error and goes to the error page if there are any sites with no protectedArea defined.  This issue was discovered while testing CM-663 and caused by testing done for CM-99.  