### PR TITLE
CM-1198: Reduce space between park name and park group label

### DIFF
--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -56,7 +56,7 @@ const ParkLink = ({ park, advisories }) => {
   return (
     <div className="park-list">
       <div className="d-md-flex justify-content-between">
-        <h2>
+        <h2 className="mb-2">
           <GatsbyLink to={`/${park.slug}`}>
             {park.protectedAreaName}
             <ExpandCircleDownIcon />


### PR DESCRIPTION
### Jira Ticket:
CM-1198

### Description:
- Reduce space between park name and park group label
