### PR TITLE
CM-723: Bugfix for page section ID's changed from int to guid

### DIFF
--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -113,6 +113,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
           }
           ... on STRAPI__COMPONENT_PARKS_PAGE_SECTION {
             id
+            strapi_id
             strapi_component
             sectionTitle
             sectionHTML {

--- a/src/gatsby/src/components/pageContent/pageContent.js
+++ b/src/gatsby/src/components/pageContent/pageContent.js
@@ -52,7 +52,14 @@ export default function PageContent({ contentType, content }) {
         return <HTMLArea isVisible={true}>{content.HTML.data.HTML}</HTMLArea>
     }
     if (contentType === "parks.page-section") {
-        return <PageSection sectionTitle={content.sectionTitle} sectionId={content.id} sectionHtml={content.sectionHTML} />
+        return (
+          <PageSection
+            sectionTitle={content.sectionTitle}
+            sectionId={content.id}
+            sectionStrapiId={content.strapi_id}
+            sectionHtml={content.sectionHTML}
+          />
+        )
     }
 
     return null

--- a/src/gatsby/src/components/pageContent/pageSection.js
+++ b/src/gatsby/src/components/pageContent/pageSection.js
@@ -4,10 +4,11 @@ import HTMLArea from "../HTMLArea"
 
 import "../../styles/pageContent/pageSection.scss"
 
-export default function PageSection({ sectionId, sectionTitle, sectionHtml})
+export default function PageSection({ sectionId, sectionStrapiId, sectionTitle, sectionHtml})
 {
     return (
         <>
+            <span id={`page-section-${sectionStrapiId}`}></span>		
             <div className="page-section" id={"page-section-" + sectionId}>
                 <h2 className="page-section-title">{sectionTitle}</h2>
                 <HTMLArea className="page-section-html" isVisible={true}>


### PR DESCRIPTION
### Jira Ticket:
CM-723

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-723

### Description:
Fixes a bug from the Strapi 4 / Gatsby 4 update that caused broken anchor links.  
NOTE: This hotfix PR is different from https://github.com/bcgov/bcparks.ca/pull/743 because it does not rely on https://github.com/bcgov/bcparks.ca/pull/720.
