### PR TITLE
CMS-211: Regenerate Kong config

### DIFF
--- a/infrastructure/kong/README.md
+++ b/infrastructure/kong/README.md
@@ -26,8 +26,10 @@ The important thing thing to note is in step #6 - once you run through the steps
 2. Copy the content of `src/cms/src/extensions/documentation/documentation/1.0.0/full_documentation.json` (the
    generated OpenAPI spec) to `infrastructure/kong/public-documentation.json` (overwriting the existing content).
 3. Run `node clean.js` to remove any private API endpoints from the file.
-4. Download the GWA CLI from https://github.com/bcgov/gwa-cli/releases
+4. Download the GWA CLI from https://github.com/bcgov/gwa-cli/releases. ***
 5. In the infrastructure/kong directory, run (for TEST):
+
+*** You will need gwa version 2.x to publish the API to the gateway, but you will also need version 1.x to run the commands below.  `gwa new` appears to be replaced by the `deck` cli for Kong.
 
    ```sh
    gwa new public-documentation.json --route-host=bcparks.api.gov.bc.ca --service-url=main-cms.c1643c-test.svc --plugins rate-limiting cors  --outfile=public-test.yaml

--- a/infrastructure/kong/clean.js
+++ b/infrastructure/kong/clean.js
@@ -10,10 +10,6 @@ const fs = require("fs");
 const data = require("./public-documentation.json");
 
 const pathsToDelete = [
-  "/public-advisory-audits",
-  "/queued-tasks",
-  "/search-indexing",
-  "/statutory-holiday",
   "/tokens",
   "/email/settings",
   "/upload",
@@ -22,8 +18,6 @@ const pathsToDelete = [
   "/auth",
   "/connect",
   "/email",
-  "/geo-shapes",
-  "/search-cities"
 ];
 const paths = data.paths;
 

--- a/infrastructure/kong/public-prod.yaml
+++ b/infrastructure/kong/public-prod.yaml
@@ -129,6 +129,28 @@ services:
       - tags:
           - OAS3_import
           - ns.bcparks
+        name: get_emergency_alerts
+        methods:
+          - GET
+        paths:
+          - /api/emergency-alerts
+        strip_path: false
+        hosts:
+          - bcparks.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: get_emergency_alerts_id
+        methods:
+          - GET
+        paths:
+          - /api/emergency-alerts/(?<id>\S+)$
+        strip_path: false
+        hosts:
+          - bcparks.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
         name: get_event_types
         methods:
           - GET
@@ -415,6 +437,28 @@ services:
       - tags:
           - OAS3_import
           - ns.bcparks
+        name: get_natural_resource_districts
+        methods:
+          - GET
+        paths:
+          - /api/natural-resource-districts
+        strip_path: false
+        hosts:
+          - bcparks.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: get_natural_resource_districts_id
+        methods:
+          - GET
+        paths:
+          - /api/natural-resource-districts/(?<id>\S+)$
+        strip_path: false
+        hosts:
+          - bcparks.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
         name: get_pages
         methods:
           - GET
@@ -563,6 +607,28 @@ services:
           - GET
         paths:
           - /api/park-operations/(?<id>\S+)$
+        strip_path: false
+        hosts:
+          - bcparks.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: get_park_operation_dates
+        methods:
+          - GET
+        paths:
+          - /api/park-operation-dates
+        strip_path: false
+        hosts:
+          - bcparks.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: get_park_operation_dates_id
+        methods:
+          - GET
+        paths:
+          - /api/park-operation-dates/(?<id>\S+)$
         strip_path: false
         hosts:
           - bcparks.api.gov.bc.ca

--- a/infrastructure/kong/public-prod.yaml
+++ b/infrastructure/kong/public-prod.yaml
@@ -415,28 +415,6 @@ services:
       - tags:
           - OAS3_import
           - ns.bcparks
-        name: get_menus
-        methods:
-          - GET
-        paths:
-          - /api/menus
-        strip_path: false
-        hosts:
-          - bcparks.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
-        name: get_menus_id
-        methods:
-          - GET
-        paths:
-          - /api/menus/(?<id>\S+)$
-        strip_path: false
-        hosts:
-          - bcparks.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
         name: get_natural_resource_districts
         methods:
           - GET
@@ -970,28 +948,6 @@ services:
           - GET
         paths:
           - /api/urgencies/(?<id>\S+)$
-        strip_path: false
-        hosts:
-          - bcparks.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
-        name: get_websites
-        methods:
-          - GET
-        paths:
-          - /api/websites
-        strip_path: false
-        hosts:
-          - bcparks.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
-        name: get_websites_id
-        methods:
-          - GET
-        paths:
-          - /api/websites/(?<id>\S+)$
         strip_path: false
         hosts:
           - bcparks.api.gov.bc.ca

--- a/infrastructure/kong/public-test.yaml
+++ b/infrastructure/kong/public-test.yaml
@@ -129,6 +129,28 @@ services:
       - tags:
           - OAS3_import
           - ns.bcparks
+        name: test_get_emergency_alerts
+        methods:
+          - GET
+        paths:
+          - /api/emergency-alerts
+        strip_path: false
+        hosts:
+          - bcparks.test.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: test_get_emergency_alerts_id
+        methods:
+          - GET
+        paths:
+          - /api/emergency-alerts/(?<id>\S+)$
+        strip_path: false
+        hosts:
+          - bcparks.test.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
         name: test_get_event_types
         methods:
           - GET
@@ -415,6 +437,28 @@ services:
       - tags:
           - OAS3_import
           - ns.bcparks
+        name: test_get_natural_resource_districts
+        methods:
+          - GET
+        paths:
+          - /api/natural-resource-districts
+        strip_path: false
+        hosts:
+          - bcparks.test.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: test_get_natural_resource_districts_id
+        methods:
+          - GET
+        paths:
+          - /api/natural-resource-districts/(?<id>\S+)$
+        strip_path: false
+        hosts:
+          - bcparks.test.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
         name: test_get_pages
         methods:
           - GET
@@ -563,6 +607,28 @@ services:
           - GET
         paths:
           - /api/park-operations/(?<id>\S+)$
+        strip_path: false
+        hosts:
+          - bcparks.test.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: test_get_park_operation_dates
+        methods:
+          - GET
+        paths:
+          - /api/park-operation-dates
+        strip_path: false
+        hosts:
+          - bcparks.test.api.gov.bc.ca
+      - tags:
+          - OAS3_import
+          - ns.bcparks
+        name: test_get_park_operation_dates_id
+        methods:
+          - GET
+        paths:
+          - /api/park-operation-dates/(?<id>\S+)$
         strip_path: false
         hosts:
           - bcparks.test.api.gov.bc.ca

--- a/infrastructure/kong/public-test.yaml
+++ b/infrastructure/kong/public-test.yaml
@@ -415,28 +415,6 @@ services:
       - tags:
           - OAS3_import
           - ns.bcparks
-        name: test_get_menus
-        methods:
-          - GET
-        paths:
-          - /api/menus
-        strip_path: false
-        hosts:
-          - bcparks.test.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
-        name: test_get_menus_id
-        methods:
-          - GET
-        paths:
-          - /api/menus/(?<id>\S+)$
-        strip_path: false
-        hosts:
-          - bcparks.test.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
         name: test_get_natural_resource_districts
         methods:
           - GET
@@ -970,28 +948,6 @@ services:
           - GET
         paths:
           - /api/urgencies/(?<id>\S+)$
-        strip_path: false
-        hosts:
-          - bcparks.test.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
-        name: test_get_websites
-        methods:
-          - GET
-        paths:
-          - /api/websites
-        strip_path: false
-        hosts:
-          - bcparks.test.api.gov.bc.ca
-      - tags:
-          - OAS3_import
-          - ns.bcparks
-        name: test_get_websites_id
-        methods:
-          - GET
-        paths:
-          - /api/websites/(?<id>\S+)$
         strip_path: false
         hosts:
           - bcparks.test.api.gov.bc.ca

--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -169,6 +169,15 @@ module.exports = ({ env }) => {
           expiresIn: "7d",
         },
       },
-    }
+    },
+    documentation: {
+      enabled: true,
+      config: {
+        "x-strapi-config": {
+          // Do not generate for plugins
+          plugins: [],
+        },
+      },
+    },
   };
 };

--- a/src/cms/src/index.js
+++ b/src/cms/src/index.js
@@ -8,7 +8,22 @@ module.exports = {
    *
    * This gives you an opportunity to extend code.
    */
-  register(/*{ strapi }*/) {},
+  register({ strapi }) {
+    strapi
+      .plugin("documentation")
+      .service("override")
+      .excludeFromGeneration([
+        "public-advisory-audit",
+        "queued-task",
+        "search-indexing",
+        "statutory-holiday",
+        "geo-shape",
+        "search-city",
+        "footer-menu",
+        "menu",
+        "website"
+      ]);
+  },
 
   /**
    * An asynchronous bootstrap function that runs before


### PR DESCRIPTION
### Jira Ticket:
CMS-211

### Description:
This fixes an error reported by BC Parks where https://bcparks.api.gov.bc.ca/api/park-operation-dates was not accessible via the API gateway.  

In addition, two new collection types were added to the API gateway
- emergency-alerts
- natural-resource-districts

The configuration of the documentation plugin (which is used to generate the Kong config) was also updated to hide collection types that are only intended to be used internally for the operation of the website.  

- public-advisory-audit
- queued-task
- search-indexing
- statutory-holiday
- geo-shape
- search-city
- footer-menu
- menu
- website
- uploads plugin
- users-permissions plugin