### PR TITLE
CM-994: Don't propagate draft fire bans

### DIFF
--- a/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
+++ b/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
@@ -51,6 +51,7 @@ module.exports = createCoreService(
             }
           ]
         },
+        publicationState: "live",
         populate: '*',
       });
 


### PR DESCRIPTION
### Jira Ticket:
CM-994

### Description:
Fixes a bug where draft fire bans were being propagated to protected areas.  

The propagate script uses the Strapi Entity Service API, and the default publicationState for the Entity Service API is “preview” (whereas the default publication state for the REST API is “live”)
