### PR TITLE
CM-704: Hide sub menu items when menu item is clicked twice

### DIFF
--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -86,7 +86,13 @@ const MegaMenu = ({ content, menuMode }) => {
         let selObj = getSelectionObj(section, {}) // track the selected item at this level and above
         setSelections(selObj)
       } else {
-        menuReset()
+        if (selections[2]) {
+          const newSelection = {...selections}
+          delete newSelection[2]
+          setSelections(newSelection)
+        } else {
+          menuReset()
+        }
       }
     }
   }

--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -86,6 +86,9 @@ const MegaMenu = ({ content, menuMode }) => {
         setSelectedItem(section)
         let selObj = getSelectionObj(section, {}) // track the selected item at this level and above
         setSelections(selObj)
+        if (selectedItem.treeLevel === 2) {
+          setHasClickedTwice(false)
+        } 
       } else {
         if (selectedItem.treeLevel === 2) {
           setHasClickedTwice(!hasClickedTwice)

--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -13,6 +13,7 @@ const MegaMenu = ({ content, menuMode }) => {
   const [selectedItem, setSelectedItem] = useState([]) // most recent item user has interacted with
   const [selections, setSelections] = useState({}) // the selected item at each level, i.e. selection breadcrumbs
   const [isMenuOpen, setIsMenuOpen] = useState(false) // currently only used for mobile - menu closed at first
+  const [hasClickedTwice, setHasClickedTwice] = useState(false)
   let sectionImages = {}
   let menuCollection
   let menuElements
@@ -86,10 +87,8 @@ const MegaMenu = ({ content, menuMode }) => {
         let selObj = getSelectionObj(section, {}) // track the selected item at this level and above
         setSelections(selObj)
       } else {
-        if (selections[2]) {
-          const newSelection = {...selections}
-          delete newSelection[2]
-          setSelections(newSelection)
+        if (selectedItem.treeLevel === 2) {
+          setHasClickedTwice(!hasClickedTwice)
         } else {
           menuReset()
         }
@@ -209,7 +208,13 @@ const MegaMenu = ({ content, menuMode }) => {
       <>
         {item.hasChildren && (
           <>
-            <nav className={"menu-level menu-level--" + item.treeLevel} aria-labelledby="mainmenulabel">
+            <nav
+              className={
+                "menu-level menu-level--" + item.treeLevel +
+                " has-clicked-twice--" + hasClickedTwice
+              }
+              aria-labelledby="mainmenulabel"
+            >
               <h2 id="mainmenulabel" className="sr-only">Main Menu</h2>
               <ul className="menu-button-list" role="presentation">
                 <li className="menu-button menu-back">

--- a/src/gatsby/src/styles/megaMenu/megaMenu.scss
+++ b/src/gatsby/src/styles/megaMenu/megaMenu.scss
@@ -366,6 +366,9 @@ nav {
     .menu-level--2 {
       padding-left: 10px;
       height: 400px;
+      &.has-clicked-twice--true {
+        display: none;
+      }
 
       .menu-arrow {
         display: none;


### PR DESCRIPTION
### Jira Ticket:
CM-704

### Description:
- If users click a sub-item in megamenu twice, megamenu keeps open but sub-item menu will be hidden