### PR TITLE
CM-824: Update the 'download as an app' message

### DIFF
--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -135,8 +135,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
+        name: `bcparks.ca`,
+        short_name: `bcparks.ca`,
         start_url: `/`,
         background_color: `#003366`,
         theme_color: `#003366`,


### PR DESCRIPTION
### Jira Ticket:
CM-824

### Description:
The way to turn off "download as an app" is to remove `gatsby-plugin-manifest`, but that plugin also turns the site into a progressive web app and controls things like the browser colour on mobile. So I just changed the wording of the message instead of removing the plugin.  Instead of saying "gatsby-starter-default' it will say "bcparks.ca".
