### PR TITLE
CM-668: Add 4 new custom filters to park-access-status

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-status.js
@@ -383,31 +383,38 @@ const getProtectedAreaStatus = async (ctx) => {
     };
   });
 
-  // filter accessStatus field
+  // custom filters on accessStatus derived field
   if (accessStatus) {
-    return (payload = payload.filter(
+    payload = payload.filter(
       (o) => o?.accessStatus?.toLowerCase() == accessStatus.toLowerCase()
-    ));
-  } else if (accessStatus_ne) {
-    return (payload = payload.filter(
+    );
+  }
+  if (accessStatus_ne) {
+    payload = payload.filter(
       (o) => o?.accessStatus?.toLowerCase() != accessStatus_ne.toLowerCase()
-    ));
-  } else if (accessStatus_contains) {
-    return (payload = payload.filter(
+    );
+  }
+  if (accessStatus_contains) {
+    payload = payload.filter(
       (o) => o?.accessStatus?.toLowerCase().includes(accessStatus_contains.toLowerCase())
-    ));
-  } else if (eventType) {
-    return (payload = payload.filter(
+    );
+  }
+
+  // custom filters on eventType derived field
+  if (eventType) {
+    payload = payload.filter(
       (o) => o?.eventType?.toLowerCase() == eventType.toLowerCase()
-    ));
-  } else if (eventType_ne) {
-    return (payload = payload.filter(
+    );
+  }
+  if (eventType_ne) {
+    payload = payload.filter(
       (o) => o?.eventType?.toLowerCase() != eventType_ne.toLowerCase()
-    ));
-  } else if (eventType_contains) {
-    return (payload = payload.filter(
+    );
+  }
+  if (eventType_contains) {
+    payload = payload.filter(
       (o) => o?.eventType?.toLowerCase().includes(eventType_contains.toLowerCase())
-    ));
+    );
   }
 
   return payload;

--- a/src/cms/src/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-status.js
@@ -89,7 +89,19 @@ const getPublicAdvisoryAudits = async () => {
 // custom route for park status view
 const getProtectedAreaStatus = async (ctx) => {
   let entities;
-  const { accessStatus, accessStatus_ne, ...query } = ctx.query;
+  const {
+    accessStatus,
+    accessStatus_ne,
+    accessStatus_contains,
+    eventType,
+    eventType_ne,
+    eventType_contains,
+    limit,
+    pagination,
+    populate,
+    fields,
+    ...query
+  } = ctx.query;
 
   const protectedAreaPopulateSettings = {
     fireZones: {  
@@ -106,32 +118,32 @@ const getProtectedAreaStatus = async (ctx) => {
       }            
     },
     parkActivities: {
-      fields: ["description"],
+      fields: ["id"],
       populate: { 
-        activityType: { fields: ["activityName", "activityCode", "icon", "iconNA", "rank"] }
+        activityType: { fields: ["activityName", "activityCode"] }
       }
     },
     parkFacilities: {
-      fields: ["description"],
+      fields: ["id"],
       populate: { 
-        facilityType: { fields: ["facilityName", "facilityCode", "icon", "iconNA", "rank"] }
+        facilityType: { fields: ["facilityName", "facilityCode"] }
       }
     }
   };
 
-  if (accessStatus || accessStatus_ne) {
+  if (
+    accessStatus
+    || accessStatus_ne
+    || accessStatus_contains
+    || eventType
+    || eventType_ne
+    || eventType_contains
+  ) {
     entities = await strapi.entityService.findMany(
       "api::protected-area.protected-area",
       {
+        ...query,
         limit: -1,
-        populate: protectedAreaPopulateSettings,
-      }
-    );
-  } else if (ctx.query.queryText) {
-    entities = await strapi.entityService.findMany(
-      "api::protected-area.protected-area",
-      {
-        ...ctx.query,
         populate: protectedAreaPopulateSettings,
       }
     );
@@ -139,7 +151,7 @@ const getProtectedAreaStatus = async (ctx) => {
     entities = await strapi.entityService.findMany(
       "api::protected-area.protected-area",
       {
-        ...query,
+        ...ctx.query,
         populate: protectedAreaPopulateSettings
       }
     );
@@ -379,6 +391,22 @@ const getProtectedAreaStatus = async (ctx) => {
   } else if (accessStatus_ne) {
     return (payload = payload.filter(
       (o) => o?.accessStatus?.toLowerCase() != accessStatus_ne.toLowerCase()
+    ));
+  } else if (accessStatus_contains) {
+    return (payload = payload.filter(
+      (o) => o?.accessStatus?.toLowerCase().includes(accessStatus_contains.toLowerCase())
+    ));
+  } else if (eventType) {
+    return (payload = payload.filter(
+      (o) => o?.eventType?.toLowerCase() == eventType.toLowerCase()
+    ));
+  } else if (eventType_ne) {
+    return (payload = payload.filter(
+      (o) => o?.eventType?.toLowerCase() != eventType_ne.toLowerCase()
+    ));
+  } else if (eventType_contains) {
+    return (payload = payload.filter(
+      (o) => o?.eventType?.toLowerCase().includes(eventType_contains.toLowerCase())
     ));
   }
 


### PR DESCRIPTION
### Jira Ticket:
CM-668

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-668

### Description:
Added 4 new custom filters to park-access-status
1. eventType
2. eventType_ne
3. eventType_contains (case-insensitive)
4. accessStatus_contains (case-insensitive)

Also, some other refactoring and optimizations are included:

1. Refactored the query to allow additional filters against protected-areas to be combined with custom filters.
2. Reduced the number of fields returned for parkActivities and parkFacilities to make the endpoint return significantly less data. 
3. Custom filters are no longer mutually exclusive and can be combined 
