### PR TITLE
CMS-267: Update handleImgError

### DIFF
--- a/src/gatsby/src/utils/helpers.js
+++ b/src/gatsby/src/utils/helpers.js
@@ -48,9 +48,11 @@ export const addSmallImagePrefix = (str) => {
   return url.substring(0, i + 1) + "small_" + url.substring(i + 1, url.length)
 }
 export const handleImgError = (errorStates, setErrorStates, index) => {
-  const newErrorStates = Array.isArray(errorStates) ? [...errorStates] : []
-  newErrorStates[index] = true
-  setErrorStates(newErrorStates)
+  setErrorStates(prevErrorStates => {
+    const newErrorStates = [...prevErrorStates]
+    newErrorStates[index] = true
+    return newErrorStates
+  })
   console.clear()
 }
 export const useScreenSize = () => {


### PR DESCRIPTION
### Jira Ticket:
CMS-267

### Description:
- Update handleImgError
- Fix the issue that the previous error state is not inherited