### PR TITLE
CM-874: Change initial max-height for ck-editor from 12.5rem to 700px

### DIFF
--- a/src/cms/src/plugins/strapi-plugin-ckeditor/admin/src/components/Input/CKEditor/theme/common.js
+++ b/src/cms/src/plugins/strapi-plugin-ckeditor/admin/src/components/Input/CKEditor/theme/common.js
@@ -298,6 +298,11 @@ export const common = css`
       width: 6em;
   }
 
+  // autoGrow onStartup
+  .ck.ck-content:not(.ck-comment__input *) { 
+    max-height: 700px !important;
+  }
+
   // Custom Styles BC Parks (End)
 
 `;


### PR DESCRIPTION
### Jira Ticket:
CM-874

### Description:
Change the initial (unfocussed) max-height for CKEditor from 12.5rem to 700px to match the focussed max-height. 
