### PR TITLE
CMS-225: Fix advisories error on park operating dates page

### DIFF
--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -152,7 +152,7 @@ module.exports = createCoreController(
                     if (!results[pa.id]) {
                         results[pa.id] = [{ accessStatusId: advisory.accessStatus.id }]
                     } else {
-                        if (!results[pa.id].find(x => x.accessStatusId === advisory.accessStatus.id)) {
+                        if (!results[pa.id].find(x => x.accessStatusId === advisory.accessStatus?.id)) {
                             results[pa.id].push({ accessStatusId: advisory.accessStatus.id })
                         }
                     }


### PR DESCRIPTION
### Jira Ticket:
CMS-225

### Description:
This change fixes an error loading advisories on the park operating dates page. To reproduce the error you need to create an advisory with no access status. 
