### PR TITLE
CM-1148: Fix caching issue with park-operation-sub-area-dates

### DIFF
--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -42,6 +42,7 @@ module.exports = {
           "park-operation",
           "park-operation-date",
           "park-operation-sub-area",
+          "park-operation-sub-area-date",
           "park-operation-sub-area-type",
           "park-photo",
           "park-sub-page",


### PR DESCRIPTION
### Jira Ticket:
CM-1148

### Description:
Fixed a Gatsby issue where park-operation-sub-area-dates were not getting refreshed unless `gatsby clean` was run
