### PR TITLE
NOBUG: Renamed elasticmanager scripts

### DIFF
--- a/src/cms/README.md
+++ b/src/cms/README.md
@@ -62,4 +62,4 @@ This step should be completed by someone familiar with OpenShift.  It involves r
 
 5. Run `npm run rebuild` to create the elasticsearch index
 
-6. The cron task will run every 2 minutes on Openshift environments. On your local, you can periodically run `node index.js once` to process the indexing jobs in your Strapi Queued-tasks collection. `node index.js reindex`, `node index.js rebuild` and `node index.js deleteindex` scripts are also available on your local and on the terminal of the elasticmanager container (running on OpenShift).
+6. The cron task will run every minute on Openshift environments. On your local dev environment you can periodically run `node manage.js once` to process the indexing jobs in your Strapi Queued-tasks collection. For a full list of index management commands available, run `node manage.js help`. These management commands are also intended to be run from the terminal of the Elasticmanager container on Openshift.

--- a/src/elasticmanager/manage.js
+++ b/src/elasticmanager/manage.js
@@ -86,7 +86,7 @@ const { populateGeoShapes } = require('./scripts/populateGeoShapes');
 
   if (noCommandLineArgs() || scriptKeySpecified("help")) {
     console.log("\nUsage: \n")
-    console.log("node index.js [command]\n")
+    console.log("node manage.js [command]\n")
     console.log("Command options:\n")
     console.log("help        : show this screen")
     console.log("reindex     : re-index all parks")

--- a/src/elasticmanager/package.json
+++ b/src/elasticmanager/package.json
@@ -3,14 +3,14 @@
   "type": "commonjs",
   "version": "1.0.0",
   "description": "Cron-automated Node.js scripts for indexing elasticsearch",
-  "main": "index.js",
+  "main": "manage.js",
   "scripts": {
     "start": "node server.js",
-    "once": "node index.js once",
-    "deleteindex": "node index.js deleteindex",
-    "reindex": "node index.js reindex",
-    "rebuild": "node index.js rebuild",
-    "liveness": "node index.js liveness"
+    "once": "node manage.js once",
+    "deleteindex": "node manage.js deleteindex",
+    "reindex": "node manage.js reindex",
+    "rebuild": "node manage.js rebuild",
+    "liveness": "node manage.js liveness"
   },
   "author": "mike@oxd.com",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Renamed the elasticmanager file `index.js` to `manage.j`s. This aligns with how frameworks like Django handle management commands, and it lowers the perceived importance of the management command file (`server.js` is actually the main file that runs the cron jobs).  Also updated some docs to reflect recent changes. 
