### PR TITLE
CM-964: Add geoshapes to Strapi and Elasticsearch

### DIFF
--- a/infrastructure/helm/bcparks/templates/elasticmanager/elasticmanager-deployment.yaml
+++ b/infrastructure/helm/bcparks/templates/elasticmanager/elasticmanager-deployment.yaml
@@ -47,6 +47,8 @@ spec:
               value: {{ .Values.cms.env.environment }}
             - name: BATCH_SIZE
               value: {{ .Values.elasticmanager.env.batchSize | quote }}
+            - name: GEOSHAPE_URL
+              value: {{ .Values.elasticmanager.env.shapeDataApi | quote }}
           livenessProbe:
             exec:
               command:

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -279,6 +279,7 @@ elasticmanager:
 
   env:
     batchSize: 20
+    shapeDataApi: "https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=GetFeature&typeName={1}&outputFormat=json&CQL_FILTER=ORCS_PRIMARY%3D%27{0}%27&SrsName=EPSG%3A4326"
 
   resources:
     limits:

--- a/src/cms/config/middlewares.js
+++ b/src/cms/config/middlewares.js
@@ -45,8 +45,17 @@ module.exports = [
   },
   "strapi::logger",
   "strapi::query",
-  "strapi::body",
   "strapi::session",
   "strapi::favicon",
   "strapi::public",
-];
+  {
+    name: 'strapi::body',
+    config: {
+      jsonLimit: '2mb',
+      formLimit: "2mb",
+      textLimit: "2mb",
+      formidable: {
+        maxFileSize: 250 * 1024 * 1024, // multipart data, modify here limit of uploaded file size
+      },
+    },
+  },];

--- a/src/cms/src/api/geo-shape/content-types/geo-shape/schema.json
+++ b/src/cms/src/api/geo-shape/content-types/geo-shape/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "collectionType",
+  "collectionName": "geo_shapes",
+  "info": {
+    "singularName": "geo-shape",
+    "pluralName": "geo-shapes",
+    "displayName": "Geo-shape",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "geometry": {
+      "type": "json"
+    },
+    "protectedArea": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::protected-area.protected-area",
+      "inversedBy": "geoShape"
+    },
+    "orcs": {
+      "type": "integer",
+      "unique": true,
+      "required": true
+    },
+    "isEmpty": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/src/cms/src/api/geo-shape/controllers/geo-shape.js
+++ b/src/cms/src/api/geo-shape/controllers/geo-shape.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * geo-shape controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::geo-shape.geo-shape');

--- a/src/cms/src/api/geo-shape/routes/geo-shape.js
+++ b/src/cms/src/api/geo-shape/routes/geo-shape.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * geo-shape router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::geo-shape.geo-shape');

--- a/src/cms/src/api/geo-shape/services/geo-shape.js
+++ b/src/cms/src/api/geo-shape/services/geo-shape.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * geo-shape service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::geo-shape.geo-shape');

--- a/src/cms/src/api/protected-area/content-types/protected-area/schema.json
+++ b/src/cms/src/api/protected-area/content-types/protected-area/schema.json
@@ -291,6 +291,12 @@
       "relation": "manyToMany",
       "target": "api::terrestrial-ecosection.terrestrial-ecosection",
       "mappedBy": "protectedAreas"
+    },
+    "geoShape": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::geo-shape.geo-shape",
+      "mappedBy": "protectedArea"
     }
   }
 }

--- a/src/cms/src/api/search-indexing/controllers/search-indexing.js
+++ b/src/cms/src/api/search-indexing/controllers/search-indexing.js
@@ -60,7 +60,10 @@ module.exports = ({ strapi }) => ({
           "urgency": { fields: ["id"] },
           "advisoryStatus": { fields: ["id", "code"] }
         }
-      }
+      },
+      geoShape: {
+        fields: ["geometry"],
+      },
     };
     query.publicationState = "preview";
 

--- a/src/elasticmanager/.env.example
+++ b/src/elasticmanager/.env.example
@@ -1,5 +1,6 @@
 STRAPI_BASE_URL=http://127.0.0.1:1337
 ELASTIC_HOST=http://127.0.0.1:9200
+GEOSHAPE_URL="https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=GetFeature&typeName={1}&outputFormat=json&CQL_FILTER=ORCS_PRIMARY%3D%27{0}%27&SrsName=EPSG%3A4326"
 # ELASTIC_USERNAME="elastic"
 # ELASTIC_PASSWORD="<enter-es-password-here>"
 ELASTIC_PARK_INDEX_NAME=bcparks-protected-areas

