### PR TITLE
CM-653: Remove double-sorting of public advisories

### DIFF
--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -23,7 +23,8 @@ const formatDate = isoDate => {
 export default function AdvisoryDetails({ advisories }) {
   let expandedsInitial = []
   advisories.sort((a, b) => {
-    return b?.urgency?.sequence - a?.urgency?.sequence
+    return b.listingRank - a.listingRank
+      || b?.urgency?.sequence - a?.urgency?.sequence
       || new Date(b.advisoryDate) - new Date(a.advisoryDate)
   }).forEach((advisory, index) => {
     expandedsInitial[index] = false

--- a/src/gatsby/src/utils/advisoryHelper.js
+++ b/src/gatsby/src/utils/advisoryHelper.js
@@ -26,8 +26,7 @@ const loadAdvisories = (apiBaseUrl, orcsId) => {
     },
     pagination: {
       limit: 100,
-    },
-    sort: ["listingRank:DESC", "urgency.sequence:DESC", "advisoryDate:DESC"],
+    }
   }, {
     encodeValuesOnly: true,
   })


### PR DESCRIPTION
### Jira Ticket:
CM-653

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-653

### Description:
Removed redundant double sorting of public advisories.  I decided to keep the client side sorting (instead of the server-side sorting) because there are issues with null sorting in Strapi, and work-arounds are easier on client-side than on server-side.  
https://github.com/strapi/strapi/issues/12593
