### PR TITLE
NOBUG: Update helm config to tune Patroni and Strapi

### DIFF
--- a/infrastructure/helm/bcparks/templates/patroni/patroni-statefulset.yaml
+++ b/infrastructure/helm/bcparks/templates/patroni/patroni-statefulset.yaml
@@ -113,9 +113,11 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           readinessProbe:
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 4
+            initialDelaySeconds: 10
+            timeoutSeconds: 20
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
             exec:
               command:
                 - /usr/share/scripts/patroni/health_check.sh

--- a/infrastructure/helm/bcparks/values-alpha-test.yaml
+++ b/infrastructure/helm/bcparks/values-alpha-test.yaml
@@ -20,10 +20,10 @@ images:
 cms:
   resources:
     limits:
-      cpu: "1"
+      cpu: 500m
       memory: 2Gi
     requests:
-      cpu: 250m
+      cpu: 125m
       memory: 250Mi
 
   env:

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -18,17 +18,17 @@ cms:
       memory: 1250Mi
     requests:
       cpu: 250m
-      memory: 600Mi
+      memory: 700Mi
 
   env:
     environment: prod
     externalUrl: https://cms.bcparks.ca
 
   hpa:
-    minReplicas: 2
+    minReplicas: 3
     maxReplicas: 4
     cpuUtilizationThreshold: 25
-    memoryUtilizationThreshold: 80
+    memoryUtilizationThreshold: 85
 
 admin:
   env:
@@ -38,11 +38,11 @@ admin:
 patroni:
   resources:
     limits:
-      cpu: 500m
+      cpu: 1
       memory: 2Gi
     requests:
       cpu: 250m
-      memory: 500Mi
+      memory: 1Gi
   replicas: 3
 
   pvc:

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -14,11 +14,11 @@ images:
 cms:
   resources:
     limits:
-      cpu: 750m
+      cpu: 500m
       memory: 1250Mi
     requests:
-      cpu: 250m
-      memory: 700Mi
+      cpu: 125m
+      memory: 750Mi
 
   env:
     environment: prod
@@ -27,7 +27,7 @@ cms:
   hpa:
     minReplicas: 3
     maxReplicas: 4
-    cpuUtilizationThreshold: 25
+    cpuUtilizationThreshold: 50
     memoryUtilizationThreshold: 85
 
 admin:

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -25,7 +25,7 @@ cms:
     externalUrl: https://cms.bcparks.ca
 
   hpa:
-    minReplicas: 3
+    minReplicas: 2
     maxReplicas: 4
     cpuUtilizationThreshold: 50
     memoryUtilizationThreshold: 85

--- a/infrastructure/helm/bcparks/values-test.yaml
+++ b/infrastructure/helm/bcparks/values-test.yaml
@@ -14,10 +14,10 @@ images:
 cms:
   resources:
     limits:
-      cpu: "1"
+      cpu: 500m
       memory: 2Gi
     requests:
-      cpu: 250m
+      cpu: 125m
       memory: 250Mi
 
   env:

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -43,10 +43,10 @@ cms:
 
   resources:
     limits:
-      cpu: "1"
+      cpu: 500m
       memory: 2Gi
     requests:
-      cpu: 250m
+      cpu: 125m
       memory: 250Mi
 
   env:

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -62,7 +62,7 @@ cms:
     smtpReplyTo: noreply@gov.bc.ca
     cacheEnabled: true
     cacheType: redis
-    cacheTtl: 300000
+    cacheTtl: 1800000
     enableGraphQLPlayground: true
 
   service:


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Updated helm settings to address issues with Strapi and Patroni

1. Increased request memory, minReplicas and memoryUtilizationThreshold for Strapi to to make strapi shut down extra pods faster, but always keep at least 3 running.
2. Increased memory and cpu for patroni
3. Adjusted health checks for patroni so it will restart itself less often
4. Increased rest cache ttl from 5 minutes to 30 minutes

NOTE: these changes are already on prod
