### PR TITLE
CM-1285: Revamp public advisory audit-tracking fields

### DIFF
--- a/src/admin/src/components/page/advisory/Advisory.js
+++ b/src/admin/src/components/page/advisory/Advisory.js
@@ -790,7 +790,6 @@ export default function Advisory({
           note: notes,
           submittedBy: submittedBy ? submittedBy : submitter,
           createdDate: moment().toISOString(),
-          createdBy: keycloak.tokenParsed.name,
           advisoryDate: advisoryDate,
           effectiveDate: startDate,
           endDate: endDate,
@@ -813,7 +812,9 @@ export default function Advisory({
           isEndDateDisplayed: displayEndDate,
           published_at: new Date(),
           isLatestRevision: true,
-          created_by: keycloak.tokenParsed.name,
+          createdByName: keycloak.tokenParsed.name,
+          createdByRole: isApprover ? "approver" : "submitter",
+          isUrgentAfterHours: !isApprover && (isAfterHours || isStatHoliday) && isAfterHourPublish
         };
 
         cmsAxios // -audit OR -audits
@@ -880,6 +881,7 @@ export default function Advisory({
             updatedDate: updatedDate,
             modifiedDate: moment().toISOString(),
             modifiedBy: keycloak.tokenParsed.name,
+            modifiedByRole: isApprover ? "approver" : "submitter",
             advisoryDate: advisoryDate,
             effectiveDate: startDate,
             endDate: endDate,

--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
@@ -93,6 +93,9 @@
     "modifiedBy": {
       "type": "string"
     },
+    "modifiedByRole": {
+      "type": "string"
+    },
     "accessStatus": {
       "type": "relation",
       "relation": "oneToOne",
@@ -161,6 +164,15 @@
     },
     "publishedRevisionNumber": {
       "type": "integer"
+    },
+    "createdByName": {
+      "type": "string"
+    },
+    "createdByRole": {
+      "type": "string"
+    },
+    "isUrgentAfterHours": {
+      "type": "boolean"
     }
   }
 }

--- a/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
+++ b/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
@@ -89,9 +89,6 @@
     "modifiedDate": {
       "type": "datetime"
     },
-    "modifiedBy": {
-      "type": "string"
-    },
     "accessStatus": {
       "type": "relation",
       "relation": "oneToOne",


### PR DESCRIPTION
### Jira Ticket:
CM-1285

### Description:

1. The `createdBy` field (which should hold a person's full name) hasn't been getting saved to Strapi since the Strapi 4 update.  This is happening because it conflicts with the built-in Strapi database field `created_by_id`.  
      (a.) A new field called `createdByName `will be added to store the missing value
      (b.) `createdByName` should only exist in the publicAdvisoryAudit collection and not in publicAdvisory because https://cms.bcparks.ca/api/public-advisories is publicly accessible, and staff names should not be appearing in the public API unnecessarily.

2. The `modifiedBy` field was in both publicAdvisoryAudit and publicAdvisory. It will be removed from publicAdvisory for the reason stated in 1b above.

4. Three new fields `createdByRole`, `modifiedByRole` and `isUrgentAfterHours` will be added to publicAdvisoryAudit to help to determine when email notifications should be triggered for CM-1259