### PR TITLE
CM-726: Fix button text color in park page accordions

### DIFF
--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -82,6 +82,9 @@
     &:focus-visible {
       outline: -webkit-focus-ring-color auto 1px;
     }
+    &.btn-primary {
+      color: $colorWhite;
+    }
   }
 }
 


### PR DESCRIPTION
### Jira Ticket:
CM-726

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-726

### Description:
Fixed button text colour so it doesn't inherit from `.parks-container a`
