### PR TITLE
CM-739: Fire bans in fire-zones not don't show in park-access-status

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-status.js
@@ -170,23 +170,6 @@ const getProtectedAreaStatus = async (ctx) => {
     }
   );
 
-  const campfireBanData = await strapi.entityService.findMany(
-    "api::fire-ban-prohibition.fire-ban-prohibition",
-    {
-      filters: {
-        prohibitionDescription: {
-          $containsi: "campfire",
-        },
-        fireCentre: {
-          id: {
-            $notNull: true,
-          },
-        },
-      },
-      populate: "*",
-    }
-  );
-
   let publicAdvisories = await getPublishedPublicAdvisories();
 
   let payload = entities.map((protectedArea) => {
@@ -264,41 +247,11 @@ const getProtectedAreaStatus = async (ctx) => {
     });
 
     // bans and prohibitions
-    let hasCampfireBan;
     let campfireBanNote = "";
-    let campfireBanEffectiveDate = null;
     if (protectedArea.hasCampfireBanOverride) {
-      hasCampfireBan = protectedArea.hasCampfireBan;
       campfireBanNote = "campfire ban set via manual override";
     } else {
-      for (const fireZone of protectedArea.fireZones) {
-        const fireBan = campfireBanData.find(
-          (f) => f.fireCentre.id === fireZone.fireCentre
-        );
-
-        if (fireBan) {
-          hasCampfireBan = true;
-          campfireBanEffectiveDate = fireBan.effectiveDate;
-          campfireBanNote = "campfire ban set via wildfire service";
-          break;
-        }
-      }
-    }
-
-    let hasSmokingBan;
-    if (protectedArea.hasSmokingBanOverride) {
-      hasSmokingBan = protectedArea.hasSmokingBan;
-    } else {
-      for (const fireZone of protectedArea.fireZones) {
-        const fireBan = campfireBanData.find(
-          (f) => f.fireCentre.id === fireZone.fireCentre
-        );
-
-        if (fireBan) {
-          hasSmokingBan = true;
-          break;
-        }
-      }
+      campfireBanNote = "campfire ban set via wildfire service";
     }
 
     return {
@@ -321,11 +274,11 @@ const getProtectedAreaStatus = async (ctx) => {
         getHasCampfiresFacility(protectedArea.parkFacilities)
       ),
 
-      hasCampfireBan: boolToYN(hasCampfireBan),
-      hasSmokingBan: boolToYN(hasSmokingBan),
+      hasCampfireBan: boolToYN(protectedArea.hasCampfireBan),
+      hasSmokingBan: boolToYN(protectedArea.hasCampfireBan),
       hasCampfireBanOverride: boolToYN(protectedArea.hasCampfireBanOverride),
       hasSmokingBanOverride: boolToYN(protectedArea.hasSmokingBanOverride),
-      campfireBanEffectiveDate: campfireBanEffectiveDate,
+      campfireBanEffectiveDate: protectedArea.campfireBanEffectiveDate,
       campfireBanRescindedDate: protectedArea.campfireBanRescindedDate,
       campfireBanNote: campfireBanNote,
       accessStatusEffectiveDate: publicAdvisory.effectiveDate,


### PR DESCRIPTION
### Jira Ticket:
CM-739

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-739

### Description:
Removed legacy code from the park-access-status view that looked up firebans by fire-centre. It now uses the `protectedArea.hasCampfireBan` value instead (which is populated by a cron job)
