### PR TITLE
CM-917: Elasticsearch indexing fixes

### DIFF
--- a/src/cms/src/api/public-advisory/content-types/public-advisory/lifecycles.js
+++ b/src/cms/src/api/public-advisory/content-types/public-advisory/lifecycles.js
@@ -32,13 +32,13 @@ const clearRestCache = async function () {
 module.exports = {
     afterCreate: async (ctx) => {
         await clearRestCache();
-        for (const pa of ctx.result?.protectedAreas || []) {
+        for (const pa of ctx.params?.data?.protectedAreas || []) {
             await indexPark(pa?.id);
         }
     },
     afterUpdate: async (ctx) => {
         await clearRestCache();
-        for (const pa of ctx.result?.protectedAreas || []) {
+        for (const pa of ctx.params?.data?.protectedAreas || []) {
             await indexPark(pa?.id);
         }
     },

--- a/src/cms/src/api/search-indexing/controllers/search-indexing.js
+++ b/src/cms/src/api/search-indexing/controllers/search-indexing.js
@@ -59,6 +59,7 @@ module.exports = ({ strapi }) => ({
         }
       }
     };
+    query.publicationState = "preview";
 
     const { results, pagination } = await strapi.service("api::protected-area.protected-area").find(query);
 

--- a/src/elasticmanager/scripts/indexParks.js
+++ b/src/elasticmanager/scripts/indexParks.js
@@ -104,6 +104,7 @@ const indexPark = async function (park, photos) {
   // if the park isn't visible on the website then remove it from 
   // Elasticsearch instead of adding it
   if (!park.isDisplayed || !park.publishedAt) {
+    getLogger().warn(`removing park ${park.id} due to unpublished or undisplayed status`);
     await removePark(park)
     return true;
   }


### PR DESCRIPTION
### Jira Ticket:
CM-917

### Description:

1. Fixed public-advisory afterCreate and afterUpdate hooks to use `ctx.params.data` instead of `ctx.result` because the latter did not contain the public advisory id.
2. Updated public-advisory-audit lifecycle hooks to use `strapi.entityservice.create` and `strapi.entityservice.delete` instead of `strapi.db.create` and `strapi.db.delete`. These are higher level methods and might work more reliably with chained lifecycle hooks.
3. Updated `getParksForIndexing()` to use `query.publicationState = "preview"`. This fixes a bug where unpublished parks were not being removed and items were being left in the task queue.  
