### PR TITLE
CM-652: Add a groupLabel field to Access-Status

### DIFF
--- a/src/cms/src/api/access-status/content-types/access-status/schema.json
+++ b/src/cms/src/api/access-status/content-types/access-status/schema.json
@@ -21,6 +21,9 @@
     },
     "color": {
       "type": "string"
+    },
+    "groupLabel": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CM-652

### Description:
Added a groupLabel field to the access-status collection, so it can be released to prod before CM-652 is implemented and pre-populated with data or populated with a migration during the next release. 
