### PR TITLE
CM-802: Optimize the query for the active advisories page

### DIFF
--- a/src/cms/src/api/public-advisory/services/public-advisory.js
+++ b/src/cms/src/api/public-advisory/services/public-advisory.js
@@ -19,20 +19,20 @@ const buildQuery = function (query) {
                 ]
             };
         } else if (query._searchType === "park") {
-            textSearch = { protectedAreas: { parkNames: { parkName: { $containsi: query.queryText } } } };
+            textSearch = { protectedAreas: { protectedAreaName: { $containsi: query.queryText } } };
         } else {
             textSearch = {
                 $or: [
                     { title: { $containsi: query.queryText } },
                     { description: { $containsi: query.queryText } },
-                    { protectedAreas: { parkNames: { parkName: { $containsi: query.queryText } } } }
+                    { protectedAreas: { protectedAreaName: { $containsi: query.queryText } } }
                 ]
             };
         }
     }
 
     if (query._eventType && query._eventType.length > 0) {
-        typeSearch = { eventType: { eventType: { $containsi: query._eventType } } };
+        typeSearch = { eventType: { eventType: { $eq: query._eventType } } };
     }
 
     query.filters = {

--- a/src/gatsby/src/archived/intro.js
+++ b/src/gatsby/src/archived/intro.js
@@ -1,3 +1,6 @@
+// This page is archived
+// If you need to publish this page, you need to move this file to under the pages directry
+
 import React from "react"
 import { graphql } from "gatsby"
 

--- a/src/gatsby/src/components/advisories/advisoryFilter.js
+++ b/src/gatsby/src/components/advisories/advisoryFilter.js
@@ -167,7 +167,7 @@ const AdvisoryFilter = ({
             options={eventTypes}
             getOptionLabel={(option) => option.label}
             onChange={(event, obj) => {
-                handleTypeFilterChange(obj ? obj.value.toLowerCase() : defaultEventType.value)
+                handleTypeFilterChange(obj ? obj.value : defaultEventType.value)
               }
             }
             renderInput={(params) =>

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -82,7 +82,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   
         const formattedEventTypes = response.data.data.map((obj) => ({
           label: obj.eventType,
-          value: obj.eventType.toLowerCase(),
+          value: obj.eventType,
         }));
   
         formattedEventTypes.splice(0, 0, defaultAdvisoryEventType);


### PR DESCRIPTION
### Jira Ticket:
CM-802

### Description:
The query on the active advisories page has been slower since an advisory was added which impacts 1023 separated protected areas.  This change will make two updates to the query to make it faster

- Search in protectedAreaName instead of parkNames
- Use $eq instead of $containsi for eventType filters

Note: As a result of the first change, fewer results will be returned for park name searches, This is not ideal, but this is a hotfix to deal with a performance issue. The back-end for this search feature will likely be replaced with Elasticsearch in the near future.
