### PR TITLE
CM-763: Sort dashboard advisories by archived, then status

### DIFF
--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
@@ -343,6 +343,9 @@ const getCurrentPublishedAdvisories = async (cmsData, setCmsData) => {
     {
       field: "advisoryStatus.advisoryStatus",
       title: "Status",
+      customSort: (a, b) => a.archived === b.archived
+        ? a.advisoryStatus.advisoryStatus < b.advisoryStatus.advisoryStatus ? -1 : 1
+        : a.archived < b.archived ? 1 : -1,
       cellStyle: {
         textAlign: "center",
       },
@@ -430,6 +433,7 @@ const getCurrentPublishedAdvisories = async (cmsData, setCmsData) => {
     {
       field: "title",
       title: "Headline",
+      customSort: (a, b) => a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1,
       headerStyle: { width: 400 },
       cellStyle: { width: 400 },
       render: (rowData) => {


### PR DESCRIPTION
### Jira Ticket:
CM-763

### Description:
- Changed the sort toggle on the "Status" column to sort by `archived` first, then by `advisoryStatus`
- Changed the sort toggle on the "Headline" column to be case insensitive
