### PR TITLE
CM-828: Helm updates

### DIFF
--- a/infrastructure/helm/bcparks/values-alpha-test.yaml
+++ b/infrastructure/helm/bcparks/values-alpha-test.yaml
@@ -18,14 +18,6 @@ images:
     name: image-registry.openshift-image-registry.svc:5000/61d198-tools/etl-develop
 
 cms:
-  resources:
-    limits:
-      cpu: 500m
-      memory: 2Gi
-    requests:
-      cpu: 125m
-      memory: 250Mi
-
   env:
     environment: alpha-test
     externalUrl: https://alpha-test-cms.bcparks.ca
@@ -41,13 +33,6 @@ admin:
 
 patroni:
   replicas: 1
-  resources:
-    limits:
-      cpu: 500m
-      memory: 2Gi
-    requests:
-      cpu: 250m
-      memory: 250Mi
 
   pvc:
     size: 10Gi

--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -14,11 +14,11 @@ images:
 cms:
   resources:
     limits:
-      cpu: 500m
+      cpu: 750m
       memory: 1250Mi
     requests:
       cpu: 125m
-      memory: 750Mi
+      memory: 625Mi
 
   env:
     environment: prod
@@ -28,7 +28,7 @@ cms:
     minReplicas: 2
     maxReplicas: 4
     cpuUtilizationThreshold: 50
-    memoryUtilizationThreshold: 85
+    memoryUtilizationThreshold: 100
 
 admin:
   env:
@@ -41,7 +41,7 @@ patroni:
       cpu: 1
       memory: 2Gi
     requests:
-      cpu: 250m
+      cpu: 200m
       memory: 1Gi
   replicas: 3
 

--- a/infrastructure/helm/bcparks/values-test.yaml
+++ b/infrastructure/helm/bcparks/values-test.yaml
@@ -12,20 +12,11 @@ images:
     tag: test
 
 cms:
-  resources:
-    limits:
-      cpu: 500m
-      memory: 2Gi
-    requests:
-      cpu: 125m
-      memory: 250Mi
-
   env:
     environment: test
     externalUrl: https://test-cms.bcparks.ca
 
   hpa:
-    minReplicas: 1
     maxReplicas: 2
 
 admin:
@@ -34,14 +25,6 @@ admin:
     publicUrl: https://test.bcparks.ca
 
 patroni:
-  resources:
-    limits:
-      cpu: 500m
-      memory: 2Gi
-    requests:
-      cpu: 250m
-      memory: 250Mi
-
   replicas: 1
 
   pvc:
@@ -59,5 +42,4 @@ backup:
 
 public:
   hpa:
-    minReplicas: 1
     maxReplicas: 2

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -43,10 +43,10 @@ cms:
 
   resources:
     limits:
-      cpu: 500m
-      memory: 2Gi
+      cpu: 750m
+      memory: 1250Mi
     requests:
-      cpu: 125m
+      cpu: 75m
       memory: 250Mi
 
   env:
@@ -71,10 +71,9 @@ cms:
 
   hpa:
     minReplicas: 1
-    # Default to 1 max replica on dev, overriden in test and prod envs
     maxReplicas: 1
-    cpuUtilizationThreshold: 50
-    memoryUtilizationThreshold: 65
+    cpuUtilizationThreshold: 125
+    memoryUtilizationThreshold: 125
 
 patroni:
   componentName: patroni
@@ -88,9 +87,9 @@ patroni:
   resources:
     limits:
       cpu: 500m
-      memory: 2Gi
+      memory: 1250Mi
     requests:
-      cpu: 250m
+      cpu: 100m
       memory: 250Mi
 
   env:
@@ -167,10 +166,9 @@ public:
 
   hpa:
     minReplicas: 1
-    # Default to 1 max replica on dev, overriden in test and prod envs
     maxReplicas: 1
-    cpuUtilizationThreshold: 50
-    memoryUtilizationThreshold: 75
+    cpuUtilizationThreshold: 125
+    memoryUtilizationThreshold: 125
 
 backup:
   componentName: postgres-backup


### PR DESCRIPTION
### Jira Ticket:
CM-828

### Description:
- Increased CPU limits for CMS pods from 500m to 750m for all environments to undo a change that may have caused Gatsby builds to start failing.

- Refactored and tuned other settings 
  - Removed resource limits from DEV and TEST environments so they are only defined in values.yaml. Now they can be updated in one place
   - Removed minReplicas settings from CMS and Public on the TEST environment because they were the same as the defaults in values.yaml
   - Decreased the memory limit on dev and test environments from 2Gi to 1250Mi because these should not be higher than PROD
   - Decreased CMS CPU requests on DEV and TEST environments from 125m to 75m because these environments sit idle most of the time and the OCIO is asking teams to use lower CPU requests on dev and test.
   - Decreased CMS memory requests on PROD from 750Mi to 625Mi and increased the memoryUtilizationThreshold from 85 to 100.  A new pod will still be spawned at approximately the same memory usage, but it reduces our overall resource claim.
   - Reduced the CPU requests on our DEV and TEST Patroni pods from 250m to 100m to reduce our resource claim.
   - Reduced the CPU requests on our 3 PROD Patroni pods from 250m to 200m to reduce our resource claim. Most of the traffic goes to the leader and the other two pod tend to be idle a lot. 
  
  
