### PR TITLE
NOBUG: Optimized the query on park pages for firebans

### DIFF
--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -52,7 +52,8 @@ const loadProtectedArea = (apiBaseUrl, orcsId) => {
       orcs: {
         $eq: orcsId
       }
-    }
+    },
+    fields: ['hasCampfireBan']
   }, {
     encodeValuesOnly: true,
   })


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Added a `fields` list to the query, so it only returns fields that are used by the Gatsby application code.
This query gets run every time a park page is loaded, so it's best to make it as fast as possible in terms of IO, network traffic and overall load on Strapi. 

