### PR TITLE
CM-1325: Remove unused fields from link-card component

### DIFF
--- a/src/cms/src/components/parks/link-card.json
+++ b/src/cms/src/components/parks/link-card.json
@@ -37,14 +37,6 @@
         "Home66Width",
         "HomeFullWidth"
       ]
-    },
-    "access_status": {
-      "type": "relation",
-      "relation": "oneToOne",
-      "target": "api::access-status.access-status"
-    },
-    "test": {
-      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CM-1325

### Description:
- Remove 2 fields from link-card component since they're not used
- Not sure why, but it seems to be added in this commit: https://github.com/bcgov/bcparks.ca/commit/e602dc0bf7f4b4fdf0734f2a7888612c04a9ad9f#diff-c53d24251a9175ad00c95800a25d18d3ca2fe73d56361bf94d5c0a22eeaf7de9