### PR TITLE
CM-849: Remove onKeyDown from homepage Search By Activity link

### DIFF
--- a/src/gatsby/src/components/search/mainSearch.js
+++ b/src/gatsby/src/components/search/mainSearch.js
@@ -58,7 +58,6 @@ const MainSearch = () => {
       <div className="parks-search-filter-link"
         role="button"
         tabIndex={0}
-        onKeyDown={searchParkFilter}
         onClick={searchParkFilter}>
         Search by activity
       </div>


### PR DESCRIPTION
### Jira Ticket:
CM-849

### Description:
Tabbing over "Search by activity" on Home page redirects the user to the Find a park page
