### PR TITLE
CM-941: Retain search query after in-page navigation

### DIFF
--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -479,13 +479,15 @@ export default function FindAPark({ location, data }) {
       setQsAreas(areas);
     }
     setInputText(searchText)
+    sessionStorage.setItem("lastSearch", window.location.search);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     selectedActivities,
     selectedCampingFacilities,
     selectedFacilities,
     selectedAreas,
-    searchText
+    searchText,
+    currentPage
   ])
 
   useEffect(() => {

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -314,12 +314,14 @@ export default function ParkTemplate({ data }) {
     </GatsbyLink>,
     <GatsbyLink
       key="2"
-      to="/find-a-park"
+      to="/find-a-park/"
       underline="hover"
       onClick={(e) => {
         if (sessionStorage.getItem("prevPath").includes('find-a-park')) {
           e.preventDefault();
           navigate(-1);
+        } else if (sessionStorage.getItem("lastSearch")) {
+          navigate('/find-a-park/' + sessionStorage.getItem("lastSearch"))
         }
       }}>
       Find a park


### PR DESCRIPTION
### Jira Ticket:
CM-941

### Description:
Restore the search querystring in cases where history.back cannot be used 
