### PR TITLE
NOBUG: Update kong for search cities

### DIFF
--- a/infrastructure/kong/clean.js
+++ b/infrastructure/kong/clean.js
@@ -23,6 +23,7 @@ const pathsToDelete = [
   "/connect",
   "/email",
   "/geo-shapes",
+  "/search-cities"
 ];
 const paths = data.paths;
 


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
Exclude search cities from Kong export.  BC Parks is not the authoritative source for this data. 
