### PR TITLE
CM-823: Change isLong to 259 from 260

### DIFF
--- a/src/gatsby/src/components/park/parkOverview.js
+++ b/src/gatsby/src/components/park/parkOverview.js
@@ -47,7 +47,7 @@ export default function ParkOverview({ data: parkOverview, type }) {
     setHeight(ref.current.clientHeight)
   }, [expanded])
 
-  const isLong = height > 260
+  const isLong = height > 259
 
   const $ = cheerio.load(parkOverview);
   $('a').attr('tabindex', '-1')


### PR DESCRIPTION
### Jira Ticket:
CM-823

### Description:
- Variable `isLong` should be true if it's greater than 259 because `classes.collapsed` `maxHeight` is 260 px
