### PR TITLE
CM-1119: Fix search park field refreshing issue

### DIFF
--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -311,7 +311,7 @@ export default function FindAPark({ location, data }) {
   // event handlers - for searching
   const handleSearch = (clickedCity) => {
     setCurrentPage(1)
-    if (searchText === "") {
+    if (searchText === "" || searchText !== inputText) {
       setSearchText(inputText)
     }
     if (clickedCity?.length > 0) {
@@ -333,6 +333,7 @@ export default function FindAPark({ location, data }) {
   const handleSearchNameChange = (selected) => {
     if (selected.length) {
       setSearchText(selected[0]?.protectedAreaName)
+      setInputText(selected[0]?.protectedAreaName)
     }
   }
   const handleSearchNameInputChange = (text) => {


### PR DESCRIPTION
### Jira Ticket:
CM-1119

### Description:
- Fix search park field refreshing issue
- The issue occurred when a user typed some words and searched, and then typed again without deleting the previous search term (e.g. Search "adams" and select text "adams" and type some new words without clearing the field)
