### PR TITLE
CMS-371: Remove h3 tags from safety_info and special_notes

### DIFF
--- a/src/cms/database/migrations/2024.08.26T00.00.21.safety-h3.js
+++ b/src/cms/database/migrations/2024.08.26T00.00.21.safety-h3.js
@@ -1,0 +1,20 @@
+'use strict'
+
+async function up(knex) {
+  // turn h3 into h4 and turn h4 into h5
+  await knex.raw(`update protected_areas set safety_info = replace(safety_info, '<h3', '<h4') where safety_info like '%<h3%' and safety_info not like '%<h4%'`);
+  await knex.raw(`update protected_areas set safety_info = replace(safety_info, '</h3', '</h4') where safety_info like '%</h3%' and safety_info not like '%</h4%'`);
+  await knex.raw(`update protected_areas set safety_info = replace(safety_info, '</h4', '</h5') where (safety_info like '%</h3%' and safety_info like '%</h4%') and safety_info not like '%</h5%'`);
+  await knex.raw(`update protected_areas set safety_info = replace(safety_info, '<h4', '<h5') where (safety_info like '%<h3%' and safety_info like '%<h4%') and safety_info not like '%<h5%'`);
+  await knex.raw(`update protected_areas set safety_info = replace(safety_info, '<h3', '<h4') where safety_info like '%<h3%' and safety_info not like '%<h4%'`);
+  await knex.raw(`update protected_areas set safety_info = replace(safety_info, '</h3', '</h4') where safety_info like '%</h3%' and safety_info not like '%</h4%'`);
+
+  await knex.raw(`update protected_areas set special_notes = replace(special_notes, '<h3', '<h4') where special_notes like '%<h3%' and special_notes not like '%<h4%'`);
+  await knex.raw(`update protected_areas set special_notes = replace(special_notes, '</h3', '</h4') where special_notes like '%</h3%' and special_notes not like '%</h4%'`);
+  await knex.raw(`update protected_areas set special_notes = replace(special_notes, '</h4', '</h5') where (special_notes like '%</h3%' and special_notes like '%</h4%') and special_notes not like '%</h5%'`);
+  await knex.raw(`update protected_areas set special_notes = replace(special_notes, '<h4', '<h5') where (special_notes like '%<h3%' and special_notes like '%<h4%') and special_notes not like '%<h5%'`);
+  await knex.raw(`update protected_areas set special_notes = replace(special_notes, '<h3', '<h4') where special_notes like '%<h3%' and special_notes not like '%<h4%'`);
+  await knex.raw(`update protected_areas set special_notes = replace(special_notes, '</h3', '</h4') where special_notes like '%</h3%' and special_notes not like '%</h4%'`);
+}
+
+module.exports = { up };


### PR DESCRIPTION
### Jira Ticket:
CMS-371

### Description:
Database migration to remove h3 tags from protected_areas.safety_info and protected_areas.special_notes.
