### PR TITLE
CM-907: Temp fix for Gatsby scroll restoration

### DIFF
--- a/src/gatsby/gatsby-browser.js
+++ b/src/gatsby/gatsby-browser.js
@@ -6,4 +6,25 @@ import "./src/styles/style.scss"
 
 export const onRouteUpdate = ({ location, prevLocation }) => {
   sessionStorage.setItem("prevPath", prevLocation ? prevLocation.pathname : null);
-}
+};
+
+// work-around for gatsby issue -- fix scroll restoration
+// see https://github.com/gatsbyjs/gatsby/issues/38201#issuecomment-1658071105
+export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPosition }) => {
+  window.history.scrollRestoration = 'manual';
+  const currentPosition = getSavedScrollPosition(location, location.key);
+  // minimum timeout needs to be somewhat greater than zero the avoid map loading
+  // interferance on park pages
+  let timeout = 100;
+  // use a longer timeout for longer pages so they can finish rendering first
+  if (currentPosition && currentPosition.length > 1 && currentPosition[1]) {
+    const y = currentPosition[1];
+    if (y > (2 * window.innerHeight)) {
+      timeout = 750;
+    }
+  }
+  setTimeout(() => {
+    window.scrollTo(...(currentPosition || [0, 0]));
+  }, timeout);
+  return false;
+};


### PR DESCRIPTION
### Jira Ticket:
CM-907

### Description:
1. Fixed an issue where park pages were scrolling to the middle of the page
2. Fixed an issue where the find-a-park page wasn't scrolling all the way back to where the user came from

This is based on a suggested work-around for this Gatsby issue: https://github.com/gatsbyjs/gatsby/issues/38201
