### PR TITLE
CM-960: Links on top of the park page do not function

### DIFF
--- a/src/gatsby/gatsby-browser.js
+++ b/src/gatsby/gatsby-browser.js
@@ -28,5 +28,5 @@ export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPo
       window.scrollTo(...(currentPosition || [0, 0]));
     }, timeout);
   }
-  return false;
+  return location.hash?.length > 0;
 };


### PR DESCRIPTION
### Jira Ticket:
CM-960

### Description:
Fixed issue preventing park pages from scrolling with location.hash coming from a Gatsby Link
