### PR TITLE
CM-1012: Add an option to load all advisories

### DIFF
--- a/src/admin/src/components/composite/dataTable/DataTable.js
+++ b/src/admin/src/components/composite/dataTable/DataTable.js
@@ -47,19 +47,6 @@ const tableIcons = {
 };
 
 export default function DataTable(props) {
-  props.options.pageSize =
-    props.data.length > props.options.pageSize
-      ? props.options.pageSize
-      : props.data.length;
-
-  let newPageSizeOptions = [];
-
-  props.options.pageSizeOptions.forEach((row) => {
-    if (props.data.length > row) newPageSizeOptions.push(row);
-  });
-
-  props.options.pageSizeOptions = newPageSizeOptions;
-
   return (
     <TableContainer component={Paper} className="data-table">
       <MaterialTable icons={tableIcons} {...props} />

--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
@@ -625,7 +625,6 @@ export default function AdvisoryDashboard({
           data-testid="AdvisoryDashboard"
         >
           <br />
-
           <div className="container-fluid">
             <DataTable
               key={publicAdvisories.length}
@@ -633,7 +632,7 @@ export default function AdvisoryDashboard({
                 filtering: true,
                 search: false,
                 pageSize: 50,
-                pageSizeOptions: [25, 50, 100],
+                pageSizeOptions: [25, 50, publicAdvisories.length],
               }}
               onFilterChange={(filters) => {
                 const advisoryFilters = JSON.parse(localStorage.getItem('advisoryFilters'));


### PR DESCRIPTION
### Jira Ticket:
CM-1012

### Description:
- Add an option to load all advisories. I couldn't add text "All" since the component allows to have only numeric prop but staff can choose the last option  (e.g. [25, 50, 100, 537 (all advisory numbers)]) from the dropdown to load all advisories.