### PR TITLE
CM-881: Add maxLength to photo caption RTE

### DIFF
--- a/src/cms/src/api/park-photo/content-types/park-photo/schema.json
+++ b/src/cms/src/api/park-photo/content-types/park-photo/schema.json
@@ -25,7 +25,8 @@
     "caption": {
       "type": "customField",
       "options": {
-        "preset": "toolbar"
+        "preset": "toolbar",
+        "maxLengthCharacters": 255
       },
       "customField": "plugin::ckeditor5.CKEditor",
       "required": true


### PR DESCRIPTION
### Jira Ticket:
CM-881

### Description:
Add a maxlength of 255 characters to the photo caption input.  
NOTE: This will show a warning to users, but it won't actually stop them from saving.  
