### PR TITLE
CM-588: UX updates to "Show archived" filter

### DIFF
--- a/src/admin/src/utils/AdvisoryDataUtil.js
+++ b/src/admin/src/utils/AdvisoryDataUtil.js
@@ -3,19 +3,23 @@ import moment from "moment";
 import qs from "qs";
 
 const advisoryArchiveDays = 30;
+const archiveDate = moment().subtract(advisoryArchiveDays, 'days').format('YYYY-MM-DD');
 
 export function getLatestPublicAdvisoryAudits(keycloak, showArchived) {
 
-    let archiveDate = moment().subtract(advisoryArchiveDays, 'days').format('YYYY-MM-DD');
-
-    let showArchivedFilter = {};
+    let advisoryFilter = {};
 
     if (!showArchived) {
-        showArchivedFilter = {
+        advisoryFilter = {
             $or: [
                 { advisoryStatus: { code: 'PUB' } },
                 { updatedAt: { $gt: archiveDate } }
             ]
+        };
+    } else {
+        const modifiedDate = moment().subtract(18, 'months').format('YYYY-MM-DD');
+        advisoryFilter = {
+            updatedAt: { $gt: modifiedDate }
         };
     }
     const query = qs.stringify({
@@ -40,7 +44,7 @@ export function getLatestPublicAdvisoryAudits(keycloak, showArchived) {
         filters: {
             $and: [
                 { isLatestRevision: true },
-                showArchivedFilter
+                advisoryFilter
             ]
         },
         pagination: {
@@ -59,7 +63,6 @@ export function getLatestPublicAdvisoryAudits(keycloak, showArchived) {
 
 export function updatePublicAdvisories(publicAdvisories, managementAreas) {
     const today = moment(new Date()).tz("America/Vancouver").toISOString();
-    let archiveDate = moment().subtract(advisoryArchiveDays, 'days').format('YYYY-MM-DD');
 
     const regionParksCount = managementAreas.reduce((region, item) => {
         region[item.region?.id] = (region[item.region?.id] || 0) + item.protectedAreas?.length;


### PR DESCRIPTION
### Jira Ticket:
CM-588

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/CM-588

### Description:
- Instead of returning up to 2000 records, return advisories up to 18 months old. This is easier to communicate in the tooltip, and it is still well under the API limit.
- Use sessionStorage instead of localStorage to save state of the checkbox. This ensures that it keeps reverting to the shorter list and doesn't get stuck on the longer list. 
