### PR TITLE
CM-1018: Fix for scheduled advisory publish and expiry

### DIFF
--- a/src/cms/config/cron-tasks.js
+++ b/src/cms/config/cron-tasks.js
@@ -9,7 +9,6 @@
  *
  * See more details here: https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#cron-tasks
  */
-const _ = require("lodash");
 
 module.exports = {
   // Execute the cron at 2 minutes past every hour.
@@ -38,7 +37,7 @@ module.exports = {
             filters: {
               isLatestRevision: true,
               advisoryDate: {
-                $lte: new Date()
+                $lte: new Date().toISOString()
               },
               advisoryStatus: advisoryStatusMap["APR"].id,
             },
@@ -76,7 +75,7 @@ module.exports = {
           "api::public-advisory.public-advisory", {
             filters: {
               expiryDate: {
-                $lte: new Date()
+                $lte: new Date().toISOString()
               },
               advisoryStatus: advisoryStatusMap["PUB"].id,
             },


### PR DESCRIPTION
### Jira Ticket:
CM-1018

### Description:
The examples in the Strapi documentation show that date filters should be passed to the Strapi entityService as ISO strings, not date objects https://docs.strapi.io/dev-docs/api/entity-service/filter#and