### PR TITLE
CM-994: reindex parks updated by fireban propagation

### DIFF
--- a/src/cms/src/api/fire-ban-prohibition/controllers/fire-ban-prohibition.js
+++ b/src/cms/src/api/fire-ban-prohibition/controllers/fire-ban-prohibition.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const _ = require("lodash");
+
 /**
  * fire-ban-prohibition controller
  */
@@ -11,6 +13,20 @@ module.exports = createCoreController(
   ({ strapi }) => ({
     async propagate(ctx) {
 
+      let before = [];
+      let after = [];
+
+      try {
+        before = await strapi
+          .service("api::fire-ban-prohibition.fire-ban-prohibition")
+          .getAllProtectedAreaFireBans();
+      } catch (error) {
+        return ctx.internalServerError(
+          "Error in service fire-ban-prohibition:getAllProtectedAreaFireBans()",
+          error.message
+        );
+      }
+
       try {
         await strapi
           .service("api::fire-ban-prohibition.fire-ban-prohibition")
@@ -21,7 +37,7 @@ module.exports = createCoreController(
           error.message
         );
       }
-      
+
       let result;
 
       try {
@@ -33,6 +49,30 @@ module.exports = createCoreController(
           "Error in service fire-ban-prohibition:generateAllProtectedAreaFireBans()",
           error.message
         );
+      }
+
+      try {
+        after = await strapi
+          .service("api::fire-ban-prohibition.fire-ban-prohibition")
+          .getAllProtectedAreaFireBans();
+      } catch (error) {
+        return ctx.internalServerError(
+          "Error in service fire-ban-prohibition:getAllProtectedAreaFireBans()",
+          error.message
+        );
+      }
+
+      const updatedParks = _.difference(before, after).concat(_.difference(after, before))
+
+      const queueList = updatedParks.map(p => {
+        return {
+          action: 'elastic index park',
+          numericData: p
+        }
+      });
+
+      if (queueList.length) {
+        await strapi.db.query("api::queued-task.queued-task").createMany({ data: queueList });
       }
 
       const cachePlugin = strapi.plugins["rest-cache"];

--- a/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
+++ b/src/cms/src/api/fire-ban-prohibition/services/fire-ban-prohibition.js
@@ -108,6 +108,18 @@ module.exports = createCoreService(
         campfireBanCount: campfireBans.length,
         parkCount: rowsUpdated
       };
+    },
+    /* Gets an array of protected area id's that have fire bans
+     */
+    async getAllProtectedAreaFireBans() {
+      const bans = await strapi.db.query("api::protected-area.protected-area")
+        .findMany({
+          where: {
+            hasCampfireBan: true,
+          },
+          select: ['id']
+        });
+      return bans.map(b => { return b.id });
     }
   })
 );


### PR DESCRIPTION
### Jira Ticket:
CM-994

### Description:
Compare the list of parks with firebans before and after running the propagation script.  Any parks with firebans added or removed need to be re-indexed. 
