### PR TITLE
CM-869: Add missing backcountry camping icon

### DIFF
--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -36,6 +36,7 @@ import ParkLinksModal from "../components/search/parkLinksModal"
 
 import parksLogo from "../images/Mask_Group_5.png"
 import campingIcon from "../../static/icons/vehicle-accessible-camping.svg"
+import backcountryCampingIcon from "../../static/icons/wilderness-camping.svg"
 import hikingIcon from "../../static/icons/hiking.svg"
 import picincIcon from "../../static/icons/picnic-areas.svg"
 import swimmingIcon from "../../static/icons/swimming.svg"
@@ -113,13 +114,16 @@ const Icon = ({ src, label, size }) => {
 
 const FeatureIcons = ({ park }) => {
   const iconSize = 32;
-  const facilities = park.parkFacilities.filter(f => [1, 6].includes(f.num)) || [];
+  const facilities = park.parkFacilities.filter(f => [1, 6, 36].includes(f.num)) || [];
   const activities = park.parkActivities.filter(a => [1, 3, 8, 9].includes(a.num)) || [];
 
   return (
     <>
       {facilities.some(x => x.code === 'vehicle-accessible-camping') &&
         <Icon src={campingIcon} label="Vehicle accesible camping" size={iconSize} />
+      }
+      {facilities.some(x => x.code === 'backcountry-camping') &&
+        <Icon src={backcountryCampingIcon} label="Backcountry camping" size={iconSize} />
       }
       {activities.some(x => x.code === 'hiking') &&
         <Icon src={hikingIcon} label="Hiking" size={iconSize} />
@@ -136,13 +140,13 @@ const FeatureIcons = ({ park }) => {
       {activities.some(x => x.code === 'pets-on-leash') &&
         <Icon src={petsIcon} label="Pets on leash" size={iconSize} />
       }
-      {facilities.some(x => x.code === 'vehicle-accessible-camping') ? (
+      {facilities.some(x => [1, 36].includes(x.num)) ? (
         <GatsbyLink href={`/${park.slug}/#park-camping-details-container`}>
           <p aria-label="See all facilities and activities">see all</p>
         </GatsbyLink>
       ) : (
         (activities.length > 0 || facilities.length > 0) && (
-          facilities.length > 0 ? (
+          facilities.some(x => x.code === 'picnic-areas') ? (
             <GatsbyLink href={`/${park.slug}/#park-facility-container`}>
               <p aria-label="See all facilities and activities">see all</p>
             </GatsbyLink>


### PR DESCRIPTION
### Jira Ticket:
CM-869

### Description:
Added missing backcountry camping icon which was missing from search result cards.  

NOTE: Further work is needed to update the card layout. Seven icons don't fit properly on medium-sized screens. See the ticket for design. 
