### PR TITLE
CM-1270: Update search advisory api population

### DIFF
--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -24,18 +24,17 @@ const populateStandardMessages = function (query) {
     return query;
 }
 
-const appendStandardMessages = function(entity) {
+const appendStandardMessages = function (entity) {
     if (entity) {
         const { description = "", standardMessages } = entity;
         if (standardMessages && standardMessages.length > 0) {
             entity.description = (
-                description +
-                " " +
+                "<p>" + description + "</p>" +
                 standardMessages.map((m) => m.description).join(" ")
             ).trim();
         }
     }
-    return entity;    
+    return entity;
 }
 
 module.exports = createCoreController(

--- a/src/cms/src/api/public-advisory/services/search.js
+++ b/src/cms/src/api/public-advisory/services/search.js
@@ -88,7 +88,7 @@ const buildQuery = function (query) {
     regions: true,
     sections: true,
     sites: { fields: ["siteName", "slug", "isDisplayed", "publishedAt", "orcsSiteNumber"] },
-    standardMesages: true,
+    standardMessages: true,
     urgency: true
   };
 


### PR DESCRIPTION
### Jira Ticket:
CM-1270

### Description:
- Update search advisory api population
- Turned out, a simple misspelling caused an issue that made `standardMessages` missing
