### PR TITLE
CM-1167: Email notification for advisories expiring soon

### DIFF
--- a/infrastructure/helm/bcparks/templates/scheduler/scheduler-deployment.yaml
+++ b/infrastructure/helm/bcparks/templates/scheduler/scheduler-deployment.yaml
@@ -59,6 +59,10 @@ spec:
               value: {{ .Values.scheduler.env.emailSender }}
             - name: EMAIL_RECIPIENT
               value: {{ .Values.scheduler.env.emailRecipient | quote }}
+            - name: PUBLIC_URL
+              value: {{ .Values.admin.env.publicUrl | quote }}
+            - name: ADMIN_URL
+              value: {{ .Values.admin.env.externalUrl | quote }}
           livenessProbe:
             exec:
               command:

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -282,7 +282,7 @@ scheduler:
     batchSize: 20
     shapeDataApi: "https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=GetFeature&typeName={1}&outputFormat=json&CQL_FILTER=ORCS_PRIMARY%3D%27{0}%27&SrsName=EPSG%3A4326"
     emailEnabled: true
-    emailServer: smtp.apps.gov.bc.ca
+    emailServer: apps.smtp.gov.bc.ca
     emailPort: 25
     emailSender: parksweb@gov.bc.ca
     emailRecipient: parksweb@gov.bc.ca

--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -158,6 +158,7 @@ module.exports = createCoreController(
             const advisoryStatusMap = await strapi.service("api::public-advisory.scheduling").getAdvisoryStatusMap();
             const publishedCount = await strapi.service("api::public-advisory.scheduling").publish(advisoryStatusMap);
             const expiredCount = await strapi.service("api::public-advisory.scheduling").expire(advisoryStatusMap);
+            const expiringSoonCount = await strapi.service("api::public-advisory.scheduling").expiringSoon(advisoryStatusMap);
 
             const cachePlugin = strapi.plugins["rest-cache"];
             if (cachePlugin && (publishedCount > 0 || expiredCount > 0)) {
@@ -165,7 +166,7 @@ module.exports = createCoreController(
             }
 
             ctx.send({
-                message: `Scheduled public advisory processing complete. ${publishedCount} published. ${expiredCount} expired.`
+                message: `Scheduled public advisory processing complete. ${publishedCount} published. ${expiredCount} expired. ${expiringSoonCount} expiring soon.`
             }, 201);
         }
     })

--- a/src/scheduler/.env.example
+++ b/src/scheduler/.env.example
@@ -1,4 +1,6 @@
 STRAPI_BASE_URL=http://127.0.0.1:1337
+PUBLIC_URL=http://127.0.0.1:8000
+ADMIN_URL=http://127.0.0.1:3000
 ELASTIC_HOST=http://127.0.0.1:9200
 GEOSHAPE_URL="https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=GetFeature&typeName={1}&outputFormat=json&CQL_FILTER=ORCS_PRIMARY%3D%27{0}%27&SrsName=EPSG%3A4326"
 # ELASTIC_USERNAME="elastic"

