### PR TITLE
CM-495: Revert the use of escaped parknames on park pages

### DIFF
--- a/src/elasticmanager/transformers/park.js
+++ b/src/elasticmanager/transformers/park.js
@@ -38,16 +38,6 @@ exports.createElasticPark = async function (park, photos) {
   }
   delete park.managementAreas;
 
-  // convert parkNames
-  if (park.parkNames?.length) {
-    let parkNames = park.parkNames
-      .filter(n => n.parkNameType?.nameTypeId !== 2)
-      .map(n => {
-        return n.parkName.toLowerCase();
-      });
-    park.parkNames = [...new Set(parkNames || [])];
-  }
-
   // store protectedAreaName as lowercase for sorting
   park.nameLowerCase = park.protectedAreaName.toLowerCase();
 

--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -59,9 +59,6 @@ module.exports = {
             singularName: "protected-area",
             queryParams: {
               populate: {
-                parkNames: {
-                  populate: ["parkNameType"]
-                },
                 parkActivities: {
                   populate: ["activityType"]
                 },

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -13,7 +13,7 @@ import {
 
 import useScrollSpy from "react-use-scrollspy"
 
-import { capitalizeFirstLetter, renderHTML, isNullOrWhiteSpace } from "../utils/helpers";
+import { capitalizeFirstLetter, isNullOrWhiteSpace } from "../utils/helpers";
 import { loadAdvisories } from '../utils/advisoryHelper';
 
 import Footer from "../components/footer"
@@ -307,7 +307,7 @@ export default function ParkTemplate({ data }) {
     parkOrcs: park.orcs
   }
 
-  const parkName = renderHTML(park.parkNames.find(item=> item.parkNameType === PARK_NAME_TYPE.Escaped)?.parkName  || park.protectedAreaName);
+  const parkName = park.protectedAreaName;
 
   const breadcrumbs = [
     <GatsbyLink key="1" to="/" underline="hover">
@@ -664,16 +664,6 @@ export const query = graphql`
           appendStandardCalloutText {
             data
           }
-        }
-      }
-      parkNames {
-        id
-        parkName
-        parkNameType {
-          id
-          nameType
-          nameTypeId
-          description
         }
       }
       parkOperation {


### PR DESCRIPTION
### Jira Ticket:
CM-495

### Description:
Remove unused fields from Gatsby GraphQL to reduce the number of joins needed to populate the data from Strapi 