### PR TITLE
CM-976: Fix missing management document type in management documents list

### DIFF
--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -45,6 +45,7 @@ module.exports = {
           "park-sub-page",
           "public-advisory",
           "search-area",
+          "management-document",
           {
             singularName: "page",
             queryParams: {


### PR DESCRIPTION
### Jira Ticket:
CM-976

### Description:
- Fix missing management document type in the management documents list
- Merge it to main since this issue is happening on PROD
