### PR TITLE
CM-1201: Update gate logic and display

### DIFF
--- a/src/gatsby/src/components/park/parkAccessStatus.js
+++ b/src/gatsby/src/components/park/parkAccessStatus.js
@@ -180,7 +180,7 @@ export default function ParkAccessStatus({ advisories, slug, subAreas, operation
         {accessStatus.parkStatusText === "Open" ? (
           <>
             <img src={accessStatus.parkStatusIcon} alt="" className="mr-2" />
-            {accessStatus.parkStatusText}
+            {accessStatus.parkStatusText}{punctuation}
           </>
         ) : (
           <>

--- a/src/gatsby/src/components/park/parkDates.js
+++ b/src/gatsby/src/components/park/parkDates.js
@@ -149,7 +149,6 @@ export default function ParkDates({ data }) {
   const parkOperation = dataCopy.parkOperation || {}
   const parkType = dataCopy.parkType
   const subAreas = dataCopy.subAreas || []
-  const marineProtectedArea = dataCopy.marineProtectedArea || ""
   subAreas.sort((a, b) => (a.parkSubArea >= b.parkSubArea ? 1 : -1))
 
   const [open, setOpen] = useState(false)
@@ -243,9 +242,9 @@ export default function ParkDates({ data }) {
                   <GatsbyLink to="#park-advisory-details-container">Check advisories</GatsbyLink> before visiting.
                   Dates may change without notice.
                 </div>
-                {(parkDates && !(parkOperation.hasParkGate === false)) && (
+                {parkDates && (
                   <h4 className="my-3">
-                    The {parkType.toLowerCase()} {marineProtectedArea !== 'Y' && "gate"} is open {parkDates}
+                    The {parkType.toLowerCase()} {parkOperation.hasParkGate !== false && "gate"} is open {parkDates}
                   </h4>
                 )}
                 {!parkDates && (

--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -65,25 +65,20 @@ const ParkLink = ({ park, advisories }) => {
         </h2>
       </div>
       <div className="mb-3">
-        {(parkDates && parkOperation.hasParkGate !== false) ? (
-          <>
-            <div className="mr-1">
-              <ParkAccessStatus
-                advisories={advisories}
-                slug={park.slug}
-                subAreas={park.parkOperationSubAreas}
-                operationDates={park.parkOperationDates}
-              />
-              .
-            </div>
-            <div className="gate-text">The {park.type.toLowerCase()} {park.marineProtectedArea !== 'Y' && "gate"} is open {parkDates}.</div>
-          </>
-        ) : (<ParkAccessStatus
-            advisories={advisories}
-            slug={park.slug}
-            subAreas={park.parkOperationSubAreas}
-            operationDates={park.parkOperationDates}
-            punctuation="." />)}
+        <>
+          <span className="mr-1">
+            <ParkAccessStatus
+              advisories={advisories}
+              slug={park.slug}
+              subAreas={park.parkOperationSubAreas}
+              operationDates={park.parkOperationDates}
+              punctuation={parkDates ? "." : ""}
+            />
+          </span>
+          {parkDates && (
+            <span className="gate-text">The {park.type.toLowerCase()} {parkOperation.hasParkGate !== false && "gate"} is open {parkDates}.</span>
+          )}
+        </>
       </div>
       {/* display table list if the screen size is bigger than 768 px */}
       <table className="table">

--- a/src/gatsby/src/styles/listPage.scss
+++ b/src/gatsby/src/styles/listPage.scss
@@ -179,14 +179,15 @@
         display: inline;
       }
     }
-    .gate-text {
-      margin-left: 24px;
-      padding-left: 0.5rem;
-    }
 
     @media screen and (max-width: $mdBreakpoint) {
       .access-status-icon {
         margin-top: 8px;
+      }
+      .gate-text {
+        margin-left: 24px;
+        padding-left: 0.5rem;
+        display: block;
       }
     }
   }

--- a/src/gatsby/src/utils/parkDatesHelper.js
+++ b/src/gatsby/src/utils/parkDatesHelper.js
@@ -1,7 +1,7 @@
 import moment from "moment"
 import _ from "lodash"
 
-const datePhrase = (openDate, closeDate, fmt, yearRoundText, delimiter, prefix) => {
+const datePhrase = (openDate, closeDate, fmt, yearRoundText, delimiter, prefix, nowrap) => {
   if (openDate && closeDate) {
     try {
       const open = moment(openDate).format(fmt)
@@ -10,7 +10,10 @@ const datePhrase = (openDate, closeDate, fmt, yearRoundText, delimiter, prefix) 
         (open.indexOf("Jan 1") === 0 && close.indexOf("Dec 31") === 0) ||
         (open.indexOf("January 1") === 0 && close.indexOf("December 31") === 0)
       let output = openYearRound ? yearRoundText : `${prefix || ""}${open}${delimiter}${close}`
-      return output.replace(/ /g, "\u00A0")
+      if (nowrap) {
+        return output.replace(/ /g, "\u00A0")
+      }
+      return output;
     } catch (err) {
       console.error("Err formatting date " + openDate + ", " + closeDate)
       return ""
@@ -59,9 +62,9 @@ const processDateRanges = (arr, fmt, yr, delimiter) => {
       groupedByYear.push(phrase);
     }
     if (year !== prevYear) {
-      phrase = `${year}: ${datePhrase(dateRange.start, dateRange.end, fmt, yr, delimiter)}`
+      phrase = `${year}: ${datePhrase(dateRange.start, dateRange.end, fmt, yr, delimiter, "", true)}`
     } else {
-      phrase += `, ${datePhrase(dateRange.start, dateRange.end, fmt, yr, delimiter)}`
+      phrase += `, ${datePhrase(dateRange.start, dateRange.end, fmt, yr, delimiter, "", true)}`
     }
     prevYear = year;
   }


### PR DESCRIPTION
### Jira Ticket:
CM-1201
CM-1154

### Description:
Minor updates to gate logic and display based on UX and QA feedback

CM-1201: 
- Reverted back to single-line accessStatus/gateText display on larger devices
- Streamlined logic for determining when to add a period in the text
- Updated some logic that was adding `&nbsp;` characters to date phrases so it is used more sparingly. It was messing up formatting in some places where it wasn't needed.

CM-1154:
- Removed the check for marineProtectedArea
- Don't hide the gate sentence when `hasParkGate === false`. Instead just remove the word "gate" from the sentence.  