### PR TITLE
CM-871: Back-end for region filters

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-search.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-search.js
@@ -101,6 +101,7 @@ function parseSearchFilters(query) {
 
   let activityNumbers = [];
   let facilityNumbers = [];
+  let regionNumbers = [];
 
   if (query.activities) {
     if (typeof query.activities === "object") {
@@ -120,6 +121,15 @@ function parseSearchFilters(query) {
       facilityNumbers = [parseInt(query.facilities, 10)];
     }
   }
+  if (query.regions) {
+    if (typeof query.regions === "object") {
+      regionNumbers = query.regions.map((region) =>
+        parseInt(region, 10)
+      );
+    } else {
+      regionNumbers = [parseInt(query.regions, 10)];
+    }
+  }
 
   return {
     searchText,
@@ -129,6 +139,7 @@ function parseSearchFilters(query) {
     marineProtectedArea,
     activityNumbers,
     facilityNumbers,
+    regionNumbers
   };
 }
 


### PR DESCRIPTION
### Jira Ticket:
CM-871

### Description:
Added region filters. 
Syntax is as follows:
`http://localhost:1337/api/protected-areas/search?queryText=golden&regions[]=1&regions[]=2`
(1 and 2 are the **regionNumber** field from the Regions collection)
Note that region filters are "OR" filters, not "AND" filters like the other filters.  Region aggregations also behave as "OR" and are nested differently than other aggregations.
