### PR TITLE
CM-1023: bugfix for submit advisory and save draft as submitter

### DIFF
--- a/src/admin/src/components/composite/advisoryForm/AdvisoryForm.js
+++ b/src/admin/src/components/composite/advisoryForm/AdvisoryForm.js
@@ -1177,7 +1177,7 @@ export default function AdvisoryForm({
                         label="Submit"
                         styling="bcgov-normal-blue btn"
                         onClick={() => {
-                          if (validAdvisoryData(advisoryData, false, mode)) {
+                          if (validAdvisoryData(advisoryData, linksRef, false, mode)) {
                             saveAdvisory("submit");
                           }
                         }}
@@ -1187,7 +1187,7 @@ export default function AdvisoryForm({
                         label="Save Draft"
                         styling="bcgov-normal-light btn"
                         onClick={() => {
-                          if (validAdvisoryData(advisoryData, false, mode)) {
+                          if (validAdvisoryData(advisoryData, linksRef, false, mode)) {
                             saveAdvisory("draft");
                           }
                         }}
@@ -1201,7 +1201,7 @@ export default function AdvisoryForm({
                         label="Submit"
                         styling="bcgov-normal-blue btn"
                         onClick={() => {
-                          if (validAdvisoryData(advisoryData, false, mode)) {
+                          if (validAdvisoryData(advisoryData, linksRef, false, mode)) {
                             updateAdvisory("submit");
                           }
                         }}
@@ -1211,7 +1211,7 @@ export default function AdvisoryForm({
                         label="Save Draft"
                         styling="bcgov-normal-light btn"
                         onClick={() => {
-                          if (validAdvisoryData(advisoryData, false, mode)) {
+                          if (validAdvisoryData(advisoryData, linksRef, false, mode)) {
                             updateAdvisory("draft");
                           }
                         }}

--- a/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
+++ b/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
@@ -25,8 +25,7 @@ module.exports = createCoreController(
         delete version.updatedBy;
       };
 
-      return sanitize.contentAPI.output(entities.results);
+      return this.sanitizeOutput(entities.results, ctx);
     }
-  }
-  )
+  })
 );


### PR DESCRIPTION
### Jira Ticket:
CM-1023

### Description:

- 4 calls to `validAdvisoryData()` were missing the `linksRef` parameter
- Also fixed an unrelated issue that was causing a 500 error retrieving history for public advisory audits
