### PR TITLE
CM-1133: Fix park search text overlapping with a clear button

### DIFF
--- a/src/gatsby/src/styles/search.scss
+++ b/src/gatsby/src/styles/search.scss
@@ -1422,9 +1422,13 @@ a.desktop-park-link {
   }
   .rbt-aux {
     width: auto;
+    right: 4px;
     button.close {
-      width: 44px;
-      height: 44px;
+      width: 40px;
+      height: 40px;
+      color: $colorGreyMed;
+      background-color: $colorWhite;
+      opacity: 1;
       margin: 0;
     }
     .spinner-border {


### PR DESCRIPTION
### Jira Ticket:
CM-1133

### Description:
- Fix park search text overlapping with a clear button
