### PR TITLE
CMS-307: Add max width to text content on park and site page

### DIFF
--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -45,8 +45,8 @@
       }
     }
     div:not(.accordion-content) {
-      & > .raw-html-content {
-        & > p, & > ul {
+      & > .raw-html-content:not(.accordion-header) {
+        & > :not(blockquote) {
           max-width: 600px;
         }
       }

--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -44,6 +44,13 @@
         outline-offset: 0px;
       }
     }
+    div:not(.accordion-content) {
+      & > .raw-html-content {
+        & > p, & > ul {
+          max-width: 600px;
+        }
+      }
+    }
     & > div.w-100:last-of-type {
       min-height: calc(100vh - 380px);
       padding-bottom: 64px;


### PR DESCRIPTION
### Jira Ticket:
CMS-307

### Description:
- Add max width to text content from RTE on the park and site page
- This change doesn't apply to the accordions and the blockquote
