### PR TITLE
CM-904: Create and populate Search-regions

### DIFF
--- a/src/cms/database/migrations/2023.08.31T00.00.07.search-region.js
+++ b/src/cms/database/migrations/2023.08.31T00.00.07.search-region.js
@@ -1,0 +1,28 @@
+'use strict'
+
+async function up(knex) {
+
+    if (await knex.schema.hasTable('search_regions')) {
+        await knex.raw(`delete from search_regions;`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (3, 'Lower Mainland', 1, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (10, 'South Island', 2, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (7, 'Okanagan', 3, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (5, 'Sea to Sky', 4, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (2, 'Kootenay', 5, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (12, 'Cariboo', 6, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (13, 'Haida Gwaii', 7, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (6, 'North Island', 8, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (4, 'Omineca', 9, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (11, 'Peace', 10, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (9, 'Skeena East', 11, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (8, 'Skeena West', 12, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (14, 'South Central Coast', 13, current_timestamp, current_timestamp);`);
+        await knex.raw(`insert into search_regions(id, search_region_name, "rank", created_at, published_at) values (1, 'Thompson', 14, current_timestamp, current_timestamp);`);
+        await knex.raw(`select setval('search_regions_id_seq', max("id")) from search_regions;`);
+        await knex.raw(`insert into management_areas_search_region_links (management_area_id, search_region_id) select management_area_id, section_id as search_region_id from management_areas_section_links;`);
+        await knex.raw(`update management_areas_search_region_links set search_region_id = 13 where management_area_id = 45;`);
+        await knex.raw(`update management_areas_search_region_links set search_region_id = 14 where management_area_id = 7;`);
+    }
+}
+
+module.exports = { up };

--- a/src/cms/src/api/management-area/content-types/management-area/schema.json
+++ b/src/cms/src/api/management-area/content-types/management-area/schema.json
@@ -38,6 +38,12 @@
       "relation": "manyToOne",
       "target": "api::region.region",
       "inversedBy": "managementAreas"
+    },
+    "searchRegion": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::search-region.search-region",
+      "inversedBy": "managementAreas"
     }
   }
 }

--- a/src/cms/src/api/search-region/content-types/search-region/schema.json
+++ b/src/cms/src/api/search-region/content-types/search-region/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "collectionType",
+  "collectionName": "search_regions",
+  "info": {
+    "singularName": "search-region",
+    "pluralName": "search-regions",
+    "displayName": "Search-region",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "searchRegionName": {
+      "type": "string"
+    },
+    "rank": {
+      "type": "integer",
+      "unique": true,
+      "required": true
+    },
+    "managementAreas": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::management-area.management-area",
+      "mappedBy": "searchRegion"
+    }
+  }
+}

--- a/src/cms/src/api/search-region/controllers/search-region.js
+++ b/src/cms/src/api/search-region/controllers/search-region.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * search-region controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::search-region.search-region');

--- a/src/cms/src/api/search-region/routes/search-region.js
+++ b/src/cms/src/api/search-region/routes/search-region.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * search-region router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::search-region.search-region');

--- a/src/cms/src/api/search-region/services/search-region.js
+++ b/src/cms/src/api/search-region/services/search-region.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * search-region service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::search-region.search-region');


### PR DESCRIPTION
### Jira Ticket:
CM-904

### Description:
Create and populate the Search-regions collection type

NOTE: You might need to run this SQL command after you merge this change because according to [the docs](https://docs.strapi.io/dev-docs/database-migrations), _"migrations are run automatically when the application starts and are executed before the automated schema migrations that Strapi also performs on boot."_
```
delete from strapi_migrations where name = '2023.08.31T00.00.07.search-region.js'
```
