### PR TITLE
CM-1307: Create Strapi fields for URL links to reservation services

### DIFF
--- a/src/cms/src/api/park-operation-sub-area-type/content-types/park-operation-sub-area-type/schema.json
+++ b/src/cms/src/api/park-operation-sub-area-type/content-types/park-operation-sub-area-type/schema.json
@@ -40,6 +40,9 @@
       "type": "boolean",
       "default": false,
       "required": true
+    },
+    "reservationTemplateString": {
+      "type": "text"
     }
   }
 }

--- a/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
+++ b/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
@@ -168,6 +168,9 @@
     },
     "closureAffectsAccessStatus": {
       "type": "boolean"
+    },
+    "reservationOverrideUrl": {
+      "type": "text"
     }
   }
 }

--- a/src/cms/src/api/park-operation/content-types/park-operation/schema.json
+++ b/src/cms/src/api/park-operation/content-types/park-operation/schema.json
@@ -160,6 +160,12 @@
       "relation": "oneToOne",
       "target": "api::site.site",
       "inversedBy": "parkOperation"
+    },
+    "camisResourceLocationId": {
+      "type": "biginteger"
+    },
+    "camisMapId": {
+      "type": "biginteger"
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CM-1307

### Description:
This change adds support for deep URL links to the BC Parks reservation system, which will be used as part of the park page redesign.  

Four new fields have been added

1. ParkOperation.camisResourceLocationId
2. ParkOperation.camisMapId
3. ParkOperationSubAreaType.reservationTemplateString
    - this will be a URL with placeholders, e.g.  https://camping.bcparks.ca/create-booking/results?resourceLocationId={camisResourceLocationId}&mapId={camisMapId}&searchTabGroupId=0&bookingCategoryId=0
4. ParkOperationSubArea.reservationOverrideUrl
   - This field provides a mechanism for overriding the templated URLs. Several cases have been identified that will require manual overrides. 
   - this is also a URL, but without placeholders, e.g. https://camping.bcparks.ca/create-booking/results?mapId=-2147483340&searchTabGroupId=3&bookingCategoryId=6&partySize=1&resourceLocationId=-2147483526&accessPointResourceId=-2147474002

The existing field `ParkOperationSubArea.hasReservations` will also be used to determine when the URLs should appear on the redesigned park pages 

**NOTE: An issue with the CAMIS system was identified while adding these fields, where the `bookingCategoryId` radio buttons always seem to default to the first option on the tab regardless of which option is passed in the URL.**  
