### PR TITLE
CM-801: Don't hide sites with no slug from public-advisories/items

### DIFF
--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -110,8 +110,8 @@ module.exports = createCoreController(
                 links: { fields: '*' },
                 standardMessages: { fields: '*' },
                 sites: {
-                    fields: ["orcsSiteNumber", "slug"],
-                    filters: { isDisplayed: true, slug: { $notNull: true } }
+                    fields: ["orcsSiteNumber", "siteName"],
+                    filters: { isDisplayed: true }
                 }
             };
 


### PR DESCRIPTION
### Jira Ticket:
CM-801

### Description:
Allow sites without a slug in the site list on /public-advisories/items (the slugified sitename is used as a fallback in the code)
