### PR TITLE
CM-851: Made indexing faster by batching photo requests

### DIFF
--- a/src/cms/src/api/search/controllers/search.js
+++ b/src/cms/src/api/search/controllers/search.js
@@ -117,13 +117,13 @@ module.exports = ({ strapi }) => ({
   },
 
   findParkPhotos: async (ctx) => {
-    const photos = await strapi.entityService.findMany("api::park-photo.park-photo", {
-      filters: { orcs: ctx.params.orcs, isActive: true },
-      sort: "sortOrder",
-      limit: 5,
-      fields: ["imageUrl"]
-    });
-    return photos.map(p => { return p.imageUrl });
+    const contentType = strapi.contentType("api::park-photo.park-photo");
+    const query = await sanitize.contentAPI.query(ctx.query, contentType, {});
+    query.fields = ["orcs", "sortOrder", "imageUrl"];
+    query.pagination = {limit : -1 };
+    query.filters = { isActive: true, ... query.filters }
+    const { results } = await strapi.service("api::park-photo.park-photo").find(query);
+    return results;
   },
 
   setAllReindexNeeded: async (ctx) => {

--- a/src/cms/src/api/search/routes/search.js
+++ b/src/cms/src/api/search/routes/search.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     {
       method: 'GET',
-      path: '/search/indexing/photos/:orcs',
+      path: '/search/indexing/photos',
       handler: 'search.findParkPhotos',
       config: {
         policies: [],

--- a/src/elastic/package.json
+++ b/src/elastic/package.json
@@ -5,13 +5,11 @@
   "description": "Cron-automated Node.js scripts for indexing elasticsearch",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "cron": "node index.js cron",
+    "start": "node server.js",
     "once": "node index.js once",
     "deleteindex": "node index.js deleteindex",
     "reindex": "node index.js reindex",
     "rebuild": "node index.js rebuild",
-    "readiness": "node index.js readiness",
     "liveness": "node index.js liveness"
   },
   "author": "mike@oxd.com",

--- a/src/elastic/scripts/indexParks.js
+++ b/src/elastic/scripts/indexParks.js
@@ -11,6 +11,7 @@ exports.indexParks = async function () {
   const logger = getLogger();
 
   let parkList;
+  let photoList;
   let queue;
 
   // process items from the queue with the action 'elastic index park'
@@ -20,6 +21,8 @@ exports.indexParks = async function () {
     try {
       queue = await readQueue("elastic index park");
       parkList = await getBatch(queue);
+      const orcsList = parkList.map(p => { return p.orcs });
+      photoList = await getPhotos(orcsList);
     } catch (error) {
       logger.error(`indexParks() failed while reading queued tasks: ${error}`);
       process.exit(1);
@@ -27,7 +30,7 @@ exports.indexParks = async function () {
 
     for (const park of parkList) {
       logger.info(`indexing park ${park.id}`);
-      if (await indexPark(park)) {
+      if (await indexPark(park, photoList)) {
         indexed.push(taskId(queue, park.id))
       } else {
         logger.error(`error indexing park ${park.id}`)
@@ -67,7 +70,7 @@ exports.indexParks = async function () {
 /**
  *  Adds a single park to Elasticsearch
  */
-const indexPark = async function (park) {
+const indexPark = async function (park, photos) {
   if (!park) {
     return false;
   }
@@ -80,7 +83,7 @@ const indexPark = async function (park) {
   }
 
   // transform the Strapi object into an Elasticsearch object
-  const doc = await createElasticPark(park);
+  const doc = await createElasticPark(park, photos);
 
   // send the data to elasticsearch
   try {
@@ -125,10 +128,31 @@ const getBatch = async function (queuedTasks) {
   })
   const parksQuery = `${process.env.STRAPI_BASE_URL}/api/search/indexing/parks?${parksFilters}`;
   const response = await axios.get(parksQuery);
-  parkList = response.data.data;
-  getLogger().info(`Got ${parkList.length} parks from Strapi`);
+  const parkList = response.data.data;
+  getLogger().info(`Got ${parkList.length} protected areas from Strapi`);
   return parkList;
 }
+
+const getPhotos = async function (orcsList) {
+  if (orcsList.length === 0) {
+    return [];
+  }
+  const photoFilters = qs.stringify({
+    filters: {
+      orcs: {
+        $in: orcsList,
+      },
+    }
+  }, {
+    encodeValuesOnly: true,
+  })
+  const photosQuery = `${process.env.STRAPI_BASE_URL}/api/search/indexing/photos?${photoFilters}`;
+  const response = await axios.get(photosQuery);
+  const photosList = response.data;
+  getLogger().info(`Got ${photosList.length} park photo records from Strapi`);
+  return photosList;
+}
+
 
 /**
  * Looks up the id of a queued task based on the associated park id

--- a/src/elastic/server.js
+++ b/src/elastic/server.js
@@ -1,0 +1,56 @@
+const schedule = require("node-schedule");
+const { writeFile } = require('node:fs/promises');
+const dotenv = require('dotenv');
+const { exec } = require("child_process");
+
+const { getLogger } = require('./utils/logging');
+
+const { indexParks } = require('./scripts/indexParks');
+const { createParkIndex, parkIndexExists } = require('./scripts/createParkIndex');
+const { queueAll } = require('./scripts/queueAllParks');
+
+(async () => {
+  dotenv.config({
+    path: `.env`
+  });
+
+  const logger = getLogger();
+
+  /**
+   * Starts the cron job to reindex parks as entries are added to the queuedTasks 
+   * collection in Strapi
+   */
+
+  logger.info("Starting cron scheduler");
+
+  // record pod readiness for health checks when the cron job first starts
+  // (use shell command to prevent file locking)
+  exec(`echo ${JSON.stringify(new Date())} > lastrun.txt`)
+
+  await writeFile("lastrun.txt", JSON.stringify(new Date()));
+
+  // run every 2 minutes on the :00
+  schedule.scheduleJob("*/2 * * * *", async () => {
+    try {
+      if (!(await parkIndexExists())) {
+        logger.warn(
+          "The Elasticsearch index is missing. It will be recreated and repopulated"
+        );
+        await createParkIndex();
+        await queueAll();
+        await indexParks();
+      } else {
+        logger.info("Cron checking queued-tasks");
+        await indexParks();
+      }
+
+      // record pod liveness for health check every time the job runs
+      // (use shell command to prevent file locking)
+      exec(`echo ${JSON.stringify(new Date())} > lastrun.txt`)
+      await writeFile("lastrun.txt", JSON.stringify(new Date()));
+    } catch (error) {
+      logger.error(`Error running cron task: ${error}`)
+    }
+  });
+
+})();

--- a/src/elastic/transformers/park.js
+++ b/src/elastic/transformers/park.js
@@ -5,15 +5,16 @@ const axios = require("axios");
  * that is optimized for Elasticsearch
  */
 
-exports.createElasticPark = async function (park) {
+exports.createElasticPark = async function (park, photos) {
   if (!park || !park.isDisplayed || !park.publishedAt) {
     return null;
   }
 
   // get photos
-  const photosQuery = `${process.env.STRAPI_BASE_URL}/api/search/indexing/photos/${park.orcs}`;
-  const response = await axios.get(photosQuery);
-  park.parkPhotos = response.data;
+  park.parkPhotos = photos.filter((p) => p.orcs === park.orcs)
+    .sort((a, b) => { return a.sortOrder > b.sortOrder ? 1 : -1 })
+    .slice(0, 5)
+    .map(p => { return p.imageUrl });
 
   // convert managementAreas to parkLocations
   park.parkLocations = [];

--- a/src/elastic/utils/taskQueue.js
+++ b/src/elastic/utils/taskQueue.js
@@ -9,7 +9,7 @@ const readQueue = async function (actionName) {
       action: `${actionName}`
     },
     pagination: {
-      limit: 100
+      limit: 50
     }
   }, {
     encodeValuesOnly: true,


### PR DESCRIPTION
### Jira Ticket:
CM-123

### Description:
- Made indexing faster by batching photo requests
- Split the cron job into a separate server.js file to better follow node standards
- Use exec to write timestamps instead of fs.write to prevent async file locking
