### PR TITLE
CM-828: Change pageSize for Gatsby protectedAreas from 250 to 100

### DIFF
--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -115,11 +115,11 @@ module.exports = {
                   populate: "*"
                 }
               }
-            }
+            },
+            queryLimit: 100
           }
-        ],
-        queryLimit: 1000,
-      },
+        ]
+      }
     },
     `gatsby-transformer-sharp`,
     {


### PR DESCRIPTION
### Jira Ticket:
CM-828

### Description:
Changed the pageSize for protectedAreas in the `gatsby-source-strapi` settings from 250 (the default) to 100, and removed the ignored setting of 1000 that was in the wrong place.  This will hopefully fix the issue with periodic 504 gateway timeout errors when running the Publish Gatsby GitHub action.
