### PR TITLE
CM-857: autosuggest should only return parks that start with queryText

### DIFF
--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -59,6 +59,7 @@ module.exports = ({ strapi }) => ({
         {
           multi_match: {
             query: searchText,
+            fuzziness: "AUTO",
             type: "best_fields",
             fields: ["parkNames^2", "protectedAreaName^2"],
             operator: "and"
@@ -211,6 +212,7 @@ module.exports = ({ strapi }) => ({
         {
           multi_match: {
             query: searchText,
+            fuzziness: "AUTO",
             type: "best_fields",
             fields: ["parkNames^2", "protectedAreaName^5"],
             operator: "or"

--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -120,7 +120,16 @@ module.exports = ({ strapi }) => ({
             "_score",
             "nameLowerCase.keyword"
           ],
-          _source: true,
+          _source: [
+            "orcs",
+            "protectedAreaName",
+            "hasCampfireBan",
+            "slug",
+            "parkFacilities",
+            "parkActivities",
+            "parkLocations",
+            "advisories"
+          ],
           aggs: {
             activities: {
               terms: {
@@ -221,8 +230,8 @@ module.exports = ({ strapi }) => ({
         },
         {
           prefix: {
-            "parkNames": {
-              value: searchText,
+            "parkNames.keyword": {
+              value: searchText.toLowerCase(),
               boost: 3
             }
           }

--- a/src/elasticmanager/transformers/park.js
+++ b/src/elasticmanager/transformers/park.js
@@ -40,7 +40,7 @@ exports.createElasticPark = async function (park, photos) {
     let parkNames = park.parkNames
       .filter(n => n.parkNameType?.nameTypeId !== 2)
       .map(n => {
-        return n.parkName;
+        return n.parkName.toLowerCase();
       });
     park.parkNames = [...new Set(parkNames || [])];
   }


### PR DESCRIPTION
### Jira Ticket:
CM-857

### Description:
When queryText is 1 or 2 characters, autocomplete should only return parks that start with queryText. If it's 3 or more characters, then queryText can be at the start of any word in the parknames or protectedAreaName. **NOTE: data must be reindexed for this to work properly.**

Also limited the result set to the following fields:  

- "orcs",
- "protectedAreaName",
- "hasCampfireBan",
- "slug",
- "parkFacilities",
- "parkActivities",
- "parkLocations",
- "advisories"

Also enabled fuzziness for park search