### PR TITLE
CM-484: Archive the intro page

### DIFF
--- a/src/gatsby/src/archived/intro.js
+++ b/src/gatsby/src/archived/intro.js
@@ -1,3 +1,6 @@
+// This page is archived
+// If you need to publish this page, you need to move this file to under the pages directry
+
 import React from "react"
 import { graphql } from "gatsby"
 


### PR DESCRIPTION
### Jira Ticket:
CM-484

### Description:
- Needed to move intro.js from `pages/` to `archived/` because of the Gatsby folder structure
https://www.gatsbyjs.com/docs/reference/gatsby-project-structure/#folders
- Did not delete intro.js as the team wanted to unpublish the intro page/beta-landing page
