### PR TITLE
CM-958: Update ck editor CSS for a without href link

### DIFF
--- a/src/cms/src/plugins/strapi-plugin-ckeditor/admin/src/components/Input/CKEditor/theme/common.js
+++ b/src/cms/src/plugins/strapi-plugin-ckeditor/admin/src/components/Input/CKEditor/theme/common.js
@@ -115,6 +115,11 @@ export const common = css`
       text-decoration: underline;
     }
 
+    a:not([href]):not([tabindex]) {
+      text-decoration: none;
+      color: inherit;
+    }
+
     .table {
       margin: 0;
       width: 100%; // Custom Styles BCParks


### PR DESCRIPTION
### Jira Ticket:
CM-958

### Description:
- Public site has override CSS which changes `a` text link colour to be normal text colour if it does not have  `href` link, so applied this override CSS to the ck editor CSS