### PR TITLE
CMS-351: Inactive subareas are shown in Dates of Operation

### DIFF
--- a/src/gatsby/src/components/park/parkDates.js
+++ b/src/gatsby/src/components/park/parkDates.js
@@ -294,6 +294,7 @@ export default function ParkDates({ data }) {
                 </button>
               )}
               {subAreas
+                .filter(subArea => subArea.isActive)
                 .map((subArea, index) => (
                   <AccordionList
                     key={index}


### PR DESCRIPTION
### Jira Ticket:
CMS-351

### Description:
This fixes a bug where inactive subareas are being shown in the dates of operation section.  