--- a/src/elasticmanager/index.js
+++ b/src/elasticmanager/index.js
@@ -1,14 +1,13 @@
 
-const { readFile } = require('node:fs/promises');
 const dotenv = require('dotenv');
 
-const { scriptKeySpecified } = require('./utils/commandLine');
+const { scriptKeySpecified, idSpecified, noCommandLineArgs } = require('./utils/commandLine');
 const { getLogger } = require('./utils/logging');
-
 const { indexParks } = require('./scripts/indexParks');
 const { createParkIndex, parkIndexExists } = require('./scripts/createParkIndex');
 const { deleteParkIndex } = require('./scripts/deleteParkIndex');
 const { queueAll } = require('./scripts/queueAllParks');
+const { populateGeoShapes } = require('./scripts/populateGeoShapes');
 
 (async () => {
   dotenv.config({
@@ -22,6 +21,7 @@ const { queueAll } = require('./scripts/queueAllParks');
    * (manually triggered via OpenShift terminal)
    */
   if (scriptKeySpecified("reindex")) {
+    await populateGeoShapes();
     if (!await parkIndexExists()) {
       logger.warn("The Elasticsearch index is missing. It will be recreated.");
       await createParkIndex();
@@ -37,6 +37,7 @@ const { queueAll } = require('./scripts/queueAllParks');
    * (manually triggered via OpenShift terminal)
    */
   if (scriptKeySpecified("rebuild")) {
+    await populateGeoShapes();
     logger.info("Recreating the park search index and reindexing all protectedAreas")
     await deleteParkIndex();
     await createParkIndex();
@@ -46,7 +47,7 @@ const { queueAll } = require('./scripts/queueAllParks');
   }
 
   /**
- * Re-creates the park search index and indexes all parks 
+ * Deletes the park index from Elasticsearch
  * (manually triggered via OpenShift terminal)
  */
   if (scriptKeySpecified("deleteindex")) {
@@ -54,8 +55,17 @@ const { queueAll } = require('./scripts/queueAllParks');
     await deleteParkIndex();
   }
 
+
   /**
-   * Runs the cron task one time 
+   * Populates the geo-shapes collection in Strapi
+  * (manually triggered via OpenShift terminal)
+   */
+  if (scriptKeySpecified("geoshapes")) {
+    await populateGeoShapes();
+  }
+
+  /**
+   * Runs the cron task one time
    * (manually triggered via OpenShift terminal / mainly for debugging purposes)
    */
   if (scriptKeySpecified("once")) {
@@ -63,8 +73,30 @@ const { queueAll } = require('./scripts/queueAllParks');
       logger.warn("The Elasticsearch index is missing. It will be recreated.");
       await createParkIndex();
     }
+    await populateGeoShapes();
     logger.info("Reindexing protectedAreas based on queued-tasks");
     // process the queue in the opposite order to the cron job to minimize duplication    
     await indexParks({ descending: true });
+  }
+
+  /**
+   * Indexes a specific park id
+   * (manually triggered via terminal / mainly for local debugging)
+   */
+  if (idSpecified()) {
+    await indexParks({ id: Number(process.argv[2]) });
+  }
+
+  if (noCommandLineArgs() || scriptKeySpecified("help")) {
+    console.log("\nUsage: \n")
+    console.log("node index.js [command]\n")
+    console.log("Command options:\n")
+    console.log("help        : show this screen")
+    console.log("reindex     : re-index all parks")
+    console.log("rebuild     : re-create the park index and re-index all parks")
+    console.log("deleteindex : delete the park index")
+    console.log("once        : run the cron task one time")
+    console.log("geoshapes   : populate the geo-shapes collection in Strapi")
+    console.log("[integer]   : re-index a specified protectedAreaId\n")
   }
 })();

--- a/src/elasticmanager/scripts/createParkIndex.js
+++ b/src/elasticmanager/scripts/createParkIndex.js
@@ -53,9 +53,12 @@ const createParkIndex = async function () {
             }
           }
         },
-        locationGeo: {
+        location: {
           type: "geo_point"
-        }
+        },
+        geoBoundary: {  // this is a work-around because you can't sort by distance to a shape in Elasticsearch
+          type: "geo_point"
+        },
       }
     }
   };

