### PR TITLE
CMS-57: Add flag to hide seasonal advisories from the park page

### DIFF
--- a/src/cms/src/api/access-status/content-types/access-status/schema.json
+++ b/src/cms/src/api/access-status/content-types/access-status/schema.json
@@ -26,6 +26,10 @@
     },
     "description": {
       "type": "text"
+    },
+    "hidesSeasonalAdvisory": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -102,7 +102,15 @@ module.exports = createCoreController(
             let pagination;
 
             ctx.query.populate = {
-                accessStatus: { fields: ["accessStatus", "precedence", "color", "groupLabel"] },
+                accessStatus: {
+                    fields: [
+                        "accessStatus",
+                        "precedence",
+                        "color",
+                        "groupLabel",
+                        "hidesSeasonalAdvisory"
+                    ]
+                },
                 eventType: { fields: ["eventType", "precedence"] },
                 urgency: { fields: ["urgency", "code", "sequence", "color"] },
                 advisoryStatus: { fields: ["advisoryStatus", "code"] },

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -104,7 +104,7 @@ export default function ParkTemplate({ data }) {
   const [isLoadingProtectedArea, setIsLoadingProtectedArea] = useState(true)
   const [hasCampfireBan, setHasCampfireBan] = useState(false)
   const [parkAccessStatus, setParkAccessStatus] = useState(null)
-  const [addedWinterGateAdvisory, setAddedWinterGateAdvisory] = useState(false)
+  const [addedSeasonalAdvisory, setAddedSeasonalAdvisory] = useState(false)
 
   useEffect(() => {
     setIsLoadingAdvisories(true)
@@ -283,14 +283,22 @@ export default function ParkTemplate({ data }) {
 
   const parkName = park.protectedAreaName;
 
-  // add seasonal advisory
-  if (parkAccessStatus?.mainGateClosure && !addedWinterGateAdvisory) {
-    advisories.push(WINTER_FULL_PARK_ADVISORY);
-    setAddedWinterGateAdvisory(true);
-  }
-  else if (parkAccessStatus?.areaClosure && !addedWinterGateAdvisory) {
-    advisories.push(WINTER_SUB_AREA_ADVISORY);
-    setAddedWinterGateAdvisory(true);
+  if (!addedSeasonalAdvisory) {
+    // suppress any seasonal advisories if another advisory overrides them.
+    // usually this is due to some sort of full park closure event.
+    if (advisories.some(a => a.accessStatus?.hidesSeasonalAdvisory)) {
+      setAddedSeasonalAdvisory(true);
+    }
+    // add park-level seasonal advisory
+    if (parkAccessStatus?.mainGateClosure) {
+      advisories.push(WINTER_FULL_PARK_ADVISORY);
+      setAddedSeasonalAdvisory(true);
+    }
+    // add subarea seasonal advisory
+    else if (parkAccessStatus?.areaClosure) {
+      advisories.push(WINTER_SUB_AREA_ADVISORY);
+      setAddedSeasonalAdvisory(true);
+    }
   }
 
   const breadcrumbs = [


### PR DESCRIPTION
### Jira Ticket:
CMS-57

### Description:
Added a flag to access-status so the seasonal advisory could be suppressed when there was a full park closure
