### PR TITLE
CM-852: Filter out inactive subareas from dates page

### DIFF
--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -26,7 +26,7 @@ const ParkLink = ({ park }) => {
           open.indexOf("Jan 1") === 0 && close.indexOf("Dec 31") === 0
         let output = openYearRound ? yearRoundText : `${prefix || ""}${open}${delimiter}${close}`
 
-        return output.replace(/ /g, "\u202F")
+        return output.replace(/ /g, "\u00A0")
       } catch (err) {
         console.error("Err formatting date " + openDate + ", " + closeDate)
         return ""


### PR DESCRIPTION
### Jira Ticket:
CM-852

### Description:
- Filter out inactive subareas from the dates page.  The filter in the GraphQL is at the top level, and it only ensures that parks returned have at least one active subarea. It doesn't filter out the inactive subareas from the result. 
- Change the space in dates (e.g. "Dec 31") to a nbsp character, so the dates don't wrap before the number
