### PR TITLE
CMS-238: Fix the menu child item was not filtered by show boolean

### DIFF
--- a/src/gatsby/src/archived/intro.js
+++ b/src/gatsby/src/archived/intro.js
@@ -91,11 +91,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -269,7 +269,7 @@ const MegaMenu = ({ content, menuMode }) => {
                   </Link>
                 }
               </li>
-              {item.strapi_children.map((page, index) => (
+              {item.strapi_children.filter((page) => page.show).map((page, index) => (
                 <React.Fragment key={index}>
                   <li className={
                     "menu-button menu-button--" +

--- a/src/gatsby/src/pages/404.js
+++ b/src/gatsby/src/pages/404.js
@@ -21,11 +21,13 @@ const NotFoundPage = () => {
           url
           order
           id
+          show
           strapi_children {
             id
             title
             url
             order
+            show
           }
           strapi_parent {
             id

--- a/src/gatsby/src/pages/about/management-plans/approved.js
+++ b/src/gatsby/src/pages/about/management-plans/approved.js
@@ -88,11 +88,13 @@ const ApprovedListPage = () => {
           url
           order
           id
+          show
           strapi_children {
             id
             title
             url
             order
+            show
           }
           strapi_parent {
             id

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -417,11 +417,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -85,11 +85,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/pages/find-a-park/a-z-list.js
+++ b/src/gatsby/src/pages/find-a-park/a-z-list.js
@@ -42,11 +42,13 @@ const ParksPage = () => {
           url
           order
           id
+          show
           strapi_children {
             id
             title
             url
             order
+            show
           }
           strapi_parent {
             id

--- a/src/gatsby/src/pages/index.js
+++ b/src/gatsby/src/pages/index.js
@@ -54,11 +54,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -277,11 +277,13 @@ const ParkOperatingDatesPage = () => {
           url
           order
           id
+          show
           strapi_children {
             id
             title
             url
             order
+            show
           }
           strapi_parent {
             id

--- a/src/gatsby/src/pages/site-map.js
+++ b/src/gatsby/src/pages/site-map.js
@@ -67,11 +67,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/styles/cmsSnippets/parkInfoPage.scss
+++ b/src/gatsby/src/styles/cmsSnippets/parkInfoPage.scss
@@ -47,6 +47,10 @@
   }
 }
 
+.park-overview-link.expand-icon {
+  margin-top: 16px;
+}
+
 .discpver-parks {
   &__col {
     display: block;

--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -43,15 +43,6 @@
         outline: $colorBlueMed solid 2px;
         outline-offset: 0px;
       }
-      &.park-overview-link {
-        display: inline-block;
-        text-decoration: none;
-        margin-top: 24px;
-        &:hover, &:focus-visible {
-          color: $colorBlue;
-          text-decoration: underline;
-        }
-      }
     }
     & > div.w-100:last-of-type {
       min-height: calc(100vh - 380px);

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -914,11 +914,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/templates/parkSubPage.js
+++ b/src/gatsby/src/templates/parkSubPage.js
@@ -260,11 +260,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -538,11 +538,13 @@ export const query = graphql`
         url
         order
         id
+        show
         strapi_children {
           id
           title
           url
           order
+          show
         }
         strapi_parent {
           id

--- a/src/gatsby/src/templates/staticContent1.js
+++ b/src/gatsby/src/templates/staticContent1.js
@@ -30,11 +30,13 @@ export default function StaticContent1({ pageContext }) {
           url
           order
           id
+          show
           strapi_children {
             id
             title
             url
             order
+            show
           }
           strapi_parent {
             id

--- a/src/gatsby/src/templates/staticLanding1.js
+++ b/src/gatsby/src/templates/staticLanding1.js
@@ -28,11 +28,13 @@ const LandingPage = ({ pageContext }) => {
           url
           order
           id
+          show
           strapi_children {
             id
             title
             url
             order
+            show
           }
           strapi_parent {
             id


### PR DESCRIPTION
### Jira Ticket:
CMS-238

### Description:
- Fix the menu child item was not filtered by show boolean
- GraphQL doesn't filter nested relations at the child level (e.g. menu.strapi_children) so filtering was needed on FE
- Fix some styling issues on the Park page