### PR TITLE
CMS-62: Add protectedArea and site relation to parkPhoto

### DIFF
--- a/src/cms/src/api/park-photo/content-types/park-photo/lifecycles.js
+++ b/src/cms/src/api/park-photo/content-types/park-photo/lifecycles.js
@@ -22,6 +22,21 @@ const getOrcs = async function (event) {
   return photo?.orcs;
 };
 
+const getOrcsSiteNumber = async function (event) {
+  let { where } = event.params;
+  if (!where.id) {
+    return null;
+  }
+  const photo = await strapi.entityService.findOne(
+    "api::park-photo.park-photo",
+    where.id,
+    {
+      fields: ["orcsSiteNumber"],
+    }
+  );
+  return photo?.orcsSiteNumber;
+};
+
 const getProtectedAreaIdByOrcs = async function (orcs) {
   if (!orcs) {
     return null;
@@ -64,20 +79,40 @@ module.exports = {
   },
   async afterUpdate(event) {
     // If parkPhoto.protectedArea is selected, get that protectedArea.orcs in the parkPhoto.orcs
-    if (event.result?.protectedArea) {
-      const protectedAreaOrcs = event.result.protectedArea.orcs;
-      event.result.orcs = protectedAreaOrcs;
-      await strapi.entityService.update(
-        "api::park-photo.park-photo", event.result.id, { data: { orcs: protectedAreaOrcs } }
-      )
+    if (event.result?.protectedArea !== undefined) {
+      const protectedAreaOrcs = event.result.protectedArea?.orcs;
+      if (event.result.orcs !== protectedAreaOrcs) {
+        event.result.orcs = protectedAreaOrcs;
+        await strapi.entityService.update(
+          "api::park-photo.park-photo", event.result.id, { data: { orcs: protectedAreaOrcs } }
+        )
+      }
+      // If parkPhoto.protectedArea is removed, set parkPhoto.orcs to null
+    } else if (event.result?.protectedArea === null) {
+      const currentOrcs = await getOrcs(event);
+      if (currentOrcs !== null) {
+        await strapi.entityService.update(
+          "api::park-photo.park-photo", event.result.id, { data: { orcs: null } }
+        )
+      }
     }
     // If parkPhoto.site is selected, get that site.orcsSiteNumber in the parkPhoto.orcsSiteNumber
-    if (event.result?.site) {
-      const siteOrcs = event.result.site.orcsSiteNumber;
-      event.result.orcsSiteNumber = siteOrcs;
-      await strapi.entityService.update(
-        "api::park-photo.park-photo", event.result.id, { data: { orcsSiteNumber: siteOrcs } }
-      )
+    if (event.result?.site !== undefined) {
+      const siteOrcs = event.result.site?.orcsSiteNumber;
+      if (event.result.orcsSiteNumber !== siteOrcs) {
+        event.result.orcsSiteNumber = siteOrcs;
+        await strapi.entityService.update(
+          "api::park-photo.park-photo", event.result.id, { data: { orcsSiteNumber: siteOrcs } }
+        )
+      }
+      // If parkPhoto.site is removed, set parkPhoto.orcsSiteNumber to null
+    } else if (event.result?.site === null) {
+      const currentOrcsSiteNumber = await getOrcsSiteNumber(event);
+      if (currentOrcsSiteNumber !== null) {
+        await strapi.entityService.update(
+          "api::park-photo.park-photo", event.result.id, { data: { orcsSiteNumber: null } }
+        )
+      }
     }
     const newProtectedAreaId = await getProtectedAreaIdByOrcs(event.result?.orcs);
     await indexPark(newProtectedAreaId);

--- a/src/cms/src/api/park-photo/content-types/park-photo/lifecycles.js
+++ b/src/cms/src/api/park-photo/content-types/park-photo/lifecycles.js
@@ -43,10 +43,42 @@ const getProtectedAreaIdByOrcs = async function (orcs) {
 
 module.exports = {
   async afterCreate(event) {
+    // If parkPhoto.protectedArea is selected, get that protectedArea.orcs in the parkPhoto.orcs
+    if (event.result?.protectedArea) {
+      const protectedAreaOrcs = event.result.protectedArea.orcs;
+      event.result.orcs = protectedAreaOrcs;
+      await strapi.entityService.update(
+        "api::park-photo.park-photo", event.result.id, { data: { orcs: protectedAreaOrcs } }
+      )
+    }
+    // If parkPhoto.site is selected, get that site.orcsSiteNumber in the parkPhoto.orcsSiteNumber
+    if (event.result?.site) {
+      const siteOrcs = event.result.site.orcsSiteNumber;
+      event.result.orcsSiteNumber = siteOrcs;
+      await strapi.entityService.update(
+        "api::park-photo.park-photo", event.result.id, { data: { orcsSiteNumber: siteOrcs } }
+      )
+    }
     const protectedAreaId = await getProtectedAreaIdByOrcs(event.result?.orcs);
     await indexPark(protectedAreaId);
   },
   async afterUpdate(event) {
+    // If parkPhoto.protectedArea is selected, get that protectedArea.orcs in the parkPhoto.orcs
+    if (event.result?.protectedArea) {
+      const protectedAreaOrcs = event.result.protectedArea.orcs;
+      event.result.orcs = protectedAreaOrcs;
+      await strapi.entityService.update(
+        "api::park-photo.park-photo", event.result.id, { data: { orcs: protectedAreaOrcs } }
+      )
+    }
+    // If parkPhoto.site is selected, get that site.orcsSiteNumber in the parkPhoto.orcsSiteNumber
+    if (event.result?.site) {
+      const siteOrcs = event.result.site.orcsSiteNumber;
+      event.result.orcsSiteNumber = siteOrcs;
+      await strapi.entityService.update(
+        "api::park-photo.park-photo", event.result.id, { data: { orcsSiteNumber: siteOrcs } }
+      )
+    }
     const newProtectedAreaId = await getProtectedAreaIdByOrcs(event.result?.orcs);
     await indexPark(newProtectedAreaId);
   },

--- a/src/cms/src/api/park-photo/content-types/park-photo/schema.json
+++ b/src/cms/src/api/park-photo/content-types/park-photo/schema.json
@@ -5,11 +5,10 @@
     "singularName": "park-photo",
     "pluralName": "park-photos",
     "displayName": "Park-photo",
-    "name": "park-photo"
+    "name": "park-photo",
+    "description": ""
   },
   "options": {
-    "increments": true,
-    "timestamps": true,
     "draftAndPublish": true
   },
   "attributes": {
@@ -55,6 +54,18 @@
       "type": "integer",
       "required": true,
       "default": 100
+    },
+    "protectedArea": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::protected-area.protected-area",
+      "inversedBy": "parkPhotos"
+    },
+    "site": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::site.site",
+      "inversedBy": "parkPhotos"
     }
   }
 }

--- a/src/cms/src/api/protected-area/content-types/protected-area/schema.json
+++ b/src/cms/src/api/protected-area/content-types/protected-area/schema.json
@@ -263,11 +263,6 @@
       "target": "api::public-advisory.public-advisory",
       "mappedBy": "protectedAreas"
     },
-    "parkPhotos": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::park-photo.park-photo"
-    },
     "managementDocuments": {
       "type": "relation",
       "relation": "manyToMany",
@@ -310,6 +305,12 @@
     "hasDiscoverParksLink": {
       "type": "boolean",
       "default": false
+    },
+    "parkPhotos": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::park-photo.park-photo",
+      "mappedBy": "protectedArea"
     }
   }
 }

--- a/src/cms/src/api/site/content-types/site/schema.json
+++ b/src/cms/src/api/site/content-types/site/schema.json
@@ -118,6 +118,12 @@
       "relation": "manyToMany",
       "target": "api::management-document.management-document",
       "mappedBy": "sites"
+    },
+    "parkPhotos": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::park-photo.park-photo",
+      "mappedBy": "site"
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-62

### Description:
- Add protectedArea and site relation to parkPhoto
- If protectedArea/site is added to parkPhoto, its orcs/orcsSiteNumber will be updated too
- No change on FE at this moment
- Data migration will be needed
- Nearby park section file should be updated
