### PR TITLE
CM-927: Change "not yet available" to "unavailable" on park dates

### DIFF
--- a/src/gatsby/src/components/park/parkDates.js
+++ b/src/gatsby/src/components/park/parkDates.js
@@ -299,7 +299,7 @@ export default function ParkDates({ data }) {
       if (subArea.serviceDates.length === 0
         && subArea.resDates.length === 0
         && subArea.offSeasonDates.length === 0) {
-        subArea.serviceDates.push(`${new Date().getFullYear()}: Dates are not yet available`)
+        subArea.serviceDates.push(`${new Date().getFullYear()}: Dates unavailable`)
       }
     }
   }
@@ -351,7 +351,7 @@ export default function ParkDates({ data }) {
                   </h4>
                 )}
                 {!parkDates && (
-                  <h4 className="my-3">Operating dates are not yet available</h4>
+                  <h4 className="my-3">Operating dates are unavailable</h4>
                 )}
                 <h4 className="my-3">
                   Current status:

--- a/src/gatsby/src/components/park/parkDates.js
+++ b/src/gatsby/src/components/park/parkDates.js
@@ -81,9 +81,7 @@ export const AccordionList = ({ eventKey, subArea, open, isShown, subAreasNotesL
             {subArea.serviceDates.length > 0 && (
               <>
                 <dt className="mt-3">
-                  {subArea?.facilityType?.isCamping || false
-                    ? 'Main camping season dates'
-                    : 'Main operating season dates'}
+                  Main operating season dates
                 </dt>
                 <dd>
                   <ul className="pl-3">

--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -138,7 +138,7 @@ const ParkLink = ({ park }) => {
     if (subArea.serviceDates.length === 0
       && subArea.resDates.length === 0
       && subArea.offSeasonDates.length === 0) {
-      subArea.serviceDates.push(`${new Date().getFullYear()}: Dates are not yet available`)
+      subArea.serviceDates.push(`${new Date().getFullYear()}: Dates unavailable`)
     }
   }
 


### PR DESCRIPTION
### Jira Ticket:
CM-927

### Description:

- Change the wording "not yet available" to "unavailable" on park dates. The new wording still allows parks with missing dates to be identified without falsely implying that there will be dates entered sometime in the future. 
- Removed the conditional check from park pages that showed "Main camping season dates" instead of "Main operating season dates" for camping facilities.  
