### PR TITLE
CM-1060: Fix near a city field search issue

### DIFF
--- a/src/gatsby/src/components/search/cityNameSearch.js
+++ b/src/gatsby/src/components/search/cityNameSearch.js
@@ -142,11 +142,19 @@ const CityNameSearch = ({
     }
   }, [])
 
-  // clear input field if text does not exist in options
   useEffect(() => {
+    // clear input field if text does not exist in options
     if (!isDropdownOpen && cityText.length > 0 && !hasResult) {
       setCityText("")
     }
+    // search parks if a user's input is the same as one of the options
+    if (cityText.length > 0 && hasResult) {
+      const enteredCity = cities.filter(city => city.cityName.toLowerCase() === cityText.toLowerCase())
+      if (enteredCity.length > 0) {
+        setSelectedItems(enteredCity)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDropdownOpen, cityText, hasResult])
 
   return (

--- a/src/gatsby/src/components/search/parkNameSearch.js
+++ b/src/gatsby/src/components/search/parkNameSearch.js
@@ -62,8 +62,8 @@ const ParkNameSearch = ({
       setOptions([])
     }
   }, [SEARCH_NAME_URI])
-    // this prevent selecting the first option with the tab key
-    const handleKeyDownInput = () => { }
+  // this prevent selecting the first option with the tab key
+  const handleKeyDownInput = (e) => { handleKeyDownSearch(e) }
 
   return (
     <AsyncTypeahead
@@ -91,7 +91,7 @@ const ParkNameSearch = ({
                 inputRef(node)
                 referenceElementRef(node)
               }}
-              onKeyDown={handleKeyDownInput}
+              onKeyDown={(e) => handleKeyDownInput(e)}
             />
             <label htmlFor="park-search-typeahead">
               By park name


### PR DESCRIPTION
### Jira Ticket:
CM-1060

### Description:
- If the user types the same as one of the options in the near a city field, the user can search parks without selecting
- If the user types some words in the by park name field, the user can search with the enter key
