### PR TITLE
CM-935: On Mobile devices-> Filters does not retain when navigating back

### DIFF
--- a/src/gatsby/src/components/search/mobileFilters.js
+++ b/src/gatsby/src/components/search/mobileFilters.js
@@ -42,7 +42,7 @@ const MobileFilters = ({
   const [expandAll, setExpandAll] = useState(false)
 
   const alphabeticAreaItems = areaItems.slice(0)
-  alphabeticAreaItems.sort((a,b) => { return a.label > b.label ? 1 : -1 })
+  alphabeticAreaItems.sort((a, b) => { return a.label > b.label ? 1 : -1 })
 
   const handleExpandAll = () => {
     const newShowFilters = Array.from(showFilters, (filter) => !expandAll)
@@ -63,15 +63,6 @@ const MobileFilters = ({
 
   const searchParkFilter = () => {
     setCurrentPage(1);
-    navigate("/find-a-park", {
-      state: {
-        selectedAreas,
-        selectedCampingFacilities,
-        selectedActivities,
-        selectedFacilities,
-        searchText,
-      },
-    })
     setOpenFilter(false)
   }
 


### PR DESCRIPTION
### Jira Ticket:
CM-935

### Description:
Removed call to `navigate` because it was clearing the querystring and losing the search state.  
