### PR TITLE
CM-1153: Fix photo gallery alignment issue

### DIFF
--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -211,6 +211,10 @@
   &--small {
     height: 196px;
   }
+
+  &--big {
+    margin-top: 4px;
+  }
 }
 
 .show-photos {


### PR DESCRIPTION
### Jira Ticket:
CM-1153

### Description:
Added 4 pixels top margin to big images on park page photo galleries to fix alignment issue
