### PR TITLE
CMS-163: Fix error running strapi 4.25 in non-dev mode

### DIFF
--- a/src/cms/src/admin/app.js
+++ b/src/cms/src/admin/app.js
@@ -9,7 +9,7 @@ import MenuLogoLocal from './extensions/local-icon.png';
 let envBanner = "Strapi"
 let MenuLogo = null
 
-switch (process.env.STRAPI_ADMIN_ENVIRONMENT) {
+switch (process?.env.STRAPI_ADMIN_ENVIRONMENT) {
   case "local":
     MenuLogo = MenuLogoLocal
     envBanner = "Local environment"

--- a/src/cms/src/admin/app.js
+++ b/src/cms/src/admin/app.js
@@ -1,52 +1,7 @@
 import ckeditor5Dll from "ckeditor5/build/ckeditor5-dll.js";
 import ckeditor5MrkdownDll from "@ckeditor/ckeditor5-markdown-gfm/build/markdown-gfm.js";
 
-import MenuLogoProd from './extensions/bcid-icon.png';
-import MenuLogoDev from './extensions/dev-icon.png';
-import MenuLogoTest from './extensions/test-icon.png';
-import MenuLogoLocal from './extensions/local-icon.png';
-
-let envBanner = "Strapi"
-let MenuLogo = null
-
-switch (process?.env.STRAPI_ADMIN_ENVIRONMENT) {
-  case "local":
-    MenuLogo = MenuLogoLocal
-    envBanner = "Local environment"
-    break
-  case "dev":
-    MenuLogo = MenuLogoDev
-    envBanner = "Dev environment"
-    break
-  case "alpha-dev":
-    MenuLogo = MenuLogoDev
-    envBanner = "Alpha dev environment"
-    break
-  case "test":
-    MenuLogo = MenuLogoTest
-    envBanner = "Test environment"
-    break
-  case "alpha-test":
-    MenuLogo = MenuLogoTest
-    envBanner = "Alpha test environment"
-    break
-  case "prod":
-    MenuLogo = MenuLogoProd
-    envBanner = "Production environment"
-    break
-}
-
-const config = {
-  translations: {
-    en: {
-      "app.components.LeftMenu.navbrand.title": envBanner,
-      "app.components.LeftMenu.navbrand.workplace": "Dashboard"
-    },
-  },
-  menu: {
-    logo: MenuLogo,
-  }
-};
+const config = {};
 
 const bootstrap = (app) => { };
 


### PR DESCRIPTION
### Jira Ticket:
CMS-163

### Description:
This block of code never worked in non-dev mode anyway, but now it's causing Strapi admin to fail completely with the error  "process is not defined". The error is on both alpha-dev and alpha-test.
@ayumi-oxd should we just remove this code completely, or keep it because it did work on localdev? I'm leaning toward deleting the entire switch statement

Update: the code has been removed completely