### PR TITLE
CM-588: Add toggle for showing archived advisories

### DIFF
--- a/src/admin/src/components/composite/advisoryForm/AdvisoryForm.js
+++ b/src/admin/src/components/composite/advisoryForm/AdvisoryForm.js
@@ -9,8 +9,7 @@ import {
   Checkbox,
   FormControl,
   FormHelperText,
-  Button as Btn,
-  Tooltip,
+  Button as Btn
 } from "@material-ui/core";
 import MomentUtils from "@date-io/moment";
 import {
@@ -18,7 +17,6 @@ import {
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
 import Select from "react-select";
-import { withStyles } from "@material-ui/core/styles";
 import WarningIcon from "@material-ui/icons/Warning";
 import CloseIcon from "@material-ui/icons/Close";
 import AddIcon from "@material-ui/icons/Add";
@@ -36,6 +34,7 @@ import {
 
 import PrivateElement from "../../../auth/PrivateElement";
 import AdvisoryHistory from "../advisoryHistory/AdvisoryHistory";
+import LightTooltip from "../../shared/tooltip/LightTooltip";
 
 export default function AdvisoryForm({
   mode,
@@ -246,15 +245,6 @@ export default function AdvisoryForm({
     { label: "Weeks", value: "w" },
     { label: "Months", value: "M" },
   ];
-
-  const LightTooltip = withStyles(() => ({
-    tooltip: {
-      backgroundColor: "#fff",
-      color: "rgba(0, 0, 0, 0.87)",
-      boxShadow: "rgba(0, 0, 0, 0.35) 1px 1px 15px",
-      fontSize: 12,
-    },
-  }))(Tooltip);
 
   return (
     <MuiPickersUtilsProvider utils={MomentUtils}>

--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.css
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.css
@@ -51,6 +51,10 @@
 {
   color:#bdd9ed; 
 }
+.archivedIcon
+{
+  color:#bdd9ed; 
+}
 
 .warningRoundedIcon {
   color: gray;

--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
@@ -649,7 +649,7 @@ const getCurrentPublishedAdvisories = async (cmsData, setCmsData) => {
             />
           </div>
           <div className="col-xl-3 col-md-4 col-sm-12">
-            <FormControlLabel style={{ marginLeft: '5px' }} control={
+            <FormControlLabel className="ml-1" control={
               <Checkbox
                 checked={showArchived}
                 onChange={(e) => {
@@ -662,14 +662,14 @@ const getCurrentPublishedAdvisories = async (cmsData, setCmsData) => {
               />
             } label={
               <>
-                <small style={{ paddingRight: '6px' }}>
+                <small>
                   Show archived
                 </small>
                 <LightTooltip
                   arrow
                   title="Unpublished advisories are archived after 30 days of inactivity. Check the box to show
                    the 2000 most recent advisories including archived.">
-                  <HelpIcon className="helpIcon" />
+                  <HelpIcon className="helpIcon ml-1" />
                 </LightTooltip>
               </>
             } />

--- a/src/admin/src/components/shared/tooltip/LightTooltip.js
+++ b/src/admin/src/components/shared/tooltip/LightTooltip.js
@@ -1,0 +1,11 @@
+import Tooltip from "@material-ui/core/Tooltip";
+import { withStyles } from "@material-ui/core/styles";
+
+export default withStyles(() => ({
+    tooltip: {
+        backgroundColor: "#fff",
+        color: "rgba(0, 0, 0, 0.87)",
+        boxShadow: "rgba(0, 0, 0, 0.35) 1px 1px 15px",
+        fontSize: 12,
+    },
+}))(Tooltip);  

--- a/src/admin/src/utils/AdvisoryDataUtil.js
+++ b/src/admin/src/utils/AdvisoryDataUtil.js
@@ -1,0 +1,87 @@
+import { cmsAxios } from "../axios_config";
+import moment from "moment";
+import qs from "qs";
+
+const advisoryArchiveDays = 30;
+
+export function getLatestPublicAdvisoryAudits(keycloak, showArchived) {
+
+    let archiveDate = moment().subtract(advisoryArchiveDays, 'days').format('YYYY-MM-DD');
+
+    let showArchivedFilter = {};
+
+    if (!showArchived) {
+        showArchivedFilter = {
+            $or: [
+                { advisoryStatus: { code: 'PUB' } },
+                { updatedAt: { $gt: archiveDate } }
+            ]
+        };
+    }
+    const query = qs.stringify({
+        fields: ['advisoryNumber', 'advisoryDate', 'title', 'effectiveDate', 'endDate', 'expiryDate', 'updatedAt'],
+        populate: {
+            protectedAreas: {
+                fields: ['orcs', 'protectedAreaName'],
+            },
+            advisoryStatus: {
+                fields: ['advisoryStatus', 'code'],
+            },
+            eventType: {
+                fields: ['eventType'],
+            },
+            urgency: {
+                fields: ['urgency'],
+            },
+            regions: {
+                fields: ['regionName'],
+            }
+        },
+        filters: {
+            $and: [
+                { isLatestRevision: true },
+                showArchivedFilter
+            ]
+        },
+        pagination: {
+            limit: 2000
+        },
+        sort: ['advisoryDate:DESC']
+    }, {
+        encodeValuesOnly: true,
+    });
+    return cmsAxios.get(`public-advisory-audits?${query}`, {
+        headers: {
+            Authorization: `Bearer ${keycloak.token}`
+        }
+    })
+}
+
+export function updatePublicAdvisories(publicAdvisories, managementAreas) {
+    const today = moment(new Date()).tz("America/Vancouver").toISOString();
+    let archiveDate = moment().subtract(advisoryArchiveDays, 'days').format('YYYY-MM-DD');
+
+    const regionParksCount = managementAreas.reduce((region, item) => {
+        region[item.region?.id] = (region[item.region?.id] || 0) + item.protectedAreas?.length;
+        return region;
+    }, {});
+
+    return publicAdvisories.map((publicAdvisory) => {
+        publicAdvisory.expired = publicAdvisory.expiryDate < today ? "Y" : "N";
+        publicAdvisory.associatedParks = publicAdvisory.protectedAreas.map((p) => p.protectedAreaName).join(", ")
+            + publicAdvisory.regions.map((r) => r.regionName).join(", ");
+
+        let regionsWithParkCount = [];
+        if (publicAdvisory?.regions?.length > 0) {
+            publicAdvisory.regions.forEach((region) => {
+                region.count = regionParksCount[region.id];
+                regionsWithParkCount = [...regionsWithParkCount, region];
+            });
+            publicAdvisory.regions = regionsWithParkCount;
+        }
+
+        publicAdvisory.archived = publicAdvisory.advisoryStatus.code !== 'PUB' && publicAdvisory.updatedAt < archiveDate;
+
+        return publicAdvisory;
+    });
+}

--- a/src/admin/src/utils/CmsDataUtil.js
+++ b/src/admin/src/utils/CmsDataUtil.js
@@ -60,9 +60,17 @@ export function getSections(cmsData, setCmsData) {
 }
 
 export function getManagementAreas(cmsData, setCmsData) {
+    const fields = qs.stringify({
+        fields: ['id', 'managementAreaName'],
+        populate: {
+            protectedAreas: { fields: ['id', 'protectedAreaName', 'orcs'] },
+            section: { fields: ['id'] },
+            region: { fields: ['id'] }
+        }
+    });
     if (!cmsData.managementAreas) {
         const result = cmsAxios
-            .get(`/management-areas?${querySort("managementAreaName")}&populate=*`)
+            .get(`/management-areas?${querySort("managementAreaName")}&${fields}`)
             .then((res) => {
                 const data = cmsData;
                 data.managementAreas = res.data.data;

--- a/src/cms/src/api/park-name/services/park-name.js
+++ b/src/cms/src/api/park-name/services/park-name.js
@@ -37,6 +37,7 @@ module.exports = createCoreService(
         .query("api::park-name.park-name")
         .findMany({
           populate: true,
+          orderBy: 'parkName',
         });
 
       return parkNameData.map(


### PR DESCRIPTION
### Jira Ticket:
CM-588

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-588

### Description:
Added a "show archived" checkbox to the advisory dashboard.  By default, any unpublished advisories that have not been modified for more than 30 days will now be hidden.  
Additional changes were also made to populate fewer fields in Strapi REST requests.

