### PR TITLE
CM-1000: Add extra geo-points to Elasticsearch on long line segments

### DIFF
--- a/src/elasticmanager/utils/geoHelpers.js
+++ b/src/elasticmanager/utils/geoHelpers.js
@@ -23,10 +23,15 @@ const flatten = function (shape, decimalPlaces) {
   reduced to [decimalPlaces] 
 */
 const appendPoint = function (points, lat, lon, decimalPlaces) {
-  return [
-    ...[`${lat.toFixed(decimalPlaces)},${lon.toFixed(decimalPlaces)}`],
-    ...points
-  ];
+  const newPoint = `${lat.toFixed(decimalPlaces)},${lon.toFixed(decimalPlaces)}`;
+  if (points.indexOf(newPoint) === -1) {
+    return [
+      ...[newPoint],
+      ...points
+    ];
+  } else {
+    return points;
+  }
 }
 
 /* 
@@ -92,8 +97,76 @@ const outline = function (points) {
   return result;
 }
 
+/*
+  Adds extra points along long lines
+*/
+const fillLongSegments = function (shape, points, decimalPlaces) {
+  const extraMultiplier = 2; // a higher value limits the # of points added. 10 is equal to a full decimalPlace
+  let polygons = [];
+  let maxSegment = Math.pow(10, -1 * decimalPlaces);
+  const increment = +(maxSegment * extraMultiplier).toFixed(decimalPlaces);
+
+  if (shape?.geometry?.type === 'Polygon') {
+    polygons = shape.geometry.coordinates;
+  }
+
+  if (shape?.geometry?.type === 'MultiPolygon') {
+    polygons = shape.geometry.coordinates.flat(1);
+  }
+
+  for (const polygon of polygons) {
+    for (let i = 0; i < polygon.length - 1; i++) {
+      const p1 = polygon[i];
+      const p2 = polygon[i + 1];
+      let lat1 = p1[1];
+      let lon1 = p1[0];
+      let lat2 = p2[1];
+      let lon2 = p2[0];
+      const vertDiff = Math.abs(lat1 - lat2);
+      const horizDiff = Math.abs(lon1 - lon2);
+      if (vertDiff > increment || horizDiff > increment) {
+        if (vertDiff > horizDiff) {
+          if (lat1 > lat2) {
+            lat2 = lat1;
+            lon2 = lon1;
+            lat1 = p2[1];
+            lon1 = p2[0];
+          }
+          let newLat = +lat1.toFixed(decimalPlaces - 1) + increment;
+          let newLon = lon1 + ((newLat - lat1) / (lat2 - lat1)) * (lon2 - lon1);
+          while (newLat < lat2) {
+            if (newLat > lat1) {
+              points = appendPoint(points, newLat, newLon, 2);
+            }
+            newLat += increment;
+            newLon += (increment / (lat2 - lat1)) * (lon2 - lon1);
+          }
+        } else {
+          if (lon1 > lon2) {
+            lat2 = lat1;
+            lon2 = lon1;
+            lat1 = p2[1];
+            lon1 = p2[0];
+          }
+          let newLon = +lon1.toFixed(decimalPlaces - 1) + increment;
+          let newLat = lat1 + ((newLon - lon1) / (lon2 - lon1)) * (lat2 - lat1);
+          while (newLon < lon2) {
+            if (newLon > lon1) {
+              points = appendPoint(points, newLat, newLon, 2);
+            }
+            newLon += increment;
+            newLat += (increment / (lon2 - lon1)) * (lat2 - lat1);
+          }
+        }
+      }
+    }
+  }
+  return points;
+}
+
 module.exports = {
   outline,
   flatten,
-  appendPoint
+  appendPoint,
+  fillLongSegments
 }


### PR DESCRIPTION
### Jira Ticket:
CM-1000

### Description:

Add extra geo-points to Elasticsearch to fill on gaps along long line segments.  

Manning Park before
<img src="https://user-images.githubusercontent.com/547803/272397723-e54885e5-5010-43a6-b2ae-1012d6a79b56.png"  width="500">

Manning Park after
<img src="https://github.com/bcgov/bcparks.ca/assets/547803/b961bd20-9b03-45f0-94a9-6affda5b4bd5" width="500">
