### PR TITLE
CM-1328: Add natural resource districts to fire bans

### DIFF
--- a/infrastructure/helm/bcparks/templates/etl/etl-cronjob.yaml
+++ b/infrastructure/helm/bcparks/templates/etl/etl-cronjob.yaml
@@ -48,6 +48,8 @@ spec:
                       key: PARK_NAMES_API_KEY
                 - name: DISABLE_BCWFS_CRON
                   value: {{ .Values.etl.disableBcwfsCron | quote }}
+                - name: ENABLE_BCWFS_STANDALONE_PROPAGATION
+                  value: {{ .Values.etl.enableBcwfsStandalonePropagation | quote }}
                 - name: DISABLE_PARK_NAMES_CRON
                   value: {{ .Values.etl.disableParkNamesCron | quote }}
           restartPolicy: "Never"

--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -253,6 +253,7 @@ etl:
   enabled: true
   disableBcwfsCron: true
   disableParkNamesCron: false
+  enableBcwfsStandalonePropagation: false
 
   # Run the cron job every hour at 15 minutes past the hour
   schedule: "15 * * * *"

--- a/src/cms/src/api/fire-ban-prohibition/content-types/fire-ban-prohibition/schema.json
+++ b/src/cms/src/api/fire-ban-prohibition/content-types/fire-ban-prohibition/schema.json
@@ -35,6 +35,11 @@
       "relation": "oneToOne",
       "target": "api::fire-zone.fire-zone"
     },
+    "naturalResourceDistrict": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::natural-resource-district.natural-resource-district"
+    },
     "fireCentreSource": {
       "type": "string"
     }

--- a/src/etl/.env.example
+++ b/src/etl/.env.example
@@ -1,8 +1,9 @@
 BCWFS_BANS_API=https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=GetFeature&typeName=WHSE_LAND_AND_NATURAL_RESOURCE.PROT_BANS_AND_PROHIBITIONS_SP&count=50&outputFormat=json
 STRAPI_BASE_URL=http://localhost:1337
 PARK_NAMES_API=https://dev-data.bcparks.ca/api/parks/names?status=established
-DISABLE_BCWFS_CRON=false
-DISABLE_PARK_NAMES_CRON=false
+DISABLE_BCWFS_CRON='false'
+ENABLE_BCWFS_STANDALONE_PROPAGATION='false'
+DISABLE_PARK_NAMES_CRON='false'
 
 PARK_NAMES_API_KEY=   # get this token from BC Parks
 STRAPI_API_TOKEN=     # you can use the same token as you used for STRAPI_TOKEN in gatsby/.env

--- a/src/etl/index.js
+++ b/src/etl/index.js
@@ -1,6 +1,7 @@
 import * as dotenv from 'dotenv';
 
 import bcwfsLoadData from './scripts/bcwfs-bans.js';
+import bcwfsPropagateData from './scripts/bcwfs-propagate.js';
 import parkNamesLoadData from './scripts/park-names.js';
 import subareaDatesLoadData from './scripts/subarea-dates.js';
 import subareaNotesLoadData from './scripts/subarea-notes.js';
@@ -49,6 +50,11 @@ const DAILY_RUN_HOUR_UTC = 8;
         if (process.env.DISABLE_BCWFS_CRON !== "true") {
             await bcwfsLoadData();
         }
+
+        if (process.env.DISABLE_BCWFS_CRON === "true" && process.env.ENABLE_BCWFS_STANDALONE_PROPAGATION === "true") {
+            await bcwfsPropagateData();
+        }
+
         // add more hourly jobs here
 
         // Run these jobs daily at 12:15am PST or 1:15am PDT

--- a/src/etl/scripts/bcwfs-bans.js
+++ b/src/etl/scripts/bcwfs-bans.js
@@ -141,8 +141,8 @@ const loadData = async function () {
     if (insertions.length > 0 || deletions.length > 0) {
         logger.info(`Propagating firebans to protected areas`);
         try {
-            await axios.post(`${process.env.STRAPI_BASE_URL}/api/fire-ban-prohibitions/propagate`, {}, { headers: httpReqHeaders });
-            logger.info(`Propagation complete`);
+            const { data } = await axios.post(`${process.env.STRAPI_BASE_URL}/api/fire-ban-prohibitions/propagate`, {}, { headers: httpReqHeaders });
+            logger.info(data.message);
         } catch (error) {
             const { response } = error;
             const { data } = response;

--- a/src/etl/scripts/bcwfs-propagate.js
+++ b/src/etl/scripts/bcwfs-propagate.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import * as dotenv from 'dotenv';
+
+import { getLogger } from '../utils/logging.js';
+
+/**
+ *  This enables firebans to be propagated to protected areas every hour when the BCWFS ETL is disabled
+ */
+const propagate = async function () {
+    dotenv.config({
+        path: `.env`,
+    });
+
+    const httpReqHeaders = {
+        'Authorization': 'Bearer ' + process.env.STRAPI_API_TOKEN,
+        'Content-Type': 'application/json'
+    };
+
+    const logger = getLogger();
+    logger.info("PROPAGATING FIREBANS TO PROTECTED AREAS...");
+
+    try {
+        const { data } = await axios.post(`${process.env.STRAPI_BASE_URL}/api/fire-ban-prohibitions/propagate`, {}, { headers: httpReqHeaders });
+        logger.info(data.message);
+    } catch (error) {
+        const { response } = error;
+        const { data } = response;
+        logger.error(`Propagation failed: ${data?.error?.message}. ${data?.error?.details}.`)
+        process.exit(1);
+    }
+
+    logger.info("DONE!")
+};
+
+export default propagate;


### PR DESCRIPTION
### Jira Ticket:
CM-1328

### Description:

- Added natural resource districts to the firebans collection
- Added natural resource districts to fireban propagation
- Changed the logic for fireban propagation so a fireban can be propagated based on both a fire centre and a fire zone at the same time
- Added a stand-alone propagation option to the ETL cron job
