### PR TITLE
NOBUG: Bump repository-dispatch to v2

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -115,7 +115,7 @@ jobs:
         run: docker push --all-tags ${{ env.REGISTRY_IMAGE }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-alpha-test.yaml
+++ b/.github/workflows/deploy-alpha-test.yaml
@@ -28,7 +28,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag elasticmanager-develop:latest elasticmanager-develop:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -46,7 +46,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag elasticmanager-main:${{ github.event.inputs.releaseTag }} elasticmanager-main:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag elasticmanager-main:${{ github.event.inputs.releaseTag }} elasticmanager-main:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           event-type: publish-gatsby


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Bump repository-dispatch to v2 because v1 uses node12 (which is deprecated by GitHub)
