### PR TITLE
CMS-246: Add new reservation fields

### DIFF
--- a/src/cms/database/migrations/2024.07.29T00.00.16.rename-has-reservations.js
+++ b/src/cms/database/migrations/2024.07.29T00.00.16.rename-has-reservations.js
@@ -1,0 +1,9 @@
+'use strict'
+
+async function up(knex) {
+  if (await knex.schema.hasColumn('park_operations', 'has_frontcountry_reservations')) {
+    await knex.raw(`update park_operations set has_frontcountry_reservations = has_reservations;`);
+  }
+}
+
+module.exports = { up };

--- a/src/cms/src/api/park-operation/content-types/park-operation/schema.json
+++ b/src/cms/src/api/park-operation/content-types/park-operation/schema.json
@@ -21,6 +21,9 @@
     "hasReservations": {
       "type": "boolean"
     },
+    "hasFrontcountryReservations": {
+      "type": "boolean"
+    },
     "isDateRangeAnnual": {
       "type": "boolean"
     },
@@ -189,23 +192,44 @@
     "frontcountryGroupReservationUrl": {
       "type": "string"
     },
+    "hasFrontcountryGroupReservations": {
+      "type": "boolean"
+    },
     "frontcountryCabinReservationUrl": {
       "type": "string"
+    },
+    "hasFrontcountryCabinReservations": {
+      "type": "boolean"
     },
     "backcountryGroupReservationUrl": {
       "type": "string"
     },
+    "hasBackcountryGroupReservations": {
+      "type": "boolean"
+    },
     "backcountryWildernessReservationUrl": {
       "type": "string"
+    },
+    "hasBackcountryWildernessReservations": {
+      "type": "boolean"
     },
     "backcountryShelterReservationUrl": {
       "type": "string"
     },
+    "hasBackcountryShelterReservations": {
+      "type": "boolean"
+    },
     "canoeCircuitReservationUrl": {
       "type": "string"
     },
+    "hasCanoeCircuitReservations": {
+      "type": "boolean"
+    },
     "groupPicnicReservationUrl": {
       "type": "string"
+    },
+    "hasGroupPicnicReservations": {
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-246

### Description:
1. Added the following fields

- hasFrontcountryReservations (replaces hasReservations which will be dropped later)
- hasFrontcountryGroupReservations
- hasFrontcountryCabinReservations
- hasBackcountryGroupReservations
- hasBackcountryWildernessReservations
- hasBackcountryShelterReservations
- hasCanoeCircuitReservations
- hasGroupPicnicReservations

2. Copied data from  hasReservations to hasFrontCountryReservations

Note: you will need to delete the most recent migration from the strapi_migrations table and run it again. 