### PR TITLE
NOBUG: Use username instead of email for keycloak auth

### DIFF
--- a/infrastructure/helm/bcparks/templates/secrets/cms-secret.yaml
+++ b/infrastructure/helm/bcparks/templates/secrets/cms-secret.yaml
@@ -13,15 +13,6 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
 stringData:
-  STRAPI_API_TOKEN: {{ randAlphaNum 50 | quote }}
-  STRAPI_API_USER_NAME: apiuser
-  STRAPI_API_USER_EMAIL: api@{{ randAlphaNum 10 }}.com
-  STRAPI_API_USER_PASSWORD: {{ randAlphaNum 50 | quote }}
-  STRAPI_ADMIN_USER: admin
-  STRAPI_ADMIN_PASSWORD: {{ randAlphaNum 50 | quote }}
-  STRAPI_ADMIN_FIRST_NAME: Admin
-  STRAPI_ADMIN_LAST_NAME: Account
-  STRAPI_ADMIN_EMAIL: admin@{{ randAlphaNum 10 }}.com
   ADMIN_JWT_SECRET: {{ randAscii 16 | b64enc | quote }}
   APP_KEYS: {{ randAscii 16 | b64enc }},{{ randAscii 16 | b64enc }},{{ randAscii 16 | b64enc }},{{ randAscii 16 | b64enc }}
   API_TOKEN_SALT: {{ randAscii 16 | b64enc | quote }}

--- a/src/cms/config/cron-tasks.js
+++ b/src/cms/config/cron-tasks.js
@@ -16,7 +16,7 @@ module.exports = {
   // BCGW replication is hourly at 10 minutes past the hour
   cronJob: {
     task: async ({ strapi }) => {
-      console.log("CRON STARTING");
+      const startTime = +new Date();
 
       // fetch advisory statuses
       const advisoryStatus = await strapi.entityService.findMany(
@@ -120,7 +120,7 @@ module.exports = {
         });
       }
 
-      console.log("CRON FINISHED");
+      strapi.log.info(`Strapi cron finished in ${+new Date() - startTime}ms`);
     },
     options: {
       rule: "*/2 * * * *",

--- a/src/cms/src/extensions/users-permissions/strategies/keycloak-users-permissions.js
+++ b/src/cms/src/extensions/users-permissions/strategies/keycloak-users-permissions.js
@@ -12,7 +12,6 @@ const AUTH_URL =
   process.env.STRAPI_SSO_AUTH_URL || "https://dev.loginproxy.gov.bc.ca/auth";
 
 const KEYCLOAK_AUTH_ROLES = ["submitter", "approver"];
-const API_USER_EMAIL = process.env.STRAPI_API_USER_EMAIL;
 
 const authenticate = async (ctx) => {
 
@@ -44,16 +43,11 @@ const authenticate = async (ctx) => {
               KEYCLOAK_AUTH_ROLES.includes(e)
             );
 
-            if (!API_USER_EMAIL) {
-              strapi.log.warn("API_USER_EMAIL value not set");
-              throw new Error("API_USER_EMAIL value not set");
-            }
-
             if (roleMatch) {
-              const users = await getService('user').fetchAll({ filters: { email: { $eqi: API_USER_EMAIL } }, populate: { role: "*" } });
+              const users = await getService('user').fetchAll({ filters: { username: { $eq: 'apiuser' } }, populate: { role: "*" } });
               user = users.length ? users[0] : null;
               if (user === null) {
-                strapi.log.error(`A user with email '${API_USER_EMAIL}' was not found in the User collection-type`);
+                strapi.log.error(`A user with usrname 'apiuser' was not found in the User collection-type`);
                 return { error: "API user account does not exist" };
               }
             } else {


### PR DESCRIPTION
### Jira Ticket:
CM-592

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-592

### Description:
Simplified logic to reduce local dev setup steps

This PR also 
- removes some openshift secrets that were only used during the Strapi v3 seed step
- includes a minor change to cron job logging

