### PR TITLE
CM-782: Updates to active advisory location display

### DIFF
--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -88,6 +88,12 @@ module.exports = {
                 },
                 seo: {
                   populate: "*"
+                },
+                fireZones: {
+                  populate: "*"
+                },
+                managementAreas: {
+                  populate: "*"
                 }
               }
             },

--- a/src/gatsby/src/components/advisories/advisoryCard.js
+++ b/src/gatsby/src/components/advisories/advisoryCard.js
@@ -7,11 +7,67 @@ import HTMLArea from "../HTMLArea"
 
 import "../../styles/advisories/advisoryCard.scss"
 
-const AdvisoryCard = ({ advisory, index }) => {
+const AdvisoryCard = ({ advisory, index, parkInfoHash }) => {
   const [open, setOpen] = useState(false)
   const checkRelation = (orcs, orcsSite) => {
     return orcsSite?.includes(orcs?.toString())
   }
+
+  const checkAdditionalParks = () => {
+
+    const advisoryFireCentres = advisory.fireCentres.map(c => { return c.id })
+    const advisoryRegions = advisory.regions.map(r => { return r.id })
+    const advisorySections = advisory.sections.map(s => { return s.id })
+
+    let hasAdditionalParks = false;
+
+    const parkCameFromFireCentre = (protectedAreaId) => {
+      if (!advisoryFireCentres.length) {
+        return false;
+      }
+      const parkFireCentres = parkInfoHash[protectedAreaId.toString()]?.fireCentres || [];
+      return parkFireCentres.filter(value => advisoryFireCentres.includes(value)).length > 0;
+    }
+
+    const parkCameFromRegion = (protectedAreaId) => {
+      if (!advisoryRegions.length) {
+        return false;
+      }
+      const parkRegions = parkInfoHash[protectedAreaId.toString()]?.regions || [];
+      return parkRegions.filter(value => advisoryRegions.includes(value)).length > 0;
+    }
+
+    const parkCameFromSection = (protectedAreaId) => {
+      if (!advisorySections.length) {
+        return false;
+      }
+      const parkSections = parkInfoHash[protectedAreaId.toString()]?.sections || [];
+      return parkSections.filter(value => advisorySections.includes(value)).length > 0;
+    }
+
+    for (const pa of advisory.protectedAreas) {
+      if (showFireCentres) {
+        hasAdditionalParks = hasAdditionalParks || !parkCameFromFireCentre(pa.id)
+      }
+      if (showRegions) {
+        hasAdditionalParks = hasAdditionalParks || !parkCameFromRegion(pa.id)
+      }
+      if (showSections) {
+        hasAdditionalParks = hasAdditionalParks || !parkCameFromSection(pa.id)
+      }
+
+      if (hasAdditionalParks) {
+        break;
+      }
+    }
+
+    return hasAdditionalParks;
+  }
+
+  const showFireCentres = advisory.fireCentres?.length > 0; // 1st priority
+  const showRegions = advisory.regions?.length > 0 && !showFireCentres; // 2nd priority
+  const showSections = advisory.sections?.length > 0 && !showFireCentres && !showRegions;  // 3rd priority
+  const hasAdditionalParks = checkAdditionalParks();
 
   return (
     <>
@@ -92,7 +148,7 @@ const AdvisoryCard = ({ advisory, index }) => {
                     </div>
                   )}
                   <div>
-                    {advisory.fireCentres.length > 0 && advisory.fireCentres.map(
+                    {showFireCentres && advisory.fireCentres.map(
                       (fireCentre, index) => (
                         <Link
                           className="parkLink badge badge-pill badge-primary mb-2 mr-2"
@@ -101,6 +157,31 @@ const AdvisoryCard = ({ advisory, index }) => {
                           {fireCentre.fireCentreName}
                         </Link>
                       ))}
+                    {showRegions && advisory.regions.map(
+                      (region, index) => (
+                        <Link
+                          className="parkLink badge badge-pill badge-primary mb-2 mr-2"
+                          key={index}
+                        >
+                          {region.regionName} Region
+                        </Link>
+                      ))}
+                    {showSections && advisory.sections.map(
+                      (section, index) => (
+                        <Link
+                          className="parkLink badge badge-pill badge-primary mb-2 mr-2"
+                          key={index}
+                        >
+                          {section.sectionName} Section
+                        </Link>
+                      ))}
+                    {hasAdditionalParks &&
+                      <Link
+                        className="parkLink badge-pill badge-secondary-light mb-2 mr-2"
+                      >
+                        Additional parks
+                      </Link>
+                    }
                   </div>
                   <div>
                     {advisory.protectedAreas.length > 5 ? (

--- a/src/gatsby/src/components/advisories/advisoryList.js
+++ b/src/gatsby/src/components/advisories/advisoryList.js
@@ -3,7 +3,7 @@ import React from "react"
 
 import AdvisoryCard from "../advisories/advisoryCard"
 
-const AdvisoryList = ({ advisories }) => {
+const AdvisoryList = ({ advisories, parkInfoHash }) => {
   // NB when paging was done in front-end, this component
   // had more work to do. However this component still processes
   // visible advisories for dates, alerts, etc.
@@ -113,17 +113,21 @@ const AdvisoryList = ({ advisories }) => {
     return (a);
   }
 
-  processAdvisories(advisories);
+  processAdvisories(advisories, parkInfoHash);
 
   return (
-    <>  
-    { haveAdvisories && (       
-      <div>
+    <>
+      {haveAdvisories && (
+        <div>
           {advisories.map((advisory, index) => (
-           <AdvisoryCard key={index} advisory={advisory} index={index}></AdvisoryCard>
+            <AdvisoryCard key={index}
+              advisory={advisory}
+              index={index}
+              parkInfoHash={parkInfoHash}>
+            </AdvisoryCard>
           ))}
-      </div>
-    )}
+        </div>
+      )}
     </>
   );
 

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -313,6 +313,25 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     setPageIndex(p)
   }
 
+  // This hashset is used by the advisoryCard.js component to quiclky 
+  // determine if the advisoriy is associated with any parks in addition 
+  // to the specified  Fire Centres, Regions, or Sections.
+  // Management Areas and Fire Zones are not currently used for anything but 
+  // are included for completeness. The data comes from GraphQL.
+  const buildParkInfoHash = () => {
+    const hash = {};
+    for (const x of (data?.allStrapiProtectedArea.nodes || [])) {
+      hash[x?.strapi_id.toString()] = {
+        managementAreas: x.managementAreas.map(m => { return m.strapi_id }),
+        sections: x.managementAreas.map(m => { return m.section?.id }),
+        regions: x.managementAreas.map(m => { return m.region?.id }),
+        fireZones: x.fireZones.map(m => { return m.strapi_id }),
+        fireCentres: x.fireZones.map(m => { return m.fireCentre?.id })
+      };
+    }
+    return hash;
+  }
+
   // If the filter changes, set data as old and get new data
   useEffect(() => {
     if (isNewFilter) {
@@ -352,6 +371,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   }, [getAdvisoryTotalCount])
 
   const menuContent = data?.allStrapiMenu?.nodes || []
+  const parkInfoHash = buildParkInfoHash();
 
   const breadcrumbs = [
     <Link key="1" href="/" underline="hover">
@@ -401,8 +421,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
           <AdvisoryLegend />
           <AdvisoryList
             advisories={advisories}
-            pageIndex={pageIndex}
-            pageLen={pageLen}
+            parkInfoHash={parkInfoHash}
           ></AdvisoryList>
 
           <AdvisoryPageNav
@@ -451,6 +470,26 @@ export const query = graphql`
         strapi_parent {
           id
           title
+        }
+      }
+    }
+    allStrapiProtectedArea {
+      nodes {
+        strapi_id
+        managementAreas {
+          strapi_id
+          region {
+            id
+          }
+          section {
+            id
+          }
+        }
+        fireZones {
+          strapi_id
+          fireCentre {
+            id
+          }
         }
       }
     }

--- a/src/gatsby/src/styles/advisories/advisoryCard.scss
+++ b/src/gatsby/src/styles/advisories/advisoryCard.scss
@@ -91,6 +91,11 @@
   font-size: 2rem;
 }
 
+.badge-secondary-light {
+  color: $colorBlue;
+  background-color: transparent;
+}
+
 .badge-light {
   color: $colorBlue;
   background-color: transparent;


### PR DESCRIPTION
### Jira Ticket:
CM-782

### Description:
- Use the same treatment for Regions and Sections on the active advisories page that was already being used for Fire Centres
- Show an extra pill for "Additional parks" if there are parks included in the advisory that are not associated with the displayed Fire Centres, Regions or Sections.
