### PR TITLE
CM-803: Advisory search to use $startsWith: eventType & remove populate=*

### DIFF
--- a/src/cms/src/api/public-advisory/services/public-advisory.js
+++ b/src/cms/src/api/public-advisory/services/public-advisory.js
@@ -32,7 +32,7 @@ const buildQuery = function (query) {
     }
 
     if (query._eventType && query._eventType.length > 0) {
-        typeSearch = { eventType: { eventType: { $eq: query._eventType } } };
+        typeSearch = { eventType: { eventType: { $startsWith: query._eventType } } };
     }
 
     query.filters = {
@@ -49,6 +49,22 @@ const buildQuery = function (query) {
                 ...[textSearch]
             ]
         }
+    };
+
+    query.populate = {
+        accessStatus: true,
+        advisoryStatus: true,
+        eventType: true,
+        fireCentres: true,
+        fireZones: true,
+        links: true,
+        managementAreas: true,
+        protectedAreas: { fields: ["protectedAreaName", "slug", "isDisplayed", "publishedAt"] },
+        regions: true,
+        sections: true,
+        sites: { fields: ["siteName", "slug", "isDisplayed", "publishedAt"] },
+        standardMesages: true,
+        urgency: true
     };
 
     return query;

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -179,7 +179,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       "/public-advisories/count"
 
     if (advisoryType !== "all") {
-      q += `?&queryText&_eventType=${advisoryType}`
+      q += `?queryText&_eventType=${advisoryType}`
     }
 
     const newApiCountCall = apiUrl + q
@@ -191,8 +191,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   const getApiQuery = useCallback(
     advisoryTypeFilter => {
       // Order by date and exclude unpublished parks
-      let q =
-        "?populate=*&queryText"
+      let q = "?queryText"
 
       let useParksFilter = isParksFilter
       let useKeywordFilter = isKeywordFilter
@@ -261,7 +260,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
             // Get count
             let apiCount = apiUrl + "/public-advisories/count" + q
-            if (q === "?populate=*&queryText") {
+            if (q === "?queryText") {
              apiCount = apiUrl + "/public-advisories/count"
             }
             


### PR DESCRIPTION
### Jira Ticket:
CM-803

### Description:
1. Fixed a bug caused by the hotfix in #838.  Searching for "Wildfire" or "Flood" should return event types that start with these words, not just exact matches.  
2. Tuned the query to return a much smaller result set.  Previously the REST call was returning many unused fields which resulted in a 1.3MB payload for the request: https://bcparks.api.gov.bc.ca/api/public-advisories?populate=*&queryText&_eventType=Wildfire%20risk&limit=10&start=0
