### PR TITLE
Update README.md with current folder name elasticmanager

### DIFF
--- a/src/cms/README.md
+++ b/src/cms/README.md
@@ -52,7 +52,7 @@ This step should be completed by someone familiar with OpenShift.  It involves r
 
 ### Indexing data for searching
 
-1. Navigate to the bcparks.ca/src/elastic directory.
+1. Navigate to the bcparks.ca/src/elasticmanager directory.
 
 2. Copy the .env.example file to .env (`cp .env.example .env`). 
 


### PR DESCRIPTION
Updated the folder name elastic to elasticmanager in deployment steps.

### Jira Ticket:
NOBUG

### Description:
While deploying the bcparks locally noticed the folder name elastic is outdated. Replaced that with the elasticmanager.
