### PR TITLE
CM-701: Reduced header image height on park pages

### DIFF
--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -403,7 +403,16 @@
 }
 
 .park-photo {
-  height: 400px;
+  height: 150px;
+  @media (min-width: $smBreakpoint) {
+    height: 200px;
+  }
+  @media (min-width: $mdBreakpoint) {
+    height: 300px;
+  }
+  @media (min-width: $lgBreakpoint) {
+    height: 400px;
+  }
   overflow: hidden;
   position: relative;
 

--- a/src/gatsby/src/styles/staticContent1.scss
+++ b/src/gatsby/src/styles/staticContent1.scss
@@ -1,10 +1,5 @@
 @import "variables.scss";
 
-.static-content-container.page-breadcrumbs {
-  padding-top: 15px;
-  padding-bottom: 0px;
-}
-
 .static-content-container {
   max-width: 1140px;
   padding: 20px 40px 35px 40px;
@@ -63,15 +58,23 @@
     }
     @media (min-width: 576px) {
       height: 455px;
-      order: 2
+      order: 3;
+    }
+  }
+  .page-breadcrumbs {
+    margin: 16px;
+    order: 2;
+    @media (min-width: 576px) {
+      margin: 0 0 36px;
+      order: 1;
     }
   }
   .header-title {
     margin: 16px;
-    order: 2;
+    order: 3;
     @media (min-width: 576px) {
       margin: 0 0 32px;
-      order: 1;
+      order: 2;
     }
   }
 }

--- a/src/gatsby/src/templates/parkSubPage.js
+++ b/src/gatsby/src/templates/parkSubPage.js
@@ -89,12 +89,12 @@ export default function ParkSubPage({ data }) {
       <div className="max-width-override" ref={sectionRefs[0]}>
         <Header mode="internal" content={menuContent} />
       </div>
-      <div id="sr-content" className="d-none d-md-block static-content-container page-breadcrumbs">
-        <Breadcrumbs separator="›" aria-label="breadcrumb" className="p20t">
-          {breadcrumbs}
-        </Breadcrumbs>
-      </div>
       <div className="static-content--header">
+        <div id="sr-content" className="page-breadcrumbs">
+          <Breadcrumbs separator="›" aria-label="breadcrumb" className="p20t">
+            {breadcrumbs}
+          </Breadcrumbs>
+        </div>
         {header?.imageUrl && (
           <div className="header-image-wrapper">
             <img

--- a/src/gatsby/src/templates/staticContent1.js
+++ b/src/gatsby/src/templates/staticContent1.js
@@ -149,13 +149,13 @@ export default function StaticContent1({ pageContext }) {
       <div className="max-width-override" ref={sectionRefs[0]}>
         <Header mode="internal" content={menuContent} />
       </div>
-      <div id="sr-content" className="d-none d-md-block static-content-container page-breadcrumbs">
-        <Breadcrumbs separator="›" aria-label="breadcrumb">
-          {renderBreadcrumbs(menuContent, pageContext?.page)}
-        </Breadcrumbs>
-      </div>
       {hasTitle && (
         <div className="static-content--header">
+          <div id="sr-content" className="page-breadcrumbs">
+            <Breadcrumbs separator="›" aria-label="breadcrumb">
+              {renderBreadcrumbs(menuContent, pageContext?.page)}
+            </Breadcrumbs>
+          </div>
           {headerContent.imageUrl && (
             <div className="header-image-wrapper">
               <img


### PR DESCRIPTION
### Jira Ticket:
CM-701
CM-702

### Description:
Changed parks page header photos to be less tall, smoothed it out responsively. Still not consistent with non-park pages.
Added breadcrumbs to mobile view for non-parks pages. Tried to smooth out spacing a bit, but still very different than park pages.
