### PR TITLE
NOBUG: Adjust HPA thresholds

### DIFF
--- a/infrastructure/helm/bcparks/templates/cms/cms-hpa.yaml
+++ b/infrastructure/helm/bcparks/templates/cms/cms-hpa.yaml
@@ -21,6 +21,12 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.cms.hpa.memoryUtilizationThreshold }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.cms.hpa.cpuUtilizationThreshold }}
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0

--- a/infrastructure/helm/bcparks/templates/public/public-hpa.yaml
+++ b/infrastructure/helm/bcparks/templates/public/public-hpa.yaml
@@ -21,6 +21,12 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.public.hpa.memoryUtilizationThreshold }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.public.hpa.cpuUtilizationThreshold }}
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -18,7 +18,7 @@ cms:
       memory: 2Gi
     requests:
       cpu: 250m
-      memory: 500Mi
+      memory: 600Mi
 
   env:
     environment: prod

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -27,6 +27,8 @@ cms:
   hpa:
     minReplicas: 2
     maxReplicas: 4
+    cpuUtilizationThreshold: 25
+    memoryUtilizationThreshold: 80
 
 admin:
   env:
@@ -40,7 +42,7 @@ patroni:
       memory: 2Gi
     requests:
       cpu: 250m
-      memory: 250Mi
+      memory: 500Mi
   replicas: 3
 
   pvc:
@@ -68,4 +70,5 @@ public:
   hpa:
     minReplicas: 2
     maxReplicas: 8
-    memoryUtilizationThreshold: 60
+    cpuUtilizationThreshold: 35
+    memoryUtilizationThreshold: 80

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -14,8 +14,8 @@ images:
 cms:
   resources:
     limits:
-      cpu: "1"
-      memory: 2Gi
+      cpu: 750m
+      memory: 1250Mi
     requests:
       cpu: 250m
       memory: 600Mi

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -73,7 +73,8 @@ cms:
     minReplicas: 1
     # Default to 1 max replica on dev, overriden in test and prod envs
     maxReplicas: 1
-    memoryUtilizationThreshold: 60
+    cpuUtilizationThreshold: 50
+    memoryUtilizationThreshold: 65
 
 patroni:
   componentName: patroni
@@ -168,6 +169,7 @@ public:
     minReplicas: 1
     # Default to 1 max replica on dev, overriden in test and prod envs
     maxReplicas: 1
+    cpuUtilizationThreshold: 50
     memoryUtilizationThreshold: 75
 
 backup:


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Adjusting memory limits and horizontal pod autoscaler settings to try to fix the issue where pods were never scaling back down after scaling up.

The approach is based on a comment in this Stack overflow post: https://stackoverflow.com/a/58571471/2616170
_"An issue might be that you're using the memory utilization as a metric, which is not a good autoscaling metric."_
I have increased the memory thresholds and also added CPU as a second metric.  

The memory `request` level for Patroni was also increased, because it was noted that the "Lead" pod was continually running at a level above the `request` setting