### PR TITLE
NOBUG: Added latitude and longitude to Elasticsearch

### DIFF
--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -99,9 +99,9 @@ module.exports = ({ strapi }) => ({
     try {
       const query = {
         index: getIndexName(),
-        from: offset,
-        size: limit,
         body: {
+          from: offset,
+          size: limit,          
           query: {
             bool: {
               filter: [
@@ -244,11 +244,11 @@ module.exports = ({ strapi }) => ({
 
     try {
       const query = {
-        from: 0,
-        size: 10,
         index: getIndexName(),
         filterPath: "hits.hits._source",
         body: {
+          from: 0,
+          size: 10,
           query: {
             bool: {
               should: [...textFilter]

--- a/src/cms/src/api/search-indexing/controllers/search-indexing.js
+++ b/src/cms/src/api/search-indexing/controllers/search-indexing.js
@@ -15,6 +15,8 @@ module.exports = ({ strapi }) => ({
       "typeCode",
       "hasCampfireBan",
       "slug",
+      "latitude",
+      "longitude",
       "isDisplayed",
       "publishedAt"
     ];

--- a/src/elasticmanager/scripts/createParkIndex.js
+++ b/src/elasticmanager/scripts/createParkIndex.js
@@ -52,6 +52,9 @@ const createParkIndex = async function () {
               ignore_above: 256
             }
           }
+        },
+        locationGeo: {
+          type: "geo_point"
         }
       }
     }

--- a/src/elasticmanager/transformers/park.js
+++ b/src/elasticmanager/transformers/park.js
@@ -96,9 +96,16 @@ exports.createElasticPark = async function (park, photos) {
   }
   delete park.publicAdvisories;
 
+  // add geo info
+  if (park.latitude && park.longitude) {
+    park.locationGeo = [`${park.latitude},${park.longitude}`];
+  }
+
   // delete fields that are only used for indexing
   delete park.isDisplayed;
   delete park.publishedAt;
+  delete park.latitude;
+  delete park.longitude;
 
   return park;
 };


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Added latitude and longitude to Elasticsearch for demo purposes.  `node index.js rebuild` is required.  

Example of "parks near me" query
```
GET /bcparks-protected-areas-local/_search
{
  "_source": [
    "parkLocations.managementArea",
    "protectedAreaName"
  ],
  "query": {
    "geo_distance": {
      "distance": "50km",
      "locationGeo": "49.129,-122.724"
    }
  },
  "sort": [
    {
      "_geo_distance": {
        "locationGeo": "49.129,-122.724",
        "order": "asc",
        "unit": "km",
        "mode": "min",
        "distance_type": "arc",
        "ignore_unmapped": true
      }
    }
  ]
}
```
