### PR TITLE
CMS-239: Advisories not updating in Elasticsearch upon auto-expiry

### DIFF
--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -172,6 +172,7 @@ module.exports = createCoreController(
             const cachePlugin = strapi.plugins["rest-cache"];
             if (cachePlugin && (publishedCount > 0 || expiredCount > 0)) {
                 await cachePlugin.services.cacheStore.clearByUid('api::public-advisory.public-advisory');
+                await cachePlugin.services.cacheStore.clearByUid('api::protected-area.protected-area');
             }
 
             ctx.send({

--- a/src/scheduler/server.js
+++ b/src/scheduler/server.js
@@ -40,7 +40,6 @@ const { sendParkNamesEmails } = require('./email-alerts/scripts/sendParkNamesEma
     }
     try {
       logger.info("Starting cron");
-      await triggerAdvisories();
       recentAdvisoryEmails = await sendAdvisoryEmails(recentAdvisoryEmails);
       await sendParkNamesEmails();
       await populateGeoShapes({ silent: true });
@@ -56,6 +55,10 @@ const { sendParkNamesEmails } = require('./email-alerts/scripts/sendParkNamesEma
       } else {
         await indexParks();
       }
+      // run this task AFTER indexing parks. This gives a 1 minute buffer to ensure
+      // that all the lifecycle hooks and postgres replication have completed before
+      // sending data to Elasticsearch
+      await triggerAdvisories();
 
       // record pod liveness for health check every time the job runs
       // (use shell command to prevent file locking)


### PR DESCRIPTION
### Jira Ticket:
CMS-239

### Description:
1. Changed the order of tasks in the scheduler to ensure a 1 minute buffer between expiring or publishing an advisory and updating the park in Elasticsearch.  This might fix a possible race condition where the park could be getting reindexed before we finished running all the lifecycle hooks. As far as I know Patroni only queries the leader, but if my understanding of Patroni is wrong then this could also fix a Postgres replication delay. 
2. Clear the protected area cache when an advisory is expired or published. This probably wasn't causing the bug because the scheduler users the search-indexing API, not the public-advisories API.
