### PR TITLE
CM-1125: Fix race condition causing 4 REST calls instead of 2.

### DIFF
--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -484,6 +484,7 @@ export default function FindAPark({ location, data }) {
       && qsActivitiesInitialized
       && qsAreasInitialized
       && qsFacilitiesInitialized
+      && (selectedCity.length > 0 || qsLocation === "0" || !qsLocation)
       && Math.sign(qsCampingFacilities.length) === Math.sign(selectedCampingFacilities.length)
       && Math.sign(qsActivities.length) === Math.sign(selectedActivities.length)
       && Math.sign(qsAreas.length) === Math.sign(selectedAreas.length)

--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -643,6 +643,7 @@ export default function FindAPark({ location, data }) {
       }
       setQsLocation(selectedCity[0].strapi_id.toString())
     } else {
+      setQsLocation("");
       setIsCityNameLoading(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Jira Ticket:
CM-1125

### Description:
Two extra rest calls were happening with `near=0,0` in the querystring when the bookmarkable URL was being loaded.  I think this might have been causing a race condition that was causing the error in CM-1125.