--- a/src/scheduler/email-alerts/scripts/mailer.js
+++ b/src/scheduler/email-alerts/scripts/mailer.js
@@ -13,7 +13,7 @@ exports.send = async function (subject, body, summary) {
   });
 
   await transporter.sendMail({
-    from: process.env.EMAIL_SENDER,
+    from: `Staff Web Portal <${process.env.EMAIL_SENDER}>`,
     to: process.env.EMAIL_RECIPIENT,
     subject: subject,
     text: summary,

--- a/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
+++ b/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
@@ -36,10 +36,13 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
 
       const emailData = {
         ...emailInfo,
-        ...{ data: advisoryInfo[0] },
-        ...{ postedDate: format(parseJSON(advisoryInfo[0].advisoryDate), "MMMM d, yyyy") },
-        ...{ postedTime: format(parseJSON(advisoryInfo[0].advisoryDate), "h:mma").toLowerCase() },
-        ...{ environment: "alpha-dev-" } // todo: need to specify which environment
+        ...{
+          data: advisoryInfo[0],
+          postedDate: format(parseJSON(advisoryInfo[0].advisoryDate), "MMMM d, yyyy"),
+          postedTime: format(parseJSON(advisoryInfo[0].advisoryDate), "h:mma").toLowerCase(),
+          publicUrl: process.env.PUBLIC_URL,
+          adminUrl: process.env.ADMIN_URL
+        }
       };
 
       // render the email template
@@ -53,7 +56,9 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
 
       if (scriptKeySpecified("emailsend") || noCommandLineArgs()) {
         if (process.env.EMAIL_ENABLED.toLowerCase() !== "false") {
-          await send(emailData.subject, htmlMessageBody, emailData.data.title);
+          const subject = `${emailData.subject}: ${emailData.data.title}`;
+          const summary = emailData.data.description.replace(/(<([^>]+)>)/gi, "");
+          await send(subject, htmlMessageBody, summary);
         }
         await removeFromQueue([message.id])
       }

--- a/src/scheduler/email-alerts/templates/public-advisory.ejs
+++ b/src/scheduler/email-alerts/templates/public-advisory.ejs
@@ -54,10 +54,18 @@
     .manage-advisory-button:hover {
       text-decoration: underline;
     }
+
+    .link {
+      color: #2464a4 !important;
+    }
+
+    .mr-1 {
+      margin-right: 4px;
+    }
   </style>
 </head>
 
-<body style="font-family: Arial, Helvetica;">
+<body style="font-family: Arial, Helvetica; color: #1a1a1a">
   <img src="cid:logo.png" alt="BC Parks" title="BC Parks Logo" style="margin: 8px 16px 0px 0px;" width="150" />
 
   <span class="logo-subheading-text">
@@ -114,12 +122,12 @@
   <% } else { %>
   <p style="margin-top: 4px">
     <% data.protectedAreas.forEach((val) => { %>
-    <a style="margin-right: 4px" href="https://bcparks.ca/<%= val.slug %>">
+    <a class="link mr-1" href="<%= publicUrl %>/<%= val.slug %>">
       <%= val.protectedAreaName %>
     </a>
     <% }) %>
     <% data.sites.forEach((val) => { %>
-    <a style="margin-right: 4px" href="https://bcparks.ca/<%= val.protectedArea.slug %>/<%= val.slug %>">
+    <a class="link mr-1" href="<%= publicUrl %>/<%= val.protectedArea.slug %>/<%= val.slug %>">
       <%= val.siteName %>
     </a>
     <% }) %>
@@ -137,7 +145,7 @@
 
   <p style="margin-top: 32px">
     <% data.links.forEach((val) => { %>
-    <a href="<%= val.url %>">
+    <a href="<%= val.url %>" class="link">
       <%= val.title %>
       <% if (val.url.toLowerCase().endsWith(".pdf")) { %>
       [PDF]
@@ -149,8 +157,8 @@
     <% }) %>
   </p>
 
-  <p style="margin-top: 32px">
-    Posted <%= postedDate %> at <%= postedTime %>
+  <p style=" margin-top: 32px">
+      Posted <%= postedDate %> at <%= postedTime %>
   </p>
 
   <hr />
@@ -162,7 +170,7 @@
   </p>
   <% } %>
 
-  <a href="https://<%= environment %>staff.bcparks.ca/bcparks/advisory-summary/<%= advisoryNumber %>" class="manage-advisory-button">Manage Advisory</a>
+  <a href="<%= adminUrl %>/bcparks/advisory-summary/<%= advisoryNumber %>" class="manage-advisory-button">Manage Advisory</a>
 
 </body>
 


### PR DESCRIPTION
### Jira Ticket:
CM-1167

### Description:
Added the last email trigger for advisories expiring in 1 week
Note that the entry in the queued tasks may be added up to 3 times, but the `THROTTLE_MINUTES` setting in the scheduler will ensure that only 1 email is sent about any specific advisory every 10 minutes. 

Additional changes included in this PR:

1. Fix incorrect smtp server address in helm charts
2. Added environment-specific urls for linking to the public site and the admin site in emails 
3. Added the sender name "Staff Web Portal" to the email `from` header.  
4. Fixed an error in mail subjects, so the advisory headline is prepended to the subject
5. Minor updates to email font colours
