### PR TITLE
CM-776: Update megamenu styling

### DIFF
--- a/src/gatsby/src/archieved/intro.js
+++ b/src/gatsby/src/archieved/intro.js
@@ -1,3 +1,6 @@
+// This page is archived
+// If you need to publish this page, you need to move this file to under the pages directry
+
 import React from "react"
 import { graphql } from "gatsby"
 

--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react"
 import PropTypes from "prop-types"
 import { Link, navigate } from "gatsby"
 import { StaticImage } from "gatsby-plugin-image"
+import ExpandCircleDownIcon from '@mui/icons-material/ExpandCircleDown'
 
 import "../styles/megaMenu/megaMenu.scss"
 
@@ -224,6 +225,7 @@ const MegaMenu = ({ content, menuMode }) => {
                 <li className="menu-button menu-header">
                   <Link className="menu-button__title" to={item.url || "/"} role="menuitem">
                     {item.title}
+                    <ExpandCircleDownIcon className="menu-button__title--icon" />
                   </Link>
                 </li>
                 {item.strapi_children.map((page, index) => (

--- a/src/gatsby/src/components/park/about.js
+++ b/src/gatsby/src/components/park/about.js
@@ -32,12 +32,16 @@ export default function About({
           <>
             <h3>{capitalizeFirstLetter(`${park.type} details`)}</h3>
             <ul>
-              <li>
-                <strong>Date established:</strong> {formattedEstablishedDate}
-              </li>
-              <li>
-                <strong>Size:</strong> {park.totalArea} hectares
-              </li>
+              {park.establishedDate && (
+                <li>
+                  <strong>Date established:</strong> {formattedEstablishedDate}
+                </li>
+              )}
+              {park.totalArea && (
+                <li>
+                  <strong>Size:</strong> {park.totalArea} hectares
+                </li>
+              )}
               {biogeoclimaticZones?.length > 0 && (
                 <li className="ecological-list">
                   <strong>

--- a/src/gatsby/src/components/park/campingDetails.js
+++ b/src/gatsby/src/components/park/campingDetails.js
@@ -88,7 +88,7 @@ export default function CampingDetails({ data }) {
                   .filter(count => isShown(count, parkOperation))
                   .map((count, index) => (
                     <dd key={index} className="mb-0">
-                      Total {count.display.toLowerCase()}:{" "}
+                      Total {count.display.includes("RV") ? count.display : count.display.toLowerCase()}:{" "}
                       {parkOperation[count.countVar]}
                     </dd>
                   ))}

--- a/src/gatsby/src/pages/about/management-plans/approved.js
+++ b/src/gatsby/src/pages/about/management-plans/approved.js
@@ -24,7 +24,7 @@ const DocumentLink = ({ park }) => {
         checkRelation(park.orcs, site.orcsSiteNumber) && (
           titles.push({
             index: index,
-            title: `${park.protectedAreaName} - ${site.siteName} ${(doc.documentType?.documentType)?.toLowerCase()} (${calcYear(doc.documentDate)})`
+            title: `${park.protectedAreaName} – ${site.siteName} ${(doc.documentType?.documentType)?.toLowerCase()} (${calcYear(doc.documentDate)})`
           })
         ))
     ) : (

--- a/src/gatsby/src/pages/about/management-plans/approved.js
+++ b/src/gatsby/src/pages/about/management-plans/approved.js
@@ -138,7 +138,7 @@ const ApprovedListPage = () => {
       <div className="max-width-override">
         <Header mode="internal" content={menuContent} />
       </div>
-      <div id="sr-content" className="d-none d-md-block static-content-container page-breadcrumbs">
+      <div id="sr-content" className="d-block static-content-container page-breadcrumbs">
         <Breadcrumbs separator="›" aria-label="breadcrumb">
           {breadcrumbs}
         </Breadcrumbs>

--- a/src/gatsby/src/styles/advisories/advisoryCard.scss
+++ b/src/gatsby/src/styles/advisories/advisoryCard.scss
@@ -83,6 +83,7 @@
   background: #f2f2f2 !important;
   a {
     color: $colorBlue;
+    margin-top: 8px;
   }
 }
 
@@ -109,6 +110,7 @@
 
 .btn-link {
   color: $colorBlue;
+  margin-bottom: 8px;
   padding: 0;
   &:hover, &:focus {
     color: $colorBlue !important;

--- a/src/gatsby/src/styles/global.scss
+++ b/src/gatsby/src/styles/global.scss
@@ -109,7 +109,7 @@ blockquote {
   font-weight: 700;
   border: none;
   border-radius: 4px;
-  margin: 16px 0 32px;
+  margin: 16px 0;
   padding: 20px;
 }
 

--- a/src/gatsby/src/styles/megaMenu/megaMenu.scss
+++ b/src/gatsby/src/styles/megaMenu/megaMenu.scss
@@ -375,7 +375,7 @@ nav {
     }
 
     .menu-level--1 {
-      border-right: solid 1px $colorGold;
+      border-right: solid 2px rgba(0, 0, 0, 0.2);
 
       .menu-button--selected {
         border-left: solid 4px $colorGold;
@@ -426,7 +426,7 @@ nav {
       transition: background-color 0.3s;
       
       .menu-button__title {
-        color: #000;
+        color: $colorBlue;
         display: block;
         width: 100%;
         padding: 8px 10px;
@@ -439,10 +439,27 @@ nav {
       }
       &.menu-header {
         .menu-button__title {
-          color: $colorBlueMed;
+          position: relative;
+          color: $colorBlue;
           font-weight: bold;
-          margin-bottom: 4px;
           font-size: 1.25rem;
+          margin-bottom: 4px;
+          &--icon {
+            width: 1.25rem;
+            height: 1.25rem;
+            font-size: 1.25rem;
+            rotate: 270deg;
+            margin: 0 0 4px 8px;
+          }
+          &::after {
+            position: absolute;
+            content: "";
+            background-color: $colorGold;
+            height: 2px;
+            width: 50px;
+            left: 10px;
+            bottom: 0;
+          }
         }
       }
     }

--- a/src/gatsby/src/styles/megaMenu/megaMenu.scss
+++ b/src/gatsby/src/styles/megaMenu/megaMenu.scss
@@ -409,7 +409,7 @@ nav {
     .menu-children {
       transition: height 0.3s;
       opacity: 1;
-      height: 475px;
+      min-height: 475px;
     }
     .menu-children--unselected {
       display: none;

--- a/src/gatsby/src/styles/megaMenu/megaMenu.scss
+++ b/src/gatsby/src/styles/megaMenu/megaMenu.scss
@@ -154,11 +154,18 @@ nav {
       color: #000;
 
       .menu-button__title {
-        color: #000;
+        color: $colorBlue;
         width: 100%;
         padding: 8px 20px;
         display: block;
         line-height: 40px;
+        &--icon {
+          width: 1.25rem;
+          height: 1.25rem;
+          font-size: 1.25rem;
+          rotate: 270deg;
+          margin: 0 0 4px 8px;
+        }
       }
       .menu-button__arr {
         float: right;
@@ -188,7 +195,6 @@ nav {
       padding-left: 10px;
       background: #eee;
       a {
-        color: $colorBlueMed !important;
         font-size: 1.2rem;
         font-weight: 700;
       }
@@ -440,17 +446,9 @@ nav {
       &.menu-header {
         .menu-button__title {
           position: relative;
-          color: $colorBlue;
           font-weight: bold;
           font-size: 1.25rem;
           margin-bottom: 4px;
-          &--icon {
-            width: 1.25rem;
-            height: 1.25rem;
-            font-size: 1.25rem;
-            rotate: 270deg;
-            margin: 0 0 4px 8px;
-          }
           &::after {
             position: absolute;
             content: "";
@@ -459,6 +457,13 @@ nav {
             width: 50px;
             left: 10px;
             bottom: 0;
+          }
+          &--icon {
+            width: 1.25rem;
+            height: 1.25rem;
+            font-size: 1.25rem;
+            rotate: 270deg;
+            margin: 0 0 4px 8px;
           }
         }
       }

--- a/src/gatsby/src/styles/megaMenu/megaMenu.scss
+++ b/src/gatsby/src/styles/megaMenu/megaMenu.scss
@@ -366,9 +366,9 @@ nav {
       }
     }
     .menu-level-0-children.menu-children--unselected {
-      transition: opacity 0.3s, height 0.9s;
+      transition: opacity 0.3s, min-height 0.9s;
       opacity: 0;
-      height: 0px;
+      min-height: 0px;
       padding: 0px;
       display: block;
       nav,
@@ -407,7 +407,7 @@ nav {
       display: none;
     }
     .menu-children {
-      transition: height 0.3s;
+      transition: opacity 0.3s, min-height 0.3s;
       opacity: 1;
       min-height: 475px;
     }

--- a/src/gatsby/src/templates/parkSubPage.js
+++ b/src/gatsby/src/templates/parkSubPage.js
@@ -60,6 +60,8 @@ export default function ParkSubPage({ data }) {
     useRef(null),
     useRef(null),
     useRef(null),
+    useRef(null),
+    useRef(null),
   ]
 
   const activeSection = useScrollSpy({


### PR DESCRIPTION
### Jira Ticket:
CM-364
CM-367
CM-484
CM-731
CM-746
CM-747
CM-753
CM-772
CM-774
CM-776

### Description:
- CM-364: Hide park size if there is no data
- CM-367: Change rv in uppercase
- CM-484: Archive the intro page
  - Needed to move `intro.js` from `pages/` to `archived/` because of the Gatsby folder structure
  https://www.gatsbyjs.com/docs/reference/gatsby-project-structure/#folders
  - Did not delete `intro.js` as the team wanted to unpublish the intro page/beta-landing page
- CM-731: Add breadcrumbs to management plan page on mobile 
- CM-746: Fix spacing issue under the standard callout text
- CM-747: Fix spacing issues on the active advisories page
- CM-753: Change megamenu height
- CM-772: Change hyphen to en dash between park name and site name on approved page
- CM-774: Add more useref to parksubpage sections
- CM-776: Update megamenu styling based on the new mockup
