### PR TITLE
CM-851: Fix for error removing parks from elasticsearch

### DIFF
--- a/src/elasticmanager/scripts/indexParks.js
+++ b/src/elasticmanager/scripts/indexParks.js
@@ -125,9 +125,9 @@ const indexPark = async function (park, photos) {
 /**
  *  Removes a single park from Elasticsearch
  */
-const removePark = async function (protectedAreaId) {
+const removePark = async function (park) {
   try {
-    await elasticClient.removePark({ itemId: protectedAreaId });
+    await elasticClient.removePark({ itemId: park.id });
   } catch (error) {
     getLogger().error(error);
     return false;

--- a/src/elasticmanager/utils/elasticClient.js
+++ b/src/elasticmanager/utils/elasticClient.js
@@ -86,7 +86,7 @@ async function removePark({ itemId }) {
   } catch (err) {
     if (!JSON.stringify(err).includes("not_found")) {
       console.log(
-        "Error encountered while removing indexed data from ElasticSearch."
+        `Error encountered while removing indexed data from ElasticSearch.\n${JSON.stringify(err)}`
       );
       throw err;
     }


### PR DESCRIPTION
### Jira Ticket:
CM-851

### Description:
Fixed a bug where the entire park object was being passed to removePark instead of just the id.  
