### PR TITLE
CM-1147: Fixed missing period between "Open" and gate sentence

### DIFF
--- a/src/gatsby/src/components/park/parkAccessStatus.js
+++ b/src/gatsby/src/components/park/parkAccessStatus.js
@@ -180,15 +180,15 @@ export default function ParkAccessStatus({ advisories, slug, subAreas, operation
         {accessStatus.parkStatusText === "Open" ? (
           <>
             <img src={accessStatus.parkStatusIcon} alt="" className="mr-2" />
-            {accessStatus.parkStatusText}
+            {accessStatus.parkStatusText}{punctuation}
           </>
         ) : (
           <>
             <img src={accessStatus.parkStatusIcon} alt="" className="mr-2" />
             {accessStatus.parkStatusText}{", "}
             <Link to={`/${slug}/#park-advisory-details-container`}>
-              check advisories{punctuation}
-            </Link>
+              check advisories
+            </Link>{punctuation}
           </>
         )}
       </>)}


### PR DESCRIPTION
### Jira Ticket:
CM-1147

### Description:
Fixed a missing period between "Open" and the gate sentence following the Park Access Status on the park-operating-dates page.  
