### PR TITLE
CM-766: Fix conflict between archived filter and region/park filters

### DIFF
--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
@@ -64,13 +64,13 @@ export default function AdvisoryDashboard({
 
   useEffect(() => {
     filterAdvisoriesByRegionId(selectedRegionId);
-  }, [selectedRegionId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedRegionId, originalPublicAdvisories]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (selectedParkId !== -1) {
       filterAdvisoriesByParkId(selectedParkId);
     }
-  }, [selectedParkId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedParkId, regionalPublicAdvisories]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Preserve filters
   const savedFilters = JSON.parse(localStorage.getItem('advisoryFilters'));


### PR DESCRIPTION
### Jira Ticket:
CM-766

### Description:
Fixed an issue where the archived toggle on the advisory dashboard (in the Staff Portal) was not re-applying the region and park filters.  
