### PR TITLE
NOBUG: Temporarily increase GraphQL amountLimit to 2500

### DIFF
--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -3,7 +3,7 @@ module.exports = ({ env }) => {
     graphql: {
       config: {
         shadowCRUD: true,
-        amountLimit: 500,
+        amountLimit: 2500,
         depthLimit: 7,
         playgroundAlways: process.env.ENABLE_GRAPHQL_PLAYGROUND || false,
         apolloServer: {


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Temporarily increase GraphQL amountLimit to 2500 to fix issue with dates.bcparks.ca that was introduced by https://github.com/bcgov/bcparks.ca/pull/717. This will be reverted when https://github.com/bcgov/bcparks.ca/pull/854 is deployed to PROD. 
