### PR TITLE
NOBUG: Fix gatsby build error

### DIFF
--- a/src/gatsby/src/components/park/campingDetails.js
+++ b/src/gatsby/src/components/park/campingDetails.js
@@ -19,7 +19,9 @@ export const CampingType = ({ camping }) => {
   const ref = useRef(null)
   const isLong = height > 259
   const campingDescription = !isNullOrWhiteSpace(camping.description?.data) ?
-    camping.description.data : camping?.campingType?.defaultDescription.data
+    camping.description.data :
+    !isNullOrWhiteSpace(camping?.campingType?.defaultDescription?.data) ?
+      camping.campingType.defaultDescription.data : ""
 
   const $ = cheerio.load(campingDescription)
   $('a').attr('tabindex', '-1')
@@ -28,7 +30,7 @@ export const CampingType = ({ camping }) => {
 
   useEffect(() => {
     setHeight(ref.current.clientHeight)
-  }, [expanded])
+  }, [expanded, camping])
 
   useEffect(() => {
     if (ref.current) {


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
- Fix gatsby build error: https://github.com/bcgov/bcparks.ca/actions/runs/10411420229/job/28835288044#step:11:249
```
  19 |     return function load(content, options, isDocument = true) {
  20 |         if (content == null) {
> 21 |             throw new Error('cheerio.load() expects a string');
     | ^
  22 |         }
  23 |         const internalOpts = { ...defaultOptions, ...flattenOptions(options) };
  24 |         const initialRoot = parse(content, internalOpts, isDocument, null);


  WebpackError:cheerio.load() expects a string
```
