### PR TITLE
CM-944: Update strapi-rest-cache ttl & fix helm issue

### DIFF
--- a/infrastructure/helm/bcparks/values-prod.yaml
+++ b/infrastructure/helm/bcparks/values-prod.yaml
@@ -27,6 +27,7 @@ cms:
   env:
     environment: prod
     externalUrl: https://cms.bcparks.ca
+    cacheTtl: "600000"
 
   hpa:
     minReplicas: 2

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -65,7 +65,7 @@ cms:
     smtpReplyTo: noreply@gov.bc.ca
     cacheEnabled: true
     cacheType: redis
-    cacheTtl: 1800000
+    cacheTtl: "60000"
     enableGraphQLPlayground: true
     indexName: bcparks-protected-areas    
 


### PR DESCRIPTION
### Jira Ticket:
CM-944

### Description:
Fix for issue where the rest cache was empty.

- Pass in values as strings because long integers can get converted to exponents by Helm
- Reduce the cache duration for PROD for 30 minutes to 10 minutes
- Reduce the cache duration for all other environments to 1 minute
