### PR TITLE
CM-522: Remove hover state on mobile

### DIFF
--- a/src/gatsby/src/components/scrollToTop.js
+++ b/src/gatsby/src/components/scrollToTop.js
@@ -20,7 +20,7 @@ const Root = styled('div')((
     position: "fixed",
     bottom: "2vh",
     color: "#ffffff",
-    opacity: "0.75",
+    opacity: "1",
     backgroundColor: "#003366",
     boxShadow: "none",
     "&:hover, &.Mui-focusVisible": {
@@ -34,6 +34,7 @@ const Root = styled('div')((
     },
     [theme.breakpoints.up("md")]: {
       right: "2%",
+      opacity: "0.75",
     },
   }
 }));


### PR DESCRIPTION
### Jira Ticket:
CM-522

### Description:
- Remove the hover state (change of opacity) on tablet and mobile since it requires users to double-tap