### PR TITLE
CM-852: Special text for year-round parks and marine parks

### DIFF
--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -144,7 +144,7 @@ const ParkLink = ({ park }) => {
           <ExpandCircleDownIcon />
         </GatsbyLink>
       </h2>
-      <p>The park gate is open {parkDates}.</p>
+      <p>The park { park.marineProtectedArea !== 'Y'? (<>gate</>) : ("") } is open {parkDates}.</p>
       {/* display table list if the screen size is bigger than 768 px */}
       <table className="table">
         <thead className="thead-light">
@@ -203,7 +203,12 @@ const ParkLink = ({ park }) => {
                     )}
                   </ul>
                 ) : (
+                  parkDates === 'year-round' ? (
+                    <>Limited services</>  
+                  ) :
+                  (
                   <>No services</>
+                  )
                 )}
               </td>
             </tr>
@@ -286,6 +291,7 @@ const ParkOperatingDatesPage = () => {
         nodes {
           slug
           protectedAreaName
+          marineProtectedArea
           parkOperation {
             openDate
             closeDate


### PR DESCRIPTION
### Jira Ticket:
CM-852

### Description:
- Show "Limited services" instead of "No services" in the winter text for parks that are open year round
- Remove the word "gate" from marine parks (because they have beaches, not gates)
