### PR TITLE
CM-652: Update access status to group label on park page

### DIFF
--- a/src/gatsby/src/components/park/parkAccessStatus.js
+++ b/src/gatsby/src/components/park/parkAccessStatus.js
@@ -51,7 +51,7 @@ function ParkAccessFromAdvisories(advisories) {
       accessStatuses.push({
         precedence: advisory.accessStatus.precedence,
         color: advisory.accessStatus.color,
-        text: advisory.accessStatus.accessStatus,
+        text: advisory.accessStatus.groupLabel,
       })
     }
     if (advisory.access_status_id) {


### PR DESCRIPTION
### Jira Ticket:
CM-652

### Description:
- Update access status to group label on the park page
- The status in the park page header and the status in the dates of operation has been changed to group label
