### PR TITLE
CM-730: Bugfix for incorrect access statuses in park search results

### DIFF
--- a/src/cms/src/api/protected-area/services/protected-area.js
+++ b/src/cms/src/api/protected-area/services/protected-area.js
@@ -62,7 +62,8 @@ module.exports = createCoreService("api::protected-area.protected-area", ({ stra
               SELECT j FROM (
                 SELECT adv."id", 
                 public_advisories_urgency_links.urgency_id, 
-                public_advisories_advisory_status_links.advisory_status_id
+                public_advisories_advisory_status_links.advisory_status_id,
+                public_advisories_access_status_links.access_status_id
               ) j
             ))
             FROM public_advisories_protected_areas_links
@@ -72,6 +73,10 @@ module.exports = createCoreService("api::protected-area.protected-area", ({ stra
               ON adv.id = public_advisories_urgency_links.public_advisory_id
             INNER JOIN public_advisories_advisory_status_links
               ON adv.id = public_advisories_advisory_status_links.public_advisory_id
+            INNER JOIN public_advisories_access_status_links
+              ON adv.id = public_advisories_access_status_links.public_advisory_id
+            INNER JOIN access_statuses
+              ON access_statuses.id = public_advisories_access_status_links.access_status_id
             WHERE public_advisories_protected_areas_links.protected_area_id = protected_areas.id
               AND adv.published_at IS NOT NULL
           ) AS "advisories"`

--- a/src/cms/src/api/protected-area/services/protected-area.js
+++ b/src/cms/src/api/protected-area/services/protected-area.js
@@ -75,8 +75,6 @@ module.exports = createCoreService("api::protected-area.protected-area", ({ stra
               ON adv.id = public_advisories_advisory_status_links.public_advisory_id
             INNER JOIN public_advisories_access_status_links
               ON adv.id = public_advisories_access_status_links.public_advisory_id
-            INNER JOIN access_statuses
-              ON access_statuses.id = public_advisories_access_status_links.access_status_id
             WHERE public_advisories_protected_areas_links.protected_area_id = protected_areas.id
               AND adv.published_at IS NOT NULL
           ) AS "advisories"`

--- a/src/gatsby/src/components/park/parkAccessStatus.js
+++ b/src/gatsby/src/components/park/parkAccessStatus.js
@@ -47,19 +47,19 @@ function ParkAccessFromAdvisories(advisories) {
   let parkStatusColor = "blue"
 
   for (let advisory of advisories) {
-    if (advisory.accessStatus) {
-      if (advisory.accessStatus.precedence) {
+      if (advisory.accessStatus?.precedence) {
         // advisory is coming from parks details page
         accessStatuses.push({
           precedence: advisory.accessStatus.precedence,
           color: advisory.accessStatus.color,
           text: advisory.accessStatus.accessStatus,
         })
-      } else {
-        // advisory is coming from explore page
-        // get accessStatus based on precedence
+      }
+      if (advisory.access_status_id) {
+        // advisory is coming from find-a-park
+        // get accessStatus based on access_status_id
         let thisStatus = accessStatusList.find(status => {
-          return status.strapi_id === advisory.accessStatus
+          return status.strapi_id === advisory.access_status_id
         })
         if (!thisStatus) {
           break
@@ -71,7 +71,6 @@ function ParkAccessFromAdvisories(advisories) {
           })
         }
       }
-    }
   }
 
   accessStatuses.sort((a, b) => {


### PR DESCRIPTION
### Jira Ticket:
CM-730

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-730

### Description:
Bugfix for incorrect access statuses in park search results.  A json attribute `access_status_id` was missing from the SQL query, and the naming standard also changed when we did the Strapi 4 update (it previously would have been called `accessStatus` not `access_status_id`).  
