### PR TITLE
NOBUG: Increase resource levels for 'public' deployments

### DIFF
--- a/infrastructure/helm/bcparks/templates/cms/cms-hpa.yaml
+++ b/infrastructure/helm/bcparks/templates/cms/cms-hpa.yaml
@@ -20,7 +20,7 @@ spec:
         name: memory
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: {{ .Values.cms.hpa.memoryUtilizationThreshold }}
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0

--- a/infrastructure/helm/bcparks/templates/public/public-hpa.yaml
+++ b/infrastructure/helm/bcparks/templates/public/public-hpa.yaml
@@ -20,7 +20,7 @@ spec:
         name: memory
         target:
           type: Utilization
-          averageUtilization: 90
+          averageUtilization: {{ .Values.public.hpa.memoryUtilizationThreshold }}
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -57,6 +57,14 @@ backup:
     name: 61d198-prod
 
 public:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+
   hpa:
     minReplicas: 2
-    maxReplicas: 4
+    maxReplicas: 8

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -68,3 +68,4 @@ public:
   hpa:
     minReplicas: 2
     maxReplicas: 8
+    memoryUtilizationThreshold: 60

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -73,6 +73,7 @@ cms:
     minReplicas: 1
     # Default to 1 max replica on dev, overriden in test and prod envs
     maxReplicas: 1
+    memoryUtilizationThreshold: 60
 
 patroni:
   componentName: patroni
@@ -167,6 +168,7 @@ public:
     minReplicas: 1
     # Default to 1 max replica on dev, overriden in test and prod envs
     maxReplicas: 1
+    memoryUtilizationThreshold: 75
 
 backup:
   componentName: postgres-backup


### PR DESCRIPTION
### Jira Ticket:
None

### Jira Ticket URL:
None

### Description:
The site went down for a couple of minutes, and upon further inspection the public containers had been crashing.  
I double the memory, CPU, and HPA maxReplicas limit for these containers.  

This change is already applied to OpenShift PROD.  
