### PR TITLE
CM-965: Back-end for radius search

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-search.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-search.js
@@ -103,6 +103,8 @@ function parseSearchFilters(query) {
   let facilityNumbers = [];
   let campingNumbers = [];
   let areaNumbers = [];
+  let latitude = NaN;
+  let longitude = NaN;
 
   if (query.activities) {
     if (typeof query.activities === "object") {
@@ -140,6 +142,19 @@ function parseSearchFilters(query) {
       campingNumbers = [parseInt(query.campings, 10)];
     }
   }
+  if (query.near && query.near.indexOf(",") !== -1) {
+    const coords = query.near.split(",");
+    latitude = +coords[0];
+    longitude = +coords[1];
+    // disable radius sorting for points way outside of BC
+    // the API is probably being called incorrectly anyway
+    if (latitude < 47 || latitude > 62) {
+      latitude = NaN;
+    }
+    if (longitude < -135 || longitude > -112) {
+      longitude = NaN;
+    }
+  }
 
   return {
     searchText,
@@ -150,7 +165,9 @@ function parseSearchFilters(query) {
     activityNumbers,
     facilityNumbers,
     areaNumbers,
-    campingNumbers
+    campingNumbers,
+    latitude,
+    longitude
   };
 }
 

--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -19,9 +19,32 @@ module.exports = ({ strapi }) => ({
     campingNumbers,
     limit,
     offset,
+    latitude,
+    longitude
   }) => {
 
     let textFilter = [];
+
+    let sortOrder;
+    if (isNaN(latitude) || isNaN(longitude)) {
+      sortOrder = [
+        "_score",
+        "nameLowerCase.keyword"
+      ];
+    } else {
+      sortOrder = [
+        {
+          _geo_distance: {
+            geoBoundary: `${latitude}, ${longitude}`,
+            order: "asc",
+            unit: "km",
+            mode: "min",
+            distance_type: "arc",
+            ignore_unmapped: true
+          }
+        }
+      ]
+    }
 
     if (searchText) {
       textFilter = [
@@ -134,10 +157,7 @@ module.exports = ({ strapi }) => ({
               ]
             }
           },
-          sort: [
-            "_score",
-            "nameLowerCase.keyword"
-          ],
+          sort: sortOrder,
           _source: [
             "orcs",
             "protectedAreaName",


### PR DESCRIPTION
### Jira Ticket:
CM-965

### Description:
Added a `near` parameter to the querystring for `/protected-areas/search`.  This overrides the default sort order and sorts by distance to the designated point instead.

e.g. http://localhost:1337/api/protected-areas/search?near=49.129,-122.724&queryText=park&areas[]=3&campings[]=1&_start=0&_limit=10
