### PR TITLE
CMS-353: Data migration for nature and culture

### DIFF
--- a/src/cms/database/migrations/2024.08.22T00.00.20.nature-and-culture.js
+++ b/src/cms/database/migrations/2024.08.22T00.00.20.nature-and-culture.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const cheerio = require('cheerio');
+
+async function up(knex) {
+  if (await knex.schema.hasColumn('protected_areas', 'history')) {
+
+    const protectedAreas = await strapi.db.query("api::protected-area.protected-area").findMany();
+
+    for (const pa of protectedAreas) {
+      let text = (pa.natureAndCulture || "").replace('<p>&nbsp;</p>', '');
+      text = text.replace("</strong>&nbsp;</p>", "</strong></p>");
+      text = text.replace(":</strong>", "</strong></p><p>");
+      text = text.replace(": </strong>", "</strong></p><p>");
+      text = text.replace(/<\/strong><br>/g, "</strong></p><p>");
+
+      let matchH3 = false;
+      let matchH4 = false;
+      let matchP = false;
+
+      const $ = cheerio.load(`<div>${text}</div>`, null, false);
+      let contentBlocks = []
+      $("div > p > strong").each(function (i, elm) {
+        contentBlocks.push($(this).html().replace(": ", "").replace(":", "").replace("&nbsp;", "").toLowerCase())
+        matchP = true;
+      });
+      $("div > h3").each(function (i, elm) {
+        contentBlocks.push($(this).html().replace("<strong>", "").replace("</strong>", "").replace(": ", "").replace(":", "").replace("&nbsp;", "").toLowerCase())
+        matchH3 = true;
+      });
+      $("div > h4").each(function (i, elm) {
+        contentBlocks.push($(this).html().replace(": ", "").replace(":", "").replace("&nbsp;", "").toLowerCase())
+        matchH4 = true;
+      });
+
+      let onlyHasWhitelistedCategories = true;
+
+      for (let category of contentBlocks) {
+        if (!["conservation", "cultural heritage", "history", "wildlife"].includes(category)) {
+          onlyHasWhitelistedCategories = false;
+        }
+      }
+
+      let hasInvalidStructure = false;
+      if (contentBlocks.length > 0 && !text.startsWith("<h3>") && !text.startsWith("<h4>") && !text.startsWith("<p><strong>") && onlyHasWhitelistedCategories) {
+        hasInvalidStructure = true;
+      }
+
+      let parsedSections = [];
+      if (contentBlocks.length > 0 && onlyHasWhitelistedCategories && !hasInvalidStructure) {
+        if (matchH3) {
+          let parts = text.split("<h3>");
+          for (const p1 of parts) {
+            let parsedPart = {
+              title: p1.split("</h3>")[0],
+              text: p1.split("</h3>")[1]
+            }
+            parsedSections.push(parsedPart)
+          }
+        }
+        if (matchH4 && !matchH3) {
+          let parts = text.split("<h4>");
+          for (const p2 of parts) {
+            let parsedPart = {
+              title: p2.split("</h4>")[0],
+              text: p2.split("</h4>")[1]
+            }
+            parsedSections.push(parsedPart)
+          }
+        }
+        if (matchP && !matchH3 && !matchH4) {
+          let parts = text.split("<p><strong>");
+          for (const p3 of parts) {
+            try {
+              let parsedPart = {
+                title: p3.split("</strong></p>")[0],
+                text: p3.split("</strong></p>")[1]
+              }
+              parsedSections.push(parsedPart)
+            } catch (ex) {
+              console.log(JSON.stringify(ex))
+            }
+          }
+        }
+      }
+
+      if (parsedSections.length) {
+        parsedSections.shift();
+        const obj = {};
+        if (parsedSections.length) {
+          for (const section of parsedSections) {
+            const fieldName = section.title.toLowerCase().replace(" ", "").replace("culturalheritage", "cultural_heritage").replace("<strong>", "").replace("</strong>", "").replace("&nbsp;", "");
+            obj[fieldName] = section.text;
+          }
+          await knex('protected_areas').where({ id: pa.id }).update(obj);
+        }
+      }
+    }
+
+    await knex.raw("update protected_areas set conservation = nature_and_culture where type = 'Ecological Reserve';");
+    await knex.raw("update protected_areas set nature_and_culture = '' where type = 'Ecological Reserve';");
+
+    // todo: this line is disabled to allow QA to compare the fields
+    // await knex.raw("update protected_areas set nature_and_culture = '' where conservation <> '' or history <> '' or cultural_heritage <> '' or wildlife <> '';");
+  }
+}
+
+module.exports = { up };

--- a/src/cms/src/api/protected-area/content-types/protected-area/schema.json
+++ b/src/cms/src/api/protected-area/content-types/protected-area/schema.json
@@ -340,6 +340,34 @@
       "relation": "oneToMany",
       "target": "api::park-contact.park-contact",
       "mappedBy": "protectedArea"
+    },
+    "conservation": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "culturalHeritage": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "history": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "wildlife": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-353

### Description:

- This script migrates the nature and culture field into 4 new fields
- Only parks with a parsable nature and culture section will be migrated
- To run the migration script, you'll need to delete a strapi migration and restart strapi
`2024.08.22T00.00.20.nature-and-culture.js`
- The line of code that removes the old data from the natureAndCulture field has been commented out in the migration so QA can compare the data

