### PR TITLE
CM-1148: Park access status - update logic to include gates

### DIFF
--- a/src/elasticmanager/transformers/park/operatingDates.js
+++ b/src/elasticmanager/transformers/park/operatingDates.js
@@ -26,7 +26,7 @@ const convertParkOperationSubAreas = function (parkOperationSubAreas) {
       const sa = {
         isActive: true,
         isOpen: true,
-        subareaTypeId: subarea?.parkSubAreaType?.id,
+        subAreaTypeId: subarea?.parkSubAreaType?.id,
         isIgnored: subarea.closureAffectsAccessStatus === null ? null : !subarea.closureAffectsAccessStatus,
         parkOperationSubAreaDates: subarea.parkOperationSubAreaDates
           .filter(d =>

--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -42,6 +42,7 @@ module.exports = {
           "park-operation",
           "park-operation-date",
           "park-operation-sub-area",
+          "park-operation-sub-area-type",
           "park-photo",
           "park-sub-page",
           "public-advisory",
@@ -76,7 +77,12 @@ module.exports = {
                   fields: "*"
                 },
                 parkOperationSubAreas: {
-                  fields: "*"
+                  fields: "*",
+                  populate: {
+                    parkOperationSubAreaType: {
+                      fields: "*"
+                    }
+                  }
                 },
                 managementDocuments: {
                   populate: ["documentType"]

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -92,6 +92,11 @@ exports.createSchemaCustomization = ({ actions }) => {
     longStaySites: String
     groupSitesReservable: String
     boatLaunches: String
+    closureAffectsAccessStatus: Boolean
+  }
+
+  type STRAPI_PARK_OPERATION_SUB_AREA_TYPE implements Node {
+    closureAffectsAccessStatus: Boolean
   }
 
   type STRAPI__COMPONENT_PARKS_SEO implements Node {

--- a/src/gatsby/src/components/park/parkDates.js
+++ b/src/gatsby/src/components/park/parkDates.js
@@ -152,8 +152,6 @@ export default function ParkDates({ data }) {
   const marineProtectedArea = dataCopy.marineProtectedArea || ""
   subAreas.sort((a, b) => (a.parkSubArea >= b.parkSubArea ? 1 : -1))
 
-  const advisories = dataCopy.advisories || []
-
   const [open, setOpen] = useState(false)
 
   // Operations record is required, even if subarea records are present

--- a/src/gatsby/src/components/park/parkHeader.js
+++ b/src/gatsby/src/components/park/parkHeader.js
@@ -14,6 +14,9 @@ export default function ParkHeader({
   isLoadingAdvisories,
   advisoryLoadError,
   advisories,
+  subAreas,
+  operationDates,
+  onStatusCalculated
 }) {
   const reservationsURL = "https://camping.bcparks.ca"
   const dayUsePassURL = "https://reserve.bcparks.ca/dayuse"
@@ -28,7 +31,13 @@ export default function ParkHeader({
           {!isLoadingAdvisories && !advisoryLoadError && (
             <div className="col-12 col-lg-6 d-flex justify-content-around flex-column flex-lg-row order-lg-1 card-parent">
               <div className="row d-flex align-items-center mb-3 mb-lg-0 card-child">
-                <ParkAccessStatus advisories={advisories} slug={slug} />
+                <ParkAccessStatus
+                  advisories={advisories}
+                  slug={slug}
+                  subAreas={subAreas}
+                  operationDates={operationDates}
+                  onStatusCalculated={onStatusCalculated}
+                />
               </div>
               {hasCampfireBan &&
                 <div className="row d-flex align-items-center mb-3 mb-lg-0 card-child">
@@ -65,4 +74,7 @@ ParkHeader.propTypes = {
   advisoryLoadError: PropTypes.any,
   hasReservations: PropTypes.bool,
   advisories: PropTypes.array,
+  subAreas: PropTypes.array.isRequired,
+  operationDates: PropTypes.array.isRequired,
+  onStatusCalculated: PropTypes.func
 }

--- a/src/gatsby/src/components/search/parkCard.js
+++ b/src/gatsby/src/components/search/parkCard.js
@@ -184,6 +184,8 @@ const ParkCard = ({ r }) => {
                       <ParkAccessStatus
                         advisories={r.advisories}
                         slug={r.slug}
+                        subAreas={r.parkOperationSubAreas}
+                        operationDates={r.parkOperationDates}
                       />
                       {r.hasCampfireBan &&
                         <div className="campfire-ban-icon">
@@ -287,6 +289,8 @@ const ParkCard = ({ r }) => {
                     <ParkAccessStatus
                       advisories={r.advisories}
                       slug={r.slug}
+                      subAreas={r.parkOperationSubAreas}
+                      operationDates={r.parkOperationDates}
                     />
                     {r.hasCampfireBan &&
                       <div className="campfire-ban-icon">

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -326,6 +326,8 @@ export default function ParkTemplate({ data }) {
                 isLoadingAdvisories={isLoadingAdvisories}
                 advisoryLoadError={advisoryLoadError}
                 advisories={advisories}
+                subAreas={park.parkOperationSubAreas}
+                operationDates={park.parkOperationDates}
               />
             </div>
           )}
@@ -689,6 +691,7 @@ export const query = graphql`
         reservationNote
         offSeasonNote
         adminNote
+        closureAffectsAccessStatus
         parkOperationSubAreaDates {
           isActive
           operatingYear
@@ -706,6 +709,7 @@ export const query = graphql`
           subAreaType
           subAreaTypeCode
           iconUrl
+          closureAffectsAccessStatus
         }
         facilityType {
           facilityName

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -265,6 +265,8 @@ export default function SiteTemplate({ data }) {
                 isLoadingAdvisories={isLoadingAdvisories}
                 advisoryLoadError={advisoryLoadError}
                 advisories={advisories}
+                subAreas={park.parkOperationSubAreas.filter(sa => sa.orcsSiteNumber === site.orcsSiteNumber)}
+                operationDates={park.parkOperationDates}
               />
             </div>
           )}
@@ -424,6 +426,26 @@ export const query = graphql`
         orcs
         slug
         protectedAreaName
+        parkOperationDates {
+          operatingYear
+          gateOpenDate
+          gateCloseDate
+        }
+        parkOperationSubAreas {
+          orcsSiteNumber
+          isActive
+          isOpen
+          closureAffectsAccessStatus
+          parkOperationSubAreaDates {
+            isActive
+            operatingYear
+            openDate
+            closeDate
+          }
+          parkSubAreaType {
+            closureAffectsAccessStatus
+          }
+        }
       }
       parkActivities {
         isActive


### PR DESCRIPTION
### Jira Ticket:
CM-1148

### Description:

- Added a new "Seasonal restrictions" status which is triggered by park gates closures and subarea closures

Testing notes:
- you'll need to re-index elasticsearch after applying this change because `subareaTypeId` was renamed to `subAreaTypeId`.
- parkSubAreaType and parkSubArea must each have at least one record with a value for `closureAffectsAccessStatus`
> - frontcountry camping. day use, day use area, and picnic area sub-area-types should all be set to true, everything else should be `false`
> - set all frount country campgrounds subareas with "overflow" in their name to `false`
> - only parks that would otherwise show as `Open` will show as Seasonal restrictions when the criteria is met
> - closed and inactive subareas are ignored
> - sub area dates must be explicity set to active