### PR TITLE
CMS-27: Update park overview to highlights in this park

### DIFF
--- a/src/gatsby/src/components/park/parkOverview.js
+++ b/src/gatsby/src/components/park/parkOverview.js
@@ -52,7 +52,7 @@ export default function ParkOverview({ data: parkOverview, type }) {
           onClick={() => {
             setExpanded(!expanded)
           }}>
-          {expanded ? "Read less" : "Read more"}
+          Show {expanded ? "less" : "more"} highlights
           <i className={`fa fa-angle-down ${expanded ? "open" : "close"}`}></i>
         </a>
       }

--- a/src/gatsby/src/components/park/parkOverview.js
+++ b/src/gatsby/src/components/park/parkOverview.js
@@ -1,9 +1,5 @@
 import React, { useState, useEffect, useRef } from "react"
-
-import { capitalizeFirstLetter } from "../../utils/helpers";
-
 import HtmlContent from "./htmlContent"
-
 import * as cheerio from 'cheerio';
 
 const PREFIX = 'park-overview';
@@ -16,37 +12,50 @@ const classes = {
 export default function ParkOverview({ data: parkOverview, type }) {
   const [expanded, setExpanded] = useState(false)
   const [height, setHeight] = useState(0)
+  const [sectionHeight, setSectionHeight] = useState(0)
   const ref = useRef(null)
-
-  useEffect(() => {
-    setHeight(ref.current.clientHeight)
-  }, [expanded])
-
   const isLong = height > 259
 
   const $ = cheerio.load(parkOverview);
   $('a').attr('tabindex', '-1')
   const collapsedParkOverview = $.html()
+  const hasHr = $('hr').length > 0
+
+  useEffect(() => {
+    setHeight(ref.current.clientHeight)
+  }, [expanded])
+
+  useEffect(() => {
+    const h2 = document.querySelector('h2.section-heading');
+    const hr = document.querySelector('hr');
+    // height from the <h2> to the <hr>
+    const height = hr?.getBoundingClientRect().top - h2.getBoundingClientRect().top;
+    setSectionHeight(height)
+  }, [])
 
   return (
     <div id="park-overview-container" className="anchor-link">
-      <div className={expanded ? classes.expanded : classes.collapsed} ref={ref}>
-        <h2 className="section-heading">{capitalizeFirstLetter(`${type} overview`)}</h2>
+      <div
+        ref={ref}
+        className={expanded ? classes.expanded : classes.collapsed}
+        style={{ maxHeight: expanded ? "none" : `${hasHr ? sectionHeight : 260}px` }}
+      >
+        <h2 className="section-heading">Highlights in this {type}</h2>
         <HtmlContent className="park-overview-html">
           {expanded ? parkOverview : collapsedParkOverview}
         </HtmlContent>
       </div>
-      {isLong && 
+      {(hasHr || isLong) &&
         <a
           href="#park-overview-container"
           className="park-overview-link expand-icon"
           onClick={() => {
             setExpanded(!expanded)
           }}>
-        {expanded ? "Read less" : "Read more"}
-        <i className={`fa fa-angle-down ${expanded ? "open" : "close"}`}></i>
-      </a>
+          {expanded ? "Read less" : "Read more"}
+          <i className={`fa fa-angle-down ${expanded ? "open" : "close"}`}></i>
+        </a>
       }
-      </div>
+    </div>
   );
 }

--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -318,6 +318,11 @@ h2.section-heading {
   &.expanded {
     max-height: none;
   }
+  hr {
+    color: transparent;
+    border: none;
+    margin: 0;
+  }
 }
 
 // page section


### PR DESCRIPTION
### Jira Ticket:
CMS-27

### Description:
- Update park overview to highlights in this park
- If there's `<hr>` in RTE, the expand/collapsed toggle button will be displayed at that position, otherwise, it will display at the height of 260px