### PR TITLE
NOBUG: Handle search for ec manning without periods

### DIFF
--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -63,9 +63,9 @@ module.exports = ({ strapi }) => ({
         {
           multi_match: {
             query: searchText,
-            fuzziness: "AUTO",
+            fuzziness: 1,
             type: "best_fields",
-            fields: ["parkNames^2", "protectedAreaName^2"],
+            fields: ["parkNames^2", "protectedAreaName^2", "nameLowerCase"],
             operator: "and"
           }
         }
@@ -304,10 +304,10 @@ module.exports = ({ strapi }) => ({
         {
           multi_match: {
             query: searchText,
-            fuzziness: "AUTO",
+            fuzziness: 1,
             type: "best_fields",
-            fields: ["parkNames^2", "protectedAreaName^5"],
-            operator: "or"
+            fields: ["parkNames^2", "protectedAreaName^5", "nameLowerCase"],
+            operator: "and"
           }
         }];
     }

--- a/src/elasticmanager/transformers/park.js
+++ b/src/elasticmanager/transformers/park.js
@@ -49,7 +49,7 @@ exports.createElasticPark = async function (park, photos) {
   }
 
   // store protectedAreaName as lowercase for sorting
-  park.nameLowerCase = park.protectedAreaName.toLowerCase();
+  park.nameLowerCase = park.protectedAreaName.toLowerCase().replace(/\./g, '');
 
   // convert parkFacilities
   park.hasCamping = false;


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
This fixes an issue where you couldn't search for ec manning without periods (you could only search for "E.C. Manning")
The lowercase park names are now being stored in Elasticsearch with periods removed.  

