### PR TITLE
CM-841: Reduce breadcrumb padding on small screens to match content

### DIFF
--- a/src/gatsby/src/styles/staticContent1.scss
+++ b/src/gatsby/src/styles/staticContent1.scss
@@ -54,6 +54,9 @@
     @media (min-width: 576px) {
       padding: 40px 40px 10px 40px;
     }
+    @media screen and (max-width: 415px) {
+      padding: 10px 16px;
+    }
   }
 
   .header-image-wrapper {


### PR DESCRIPTION
### Jira Ticket:
CM-841

### Description:
Reduce the breadcrumb padding on small screens to match content, 

The issue was only happening on screens smaller than 415px because the left and right padding was being reduced on the content below at the 415px breakpoint.  I added some extra CSS to also reduce the padding on the breadcrumbs at sizes below 415px.
