### PR TITLE
CM-871: Use numbers for aggregations instead of codes and names

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-search.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-search.js
@@ -30,7 +30,7 @@ const searchParks = async function (ctx) {
             pageCount: Math.ceil(result.total?.value / 10),
             total: result.total?.value
           },
-          aggregations: resp?.body?.aggregations
+          aggregations: cleanUpAggregations(resp?.body?.aggregations)
         }
       };
     }
@@ -151,6 +151,12 @@ function parseSearchOffset(query) {
     limit,
     offset,
   };
+}
+
+function cleanUpAggregations(aggs) {
+  aggs.regions = aggs.all_regions.filtered.regions;
+  delete aggs.all_regions;
+  return aggs;
 }
 
 module.exports = {

--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -147,7 +147,7 @@ module.exports = ({ strapi }) => ({
                   aggs: {
                     regions: {
                       terms: {
-                        field: "parkLocations.region.keyword"
+                        field: "parkLocations.regionNum"
                       }
                     }
                   }

--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -25,43 +25,43 @@ module.exports = ({ strapi }) => ({
     if (searchText) {
       textFilter = [
         {
-          "match_phrase": {
+          match_phrase: {
             "protectedAreaName": {
-              "query": searchText,
-              "boost": 5
+              query: searchText,
+              boost: 5
             }
           }
         },
         {
-          "match_phrase": {
+          match_phrase: {
             "parkNames": {
-              "query": searchText,
-              "boost": 3
+              query: searchText,
+              boost: 3
             }
           }
         },
         {
-          "match_phrase_prefix": {
+          match_phrase_prefix: {
             "protectedAreaName": {
-              "query": searchText,
-              "boost": 1
+              query: searchText,
+              boost: 1
             }
           }
         },
         {
-          "match_phrase_prefix": {
-            "parkNames": {
-              "query": searchText,
-              "boost": 1
+          match_phrase_prefix: {
+            parkNames: {
+              query: searchText,
+              boost: 1
             }
           }
         },
         {
-          "multi_match": {
-            "query": searchText,
-            "type": "best_fields",
-            "fields": ["parkNames^2", "protectedAreaName^2"],
-            "operator": "and"
+          multi_match: {
+            query: searchText,
+            type: "best_fields",
+            fields: ["parkNames^2", "protectedAreaName^2"],
+            operator: "and"
           }
         }
       ];
@@ -116,47 +116,38 @@ module.exports = ({ strapi }) => ({
               ]
             }
           },
-          "sort": [
+          sort: [
             "_score",
             "nameLowerCase.keyword"
           ],
           _source: true,
           aggs: {
-            "activities": {
-              "terms": {
-                "field": "parkActivities.code.keyword",
-                "size": 50
+            activities: {
+              terms: {
+                field: "parkActivities.num",
+                size: 50
               }
             },
-            "facilities": {
-              "terms": {
-                "field": "parkFacilities.code.keyword",
-                "size": 50
+            facilities: {
+              terms: {
+                field: "parkFacilities.num",
+                size: 50
               }
             },
-            "marinePark": {
-              "terms": { "field": "marineProtectedArea" }
-            },
-            "hasCamping": {
-              "terms": { "field": "hasCamping" }
-            },
-            "typeCode": {
-              "terms": { "field": "typeCode.keyword" }
-            },
-            "all_regions": {
-              "global": {},
-              "aggs": {
-                "filtered": {
-                  "filter": {
+            all_regions: {
+              global: {},
+              aggs: {
+                filtered: {
+                  filter: {
                     bool: {
                       filter: [...mustFilter],
                       must: [{ bool: { should: [...textFilter] } }]
                     }
                   },
-                  "aggs": {
-                    "regions": {
-                      "terms": {
-                        "field": "parkLocations.region.keyword"
+                  aggs: {
+                    regions: {
+                      terms: {
+                        field: "parkLocations.region.keyword"
                       }
                     }
                   }
@@ -190,27 +181,27 @@ module.exports = ({ strapi }) => ({
     if (searchText.length > 2) {
       filtersForLongerQueries = [
         {
-          "match_phrase_prefix": {
-            "nameLowerCase": {
-              "query": searchText,
-              "boost": 4
+          match_phrase_prefix: {
+            nameLowerCase: {
+              query: searchText,
+              boost: 4
             }
           }
         },
         {
-          "match_phrase_prefix": {
-            "parkNames": {
-              "query": searchText,
-              "boost": 4
+          match_phrase_prefix: {
+            parkNames: {
+              query: searchText,
+              boost: 4
             }
           }
         },
         {
-          "multi_match": {
-            "query": searchText,
-            "type": "best_fields",
-            "fields": ["parkNames^2", "protectedAreaName^5"],
-            "operator": "or"
+          multi_match: {
+            query: searchText,
+            type: "best_fields",
+            fields: ["parkNames^2", "protectedAreaName^5"],
+            operator: "or"
           }
         }];
     }
@@ -218,18 +209,18 @@ module.exports = ({ strapi }) => ({
     if (searchText) {
       textFilter = [
         {
-          "prefix": {
+          prefix: {
             "nameLowerCase.keyword": {
-              "value": searchText.toLowerCase(),
-              "boost": 6
+              value: searchText.toLowerCase(),
+              boost: 6
             }
           }
         },
         {
-          "prefix": {
+          prefix: {
             "parkNames": {
-              "value": searchText,
-              "boost": 3
+              value: searchText,
+              boost: 3
             }
           }
         },
@@ -250,12 +241,12 @@ module.exports = ({ strapi }) => ({
             }
           }
         },
-        "sort": [
+        sort: [
           "typeCode.keyword:desc",
           "_score",
           "nameLowerCase.keyword"
         ],
-        "_source": [
+        _source: [
           "protectedAreaName",
           "slug"
         ]

--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -125,13 +125,15 @@ module.exports = ({ strapi }) => ({
             activities: {
               terms: {
                 field: "parkActivities.num",
-                size: 50
+                size: 50,
+                min_doc_count: 0
               }
             },
             facilities: {
               terms: {
                 field: "parkFacilities.num",
-                size: 50
+                size: 50,
+                min_doc_count: 0
               }
             },
             all_regions: {
@@ -147,7 +149,8 @@ module.exports = ({ strapi }) => ({
                   aggs: {
                     regions: {
                       terms: {
-                        field: "parkLocations.regionNum"
+                        field: "parkLocations.regionNum",
+                        min_doc_count: 0
                       }
                     }
                   }


### PR DESCRIPTION
### Jira Ticket:
CM-871

### Description:
Updated aggregations to use activityNumber, facilityNumber, regionNumber instead of activityCode, facilityCode, regionName.  This will make the front-end easier to implement because no extra data is neeeded to do lookups.

Also included zeros in the buckets and removed unused aggregations (hasCamping, typeCode, marineProtectedArea)