--- a/src/elasticmanager/scripts/populateGeoShapes.js
+++ b/src/elasticmanager/scripts/populateGeoShapes.js
@@ -31,7 +31,6 @@ exports.populateGeoShapes = async function () {
   })
 
   let parks;
-
   try {
     const allParks = `${process.env.STRAPI_BASE_URL}/api/protected-areas?${query}&filters[typeCode][$ne]=CS`;
     parks = await axios.get(allParks);
@@ -40,12 +39,9 @@ exports.populateGeoShapes = async function () {
     logger.error(`populateGeoShapes.js failed while getting parks, pa's and er's: ${error}`);
     return;
   }
-
-  await processList(parks)
-
+  await processParkList(parks)
 
   let conservancies;
-
   try {
     const allConservancies = `${process.env.STRAPI_BASE_URL}/api/protected-areas?${query}&filters[typeCode][$eq]=CS`;
     conservancies = await axios.get(allConservancies);
@@ -54,13 +50,10 @@ exports.populateGeoShapes = async function () {
     logger.error(`populateGeoShapes.js failed while getting conservancies: ${error}`);
     return;
   }
-
-  await processList(conservancies)
-
+  await processParkList(conservancies)
 };
 
-
-const processList = async function (parks) {
+const processParkList = async function (parks) {
   const httpReqHeaders = {
     'Authorization': 'Bearer ' + process.env.STRAPI_API_TOKEN,
     'Content-Type': 'application/json'

--- a/src/elasticmanager/scripts/populateGeoShapes.js
+++ b/src/elasticmanager/scripts/populateGeoShapes.js
@@ -1,0 +1,123 @@
+const axios = require('axios');
+const { getLogger } = require('../utils/logging');
+const qs = require('qs');
+const { isEmpty } = require('lodash');
+
+/**
+ * Populates the Geo-shapes collection in Strapi
+ */
+exports.populateGeoShapes = async function () {
+  const logger = getLogger();
+
+  const query = qs.stringify({
+    fields: ["orcs", "typeCode"],
+    filters: {
+      geoShape: {
+        geometry: {
+          $null: true
+        }
+      }
+    },
+    populate: {
+      geoShape: { fields: ["orcs"] }
+    },
+    pagination: {
+      limit: -1
+    },
+    publicationState: "preview",
+    sort: "orcs"
+  }, {
+    encodeValuesOnly: true,
+  })
+
+  let parks;
+
+  try {
+    const allParks = `${process.env.STRAPI_BASE_URL}/api/protected-areas?${query}&filters[typeCode][$ne]=CS`;
+    parks = await axios.get(allParks);
+    logger.info(`found ${parks.data.data.length} parks, pa's and er's without geo-shapes`)
+  } catch (error) {
+    logger.error(`populateGeoShapes.js failed while getting parks, pa's and er's: ${error}`);
+    return;
+  }
+
+  await processList(parks)
+
+
+  let conservancies;
+
+  try {
+    const allConservancies = `${process.env.STRAPI_BASE_URL}/api/protected-areas?${query}&filters[typeCode][$eq]=CS`;
+    conservancies = await axios.get(allConservancies);
+    logger.info(`found ${conservancies.data.data.length} conservancies without geo-shapes`)
+  } catch (error) {
+    logger.error(`populateGeoShapes.js failed while getting conservancies: ${error}`);
+    return;
+  }
+
+  await processList(conservancies)
+
+};
+
+
+const processList = async function (parks) {
+  const httpReqHeaders = {
+    'Authorization': 'Bearer ' + process.env.STRAPI_API_TOKEN,
+    'Content-Type': 'application/json'
+  };
+  const logger = getLogger();
+  for (const park of parks.data.data) {
+    if (park.attributes.geoShape.data === null) {
+      const { orcs, typeCode } = park.attributes;
+      if (orcs) {
+        logger.info(`getting geo-shape for orcs ${orcs}`)
+        let shape;
+        try {
+          shape = await getGeoShape(orcs, typeCode);
+        } catch (error) {
+          logger.warn('error getting geoshape from openmaps.gov.bc.ca:')
+          logger.warn(error)
+          continue;
+        }
+        let geoShape;
+        if (shape !== null) {
+          geoShape = {
+            protectedArea: park.id,
+            geometry: shape,
+            orcs: park.attributes.orcs,
+            isEmpty: false
+          };
+        } else {
+          geoShape = {
+            protectedArea: park.id,
+            geometry: [],
+            orcs: park.attributes.orcs,
+            isEmpty: true
+          };
+        }
+        try {
+          await axios.post(`${process.env.STRAPI_BASE_URL}/api/geo-shapes`, { data: geoShape }, { headers: httpReqHeaders });
+        } catch (error) {
+          logger.error(`populateGeoShapes.js failed saving geoshape: ${error}`);
+          continue;
+        }
+      }
+    }
+  }
+}
+
+const getGeoShape = async function (orcs, typeCode) {
+  orcs = orcs.toString().padStart(4, '0');
+  let shapeQuery = process.env.GEOSHAPE_URL.replace("{0}", orcs);
+  if (typeCode === 'CS') {
+    shapeQuery = shapeQuery.replace("{1}", "WHSE_TANTALIS.TA_CONSERVANCY_AREAS_SVW");
+  } else {
+    shapeQuery = shapeQuery.replace("{1}", "WHSE_TANTALIS.TA_PARK_ECORES_PA_SVW");
+  }
+  const response = await axios.get(shapeQuery, { timeout: 3000 });
+  if (response.data.features.length) {
+    return response.data.features[0].geometry;
+  } else {
+    return null;
+  }
+}

--- a/src/elasticmanager/scripts/queueAllParks.js
+++ b/src/elasticmanager/scripts/queueAllParks.js
@@ -1,8 +1,6 @@
 const axios = require('axios');
 const { getLogger } = require('../utils/logging');
 
-
-
 /**
  * Adds all protectedAreas to the queuedTasks so they will 
  * be reindexed by the cron job

--- a/src/elasticmanager/utils/commandLine.js
+++ b/src/elasticmanager/utils/commandLine.js
@@ -1,4 +1,8 @@
 /* Helper functions to make the code more readable */
+const idSpecified = function () {
+    return process.argv.length >= 3 && !isNaN(process.argv[2]);
+}
+
 const scriptKeySpecified = function (scriptKey) {
     return process.argv.length >= 3 && process.argv[2].toLowerCase() === scriptKey.toLowerCase();
 }
@@ -8,6 +12,7 @@ const noCommandLineArgs = function () {
 }
 
 module.exports = {
+    idSpecified,
     scriptKeySpecified,
     noCommandLineArgs
 }

--- a/src/elasticmanager/utils/geoHelpers.js
+++ b/src/elasticmanager/utils/geoHelpers.js
@@ -10,7 +10,7 @@ const flatten = function (shape, decimalPlaces) {
     for (let i = 0; i < flattened.length; i += 2) {
       const lat = Math.round(flattened[i + 1] * roundingVal) / roundingVal;
       const lon = Math.round(flattened[i] * roundingVal) / roundingVal;
-      const point = `${lat},${lon}`;
+      const point = `${lat.toFixed(decimalPlaces)},${lon.toFixed(decimalPlaces)}`;
       if (result.indexOf(point) === -1) {
         result.push(point);
       }
@@ -28,7 +28,7 @@ const appendPoint = function (points, lat, lon, decimalPlaces) {
   lat = Math.round(lat * roundingVal) / roundingVal;
   lon = Math.round(lon * roundingVal) / roundingVal;
   return [
-    ...[`${lat},${lon}`],
+    ...[`${lat.toFixed(decimalPlaces)},${lon.toFixed(decimalPlaces)}`],
     ...points
   ];
 }
@@ -67,7 +67,7 @@ const outline = function (points) {
       cols[coords[1]] = { max: point, min: point }
     } else {
       const c = cols[coords[1]];
-      cols[coords[0]] = { max: strMax(point, c.max), min: strMin(point, c.min) }
+      cols[coords[1]] = { max: strMax(point, c.max), min: strMin(point, c.min) }
     }
   }
 

--- a/src/elasticmanager/utils/geoHelpers.js
+++ b/src/elasticmanager/utils/geoHelpers.js
@@ -1,0 +1,103 @@
+/* 
+  Flattens Polygon or MultiPolygon coordinates into a unique array 
+  of Elasticsearch points with precision reduced to [decimalPlaces] 
+*/
+const flatten = function (shape, decimalPlaces) {
+  const result = [];
+  if (shape) {
+    const roundingVal = Math.pow(10, decimalPlaces);
+    const flattened = shape.flat(Infinity)
+    for (let i = 0; i < flattened.length; i += 2) {
+      const lat = Math.round(flattened[i + 1] * roundingVal) / roundingVal;
+      const lon = Math.round(flattened[i] * roundingVal) / roundingVal;
+      const point = `${lat},${lon}`;
+      if (result.indexOf(point) === -1) {
+        result.push(point);
+      }
+    }
+  }
+  return result;
+}
+
+/*
+  Adds an new point to the array created by flatten with precision 
+  reduced to [decimalPlaces] 
+*/
+const appendPoint = function (points, lat, lon, decimalPlaces) {
+  const roundingVal = Math.pow(10, decimalPlaces);
+  lat = Math.round(lat * roundingVal) / roundingVal;
+  lon = Math.round(lon * roundingVal) / roundingVal;
+  return [
+    ...[`${lat},${lon}`],
+    ...points
+  ];
+}
+
+/* 
+   Reduces an array of geo-points to only include points from the 
+   outer bounds 
+*/
+const outline = function (points) {
+
+  if (points.length < 3) {
+    return points;
+  }
+
+  const cols = {}
+  const rows = {}
+
+  const strMax = function (a, b) {
+    return a > b ? a : b;
+  }
+
+  const strMin = function (a, b) {
+    return a < b ? a : b;
+  }
+
+  for (const point of points) {
+    const coords = point.split(',')
+    if (!rows[coords[0]]) {
+      rows[coords[0]] = { max: point, min: point }
+    } else {
+      const r = rows[coords[0]];
+      rows[coords[0]] = { max: strMax(point, r.max), min: strMin(point, r.min) }
+    }
+
+    if (!cols[coords[1]]) {
+      cols[coords[1]] = { max: point, min: point }
+    } else {
+      const c = cols[coords[1]];
+      cols[coords[0]] = { max: strMax(point, c.max), min: strMin(point, c.min) }
+    }
+  }
+
+  const result = [];
+
+  for (const key in rows) {
+    const item = rows[key]
+    if (result.indexOf(item.max) === -1) {
+      result.push(item.max);
+    }
+    if (result.indexOf(item.min) === -1) {
+      result.push(item.min);
+    }
+  }
+
+  for (const key in cols) {
+    const item = cols[key]
+    if (result.indexOf(item.max) === -1) {
+      result.push(item.max);
+    }
+    if (result.indexOf(item.min) === -1) {
+      result.push(item.min);
+    }
+  }
+
+  return result;
+}
+
+module.exports = {
+  outline,
+  flatten,
+  appendPoint
+}

--- a/src/elasticmanager/utils/geoHelpers.js
+++ b/src/elasticmanager/utils/geoHelpers.js
@@ -5,11 +5,10 @@
 const flatten = function (shape, decimalPlaces) {
   const result = [];
   if (shape) {
-    const roundingVal = Math.pow(10, decimalPlaces);
     const flattened = shape.flat(Infinity)
     for (let i = 0; i < flattened.length; i += 2) {
-      const lat = Math.round(flattened[i + 1] * roundingVal) / roundingVal;
-      const lon = Math.round(flattened[i] * roundingVal) / roundingVal;
+      const lat = flattened[i + 1];
+      const lon = flattened[i];
       const point = `${lat.toFixed(decimalPlaces)},${lon.toFixed(decimalPlaces)}`;
       if (result.indexOf(point) === -1) {
         result.push(point);
@@ -24,9 +23,6 @@ const flatten = function (shape, decimalPlaces) {
   reduced to [decimalPlaces] 
 */
 const appendPoint = function (points, lat, lon, decimalPlaces) {
-  const roundingVal = Math.pow(10, decimalPlaces);
-  lat = Math.round(lat * roundingVal) / roundingVal;
-  lon = Math.round(lon * roundingVal) / roundingVal;
   return [
     ...[`${lat.toFixed(decimalPlaces)},${lon.toFixed(decimalPlaces)}`],
     ...points


### PR DESCRIPTION
### Jira Ticket:
CM-963
CM-964

### Description:
Add geo-shapes to Elasticsearch and Strapi

Note: In order to run this, you need to complete the following steps:

1. copy the `GEOSHAPE_URL` key from `src\elasticmanager\.env.example` to `src\elasticmanager\.env`
2. add permissions to the new Geo-shapes collection type in Strapi admin
    - public role: find and findOne
    - authenticated role: all permissions
3. run `node index.js rebuild` in the Elasticmanager
 