### PR TITLE
CMS-312: Add lazy load image component

### DIFF
--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -626,16 +626,11 @@ async function createRedirects(parkQuery, redirectQuery, { graphql, actions, rep
   })
 }
 
-exports.onCreateWebpackConfig = ({ stage, loaders, actions, getConfig }) => {
+exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
   if (stage === "build-html" || stage === "develop-html") {
     actions.setWebpackConfig({
       module: {
-        rules: [
-          {
-            test: /@arcgis/,
-            use: loaders.null(),
-          },
-        ],
+        rules: [],
       },
       plugins: [new NodePolyfillPlugin()],
     })

--- a/src/gatsby/package-lock.json
+++ b/src/gatsby/package-lock.json
@@ -8,7 +8,6 @@
       "name": "bc-parks-gatsby",
       "version": "0.1.0",
       "dependencies": {
-        "@arcgis/core": "^4.30.3",
         "@bcgov/bc-sans": "^2.1.0",
         "@bcgov/bootstrap-theme": "https://github.com/bcgov/bootstrap-theme/releases/download/v1.1.1/bcgov-bootstrap-theme-1.1.1.tgz",
         "@emotion/react": "^11.11.4",
@@ -50,6 +49,7 @@
         "react-bootstrap-typeahead": "^6.3.2",
         "react-device-detect": "^2.0.1",
         "react-dom": "^18.3.1",
+        "react-lazy-load-image-component": "^1.6.2",
         "react-select": "^5.8.0",
         "react-typography": "^0.16.19",
         "react-use-query-param-string": "^2.1.5",
@@ -82,21 +82,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@arcgis/core": {
-      "version": "4.30.3",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.30.3.tgz",
-      "integrity": "sha512-TKaCBcPPxYY3Q0S2QsVRnBEAY0VFjWjbFh5d3nMuvbre/dWBjOftpuhE+sIAk6tN8cbcxWFp/cYdl+CeREmmaw==",
-      "dependencies": {
-        "@esri/arcgis-html-sanitizer": "~4.0.1",
-        "@esri/calcite-colors": "~6.1.0",
-        "@esri/calcite-components": "^2.8.5",
-        "@vaadin/grid": "~24.3.13",
-        "@zip.js/zip.js": "~2.7.44",
-        "luxon": "~3.4.4",
-        "marked": "~12.0.2",
-        "sortablejs": "~1.15.2"
       }
     },
     "node_modules/@ardatan/relay-compiler": {
@@ -2299,56 +2284,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@esri/arcgis-html-sanitizer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.0.1.tgz",
-      "integrity": "sha512-6m/qIGmmbWWB2RXtyGcCBMIE/FkfM+dF9VzvW+kVH8ddvSjTtWiKcDrQXfDI73OyYPe2fDtANNPP9amu0L4sMQ==",
-      "dependencies": {
-        "xss": "1.0.13"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@esri/calcite-colors": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.1.0.tgz",
-      "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
-    },
-    "node_modules/@esri/calcite-components": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.10.1.tgz",
-      "integrity": "sha512-8M2ZBYcEk20x34TDxZ6H5rLCWtGrOJLtHA/k6yWL/GJTC85/gvY153XxbGN8F1ywJb/3imvhy/SlfNRPnVPQNQ==",
-      "dependencies": {
-        "@floating-ui/dom": "1.6.5",
-        "@stencil/core": "4.18.3",
-        "@types/color": "3.0.6",
-        "color": "4.2.3",
-        "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.11",
-        "focus-trap": "7.5.4",
-        "lodash-es": "4.17.21",
-        "sortablejs": "1.15.1",
-        "timezone-groups": "0.8.0",
-        "type-fest": "4.18.2"
-      }
-    },
-    "node_modules/@esri/calcite-components/node_modules/sortablejs": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
-      "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
-    },
-    "node_modules/@esri/calcite-components/node_modules/type-fest": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
-      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
@@ -3744,19 +3679,6 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
-      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
-    },
-    "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
-      }
-    },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
@@ -4009,11 +3931,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@open-wc/dedupe-mixin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
-      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
     },
     "node_modules/@parcel/bundler-default": {
       "version": "2.8.3",
@@ -5301,14 +5218,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@polymer/polymer": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
-      "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
-      "dependencies": {
-        "@webcomponents/shadycss": "^1.9.1"
-      }
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -5439,18 +5348,6 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
-    "node_modules/@stencil/core": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
-      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.10.0"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.4.36",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
@@ -5560,27 +5457,6 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
-    },
-    "node_modules/@types/color": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.6.tgz",
-      "integrity": "sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==",
-      "dependencies": {
-        "@types/color-convert": "*"
-      }
-    },
-    "node_modules/@types/color-convert": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
-      "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
-      "dependencies": {
-        "@types/color-name": "*"
-      }
-    },
-    "node_modules/@types/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-hulKeREDdLFesGQjl96+4aoJSHY5b2GRjagzzcqCfIrWhe5vkCqIvrLbqzBaI1q94Vg8DNJZZqTR5ocdWmWclg=="
     },
     "node_modules/@types/common-tags": {
       "version": "1.8.4",
@@ -5880,11 +5756,6 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ=="
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
-    },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -6156,172 +6027,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@vaadin/a11y-base": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.14.tgz",
-      "integrity": "sha512-IbF/T4m46vxLi2jZRexm/we8Q5hS7/dzFt2bnS0HKcdBENQ3KACqoIAczsOQKBoGTJqm+gD3DURGGNED7p8bRg==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.14",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/checkbox": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.14.tgz",
-      "integrity": "sha512-M84XdcYVwA9rZy4QyBOu3dqvm9+xxzJUrmAGRwkZ8woPR/AJ0bVZj4vvzX5y/9kGkXwXHMOjBq5TyjcOpvY0ZQ==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.14",
-        "@vaadin/component-base": "~24.3.14",
-        "@vaadin/field-base": "~24.3.14",
-        "@vaadin/vaadin-lumo-styles": "~24.3.14",
-        "@vaadin/vaadin-material-styles": "~24.3.14",
-        "@vaadin/vaadin-themable-mixin": "~24.3.14",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/component-base": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.14.tgz",
-      "integrity": "sha512-sQ3fBo+dWM7WhVDJhG19BM3419lp2YDkm1MM7AmLfN2Ll6HaFQdxHt4F4tifuu6ww1VkAhELxW0OkHQMOuvvnw==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/field-base": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.14.tgz",
-      "integrity": "sha512-sRFvqx8THQ6GuWhCEUcG+D36cw4xDsqkXixd7X1JYfdWkVM/JiGSctJUnhqZYxLJ7gtZeDm9AIQ2Cc5F33jLUg==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.14",
-        "@vaadin/component-base": "~24.3.14",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/grid": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.14.tgz",
-      "integrity": "sha512-6noqdVlLDb3525aAO7KWTAY85gPWrX+g0bRvVAqClN5IgAMyBR0XS9nrzGCnX2q0watvg60hvkJnWuvetoPF7Q==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.14",
-        "@vaadin/checkbox": "~24.3.14",
-        "@vaadin/component-base": "~24.3.14",
-        "@vaadin/lit-renderer": "~24.3.14",
-        "@vaadin/text-field": "~24.3.14",
-        "@vaadin/vaadin-lumo-styles": "~24.3.14",
-        "@vaadin/vaadin-material-styles": "~24.3.14",
-        "@vaadin/vaadin-themable-mixin": "~24.3.14"
-      }
-    },
-    "node_modules/@vaadin/icon": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.14.tgz",
-      "integrity": "sha512-iiHsFH3R6pv9ZPnxrv6Gwx3JdqWPTE4Ty0CZkQnndUqlHTzD9q6YVTXfL6VxH22qu1E4LbVTkEtDTeJtn4+jmw==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.14",
-        "@vaadin/vaadin-lumo-styles": "~24.3.14",
-        "@vaadin/vaadin-themable-mixin": "~24.3.14",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/input-container": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.14.tgz",
-      "integrity": "sha512-QbMebBSMQe5JkFlTEA66rXcZUKPjJSNq0IoEwjfpVUAjfA+bSVPbn/UCGyvggNOX3PxXCgHDJrBbbRirQhR/Aw==",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.14",
-        "@vaadin/vaadin-lumo-styles": "~24.3.14",
-        "@vaadin/vaadin-material-styles": "~24.3.14",
-        "@vaadin/vaadin-themable-mixin": "~24.3.14",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/lit-renderer": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.14.tgz",
-      "integrity": "sha512-Md+YDrHkjoOUEi+1IeK4usMle8AfRFJJUFg+RqEnZl6pKHJMW2NpqhIwHw2DRG+S5dZlhe+ga8xwel9IIuP71Q==",
-      "dependencies": {
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/text-field": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.14.tgz",
-      "integrity": "sha512-6gqUUHxim6dI46k4wEyYLCF6kT0wxn8jDPaE3DPFf3LPiNuWCkIaTN889i6FhyWK6Syikc+97kPLYluHdEWp+Q==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.14",
-        "@vaadin/component-base": "~24.3.14",
-        "@vaadin/field-base": "~24.3.14",
-        "@vaadin/input-container": "~24.3.14",
-        "@vaadin/vaadin-lumo-styles": "~24.3.14",
-        "@vaadin/vaadin-material-styles": "~24.3.14",
-        "@vaadin/vaadin-themable-mixin": "~24.3.14",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/vaadin-development-mode-detector": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
-      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
-    },
-    "node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.14.tgz",
-      "integrity": "sha512-ma3CQ0jp6ywt/I3GI9iMFUySv062wbTkDSoj1kOd1lprabmxqVsf1s2BH4dBfNlSCIXtoDnSxVRlMHi9ikywuw==",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.14",
-        "@vaadin/icon": "~24.3.14",
-        "@vaadin/vaadin-themable-mixin": "~24.3.14"
-      }
-    },
-    "node_modules/@vaadin/vaadin-material-styles": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.14.tgz",
-      "integrity": "sha512-FKJ6X7HjFZCBv2LTqWz4JfyTF12PsFYr+Ol4CKyQYqNhkT9aln5/37BJXgHreKtO2HHl1gCoEmlZUaqoaCOJcg==",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.14",
-        "@vaadin/vaadin-themable-mixin": "~24.3.14"
-      }
-    },
-    "node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.3.14",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.14.tgz",
-      "integrity": "sha512-e8P2+EK5k7R5dWeZo8ohZP5IuU8EWHxNRC+kGEHHSLqFfEwdUzuTZ/cnwFwdIyQRwsJKGUGe05DZE2zeupxaIQ==",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/vaadin-usage-statistics": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
-      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/@vercel/webpack-asset-relocator-loader": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.3.tgz",
@@ -6461,11 +6166,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webcomponents/shadycss": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6475,16 +6175,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
-    },
-    "node_modules/@zip.js/zip.js": {
-      "version": "2.7.45",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.45.tgz",
-      "integrity": "sha512-Mm2EXF33DJQ/3GWWEWeP1UCqzpQ5+fiMvT3QWspsXY05DyqqxWu7a9awSzU4/spHMHVFrTjani1PR0vprgZpow==",
-      "engines": {
-        "bun": ">=0.7.0",
-        "deno": ">=1.0.0",
-        "node": ">=16.5.0"
-      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -8773,11 +8463,6 @@
         "arity-n": "^1.0.4"
       }
     },
-    "node_modules/composed-offset-position": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
-      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -9324,11 +9009,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
-    },
     "node_modules/cssnano": {
       "version": "5.1.15",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.15.tgz",
@@ -9484,11 +9164,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -11706,14 +11381,6 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
-    },
-    "node_modules/focus-trap": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-      "dependencies": {
-        "tabbable": "^6.2.0"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -17383,34 +17050,6 @@
       "resolved": "https://registry.npmjs.org/linkfs/-/linkfs-2.1.0.tgz",
       "integrity": "sha512-kmsGcmpvjStZ0ATjuHycBujtNnXiZR28BTivEu0gAMDTT7GEyodcK6zSRtu6xsrdorrPZEIN380x7BD7xEYkew=="
     },
-    "node_modules/lit": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
-      "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.0.4",
-        "lit-html": "^3.1.2"
-      }
-    },
-    "node_modules/lit-element": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
-      "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.1.2"
-      }
-    },
-    "node_modules/lit-html": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
-      "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/lmdb": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
@@ -17479,11 +17118,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -17538,6 +17172,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -17607,14 +17246,6 @@
       "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
       "dependencies": {
         "es5-ext": "~0.10.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -17688,17 +17319,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -21165,6 +20785,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-lazy-load-image-component": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/react-lazy-load-image-component/-/react-lazy-load-image-component-1.6.2.tgz",
+      "integrity": "sha512-dAdH5PsRgvDMlHC7QpZRA9oRzEZl1kPFwowmR9Mt0IUUhxk2wwq43PB6Ffwv84HFYuPmsxDUCka0E9KVXi8roQ==",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1"
+      },
+      "peerDependencies": {
+        "react": "^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x"
+      }
+    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -22879,11 +22511,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/sortablejs": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
-      "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
-    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -23841,11 +23468,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
-    },
     "node_modules/table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -24071,14 +23693,6 @@
       "dependencies": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
-      }
-    },
-    "node_modules/timezone-groups": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
-      "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA==",
-      "bin": {
-        "timezone-groups": "dist/cli.cjs"
       }
     },
     "node_modules/title-case": {
@@ -25427,26 +25041,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/xss": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/xss/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/xstate": {
       "version": "4.38.3",

--- a/src/gatsby/package.json
+++ b/src/gatsby/package.json
@@ -4,7 +4,6 @@
   "description": "BC Parks - public site",
   "version": "0.1.0",
   "dependencies": {
-    "@arcgis/core": "^4.30.3",
     "@bcgov/bc-sans": "^2.1.0",
     "@bcgov/bootstrap-theme": "https://github.com/bcgov/bootstrap-theme/releases/download/v1.1.1/bcgov-bootstrap-theme-1.1.1.tgz",
     "@emotion/react": "^11.11.4",
@@ -46,6 +45,7 @@
     "react-bootstrap-typeahead": "^6.3.2",
     "react-device-detect": "^2.0.1",
     "react-dom": "^18.3.1",
+    "react-lazy-load-image-component": "^1.6.2",
     "react-select": "^5.8.0",
     "react-typography": "^0.16.19",
     "react-use-query-param-string": "^2.1.5",

--- a/src/gatsby/src/components/park/parkHeader.js
+++ b/src/gatsby/src/components/park/parkHeader.js
@@ -116,7 +116,7 @@ export default function ParkHeader({
             />
             :
             // display a space if it's loading advisories
-            <></>
+            <>&nbsp;</>
           }
         </div>
         {parkDates && (

--- a/src/gatsby/src/components/park/parkHeader.js
+++ b/src/gatsby/src/components/park/parkHeader.js
@@ -74,6 +74,8 @@ export default function ParkHeader({
   advisories,
   advisoryLoadError,
   isLoadingAdvisories,
+  protectedAreaLoadError,
+  isLoadingProtectedArea,
   searchArea,
   parkOperation,
   operationDates,
@@ -93,65 +95,68 @@ export default function ParkHeader({
     <div id="park-header-container" className="d-flex park-info-container">
       <div className="park-header park-header--left">
         <h1>{parkName}</h1>
-        {!isLoadingAdvisories && !advisoryLoadError && (
-          <>
-            {searchArea?.searchAreaName && (
-              <div className="park-header-child">
-                <FontAwesome icon="location-dot" />
-                {searchArea.searchAreaName}.&nbsp;
-                {latitude && longitude && (
-                  <><a href={externalLink}>View detailed map</a>.</>
-                )}
-              </div>
+        {searchArea?.searchAreaName && (
+          <div className="park-header-child">
+            <FontAwesome icon="location-dot" />
+            {searchArea.searchAreaName}.&nbsp;
+            {latitude && longitude && (
+              <><a href={externalLink}>View detailed map</a>.</>
             )}
-            <div className="park-header-child">
-              <ParkAccessStatus
-                advisories={advisories}
-                slug={slug}
-                subAreas={subAreas}
-                operationDates={operationDates}
-                onStatusCalculated={onStatusCalculated}
-                punctuation="."
-              />
-            </div>
-            {parkDates && (
-              <div className="park-header-child">
-                <FontAwesomeIcon icon={faCalendar} />
-                <div>
-                  <p>
-                    The {parkType} {parkOperation?.hasParkGate !== false && "gate"} is open {parkDates}
-                    {(parkOperation?.gateOpenTime && parkOperation?.gateCloseTime) ? (
-                      <>
-                        , from <span className="no-wrap">{formattedTime(parkOperation.gateOpenTime)}</span>{" "}
-                        to <span className="no-wrap">{formattedTime(parkOperation.gateCloseTime)}</span>, daily.
-                      </>
-                    ) : "."}
-                  </p>
-                  {(campings.length > 0 || facilities.length > 0) && (
-                    <p>
-                      {campings.length > 0 && "Check campgrounds"}
-                      {facilities.length > 0 && (campings.length > 0 ? " and facilities " : "Check facilities ")}
-                      for <a href="#park-dates-container">additional dates</a>.
-                    </p>
-                  )}
-                </div>
-              </div>
-            )}
-            {hasCampfireBan &&
-              <div className="park-header-child">
-                <CampfireBan />
-              </div>
-            }
-          </>
+          </div>
         )}
-        <div>
-          {hasReservations && (
-            <a href={parkReservationsURL} className="btn btn-secondary">Book camping</a>
-          )}
-          {hasDayUsePass && (
-            <a href={parkDayUsePassURL} className="btn btn-secondary">Get a day-use pass</a>
-          )}
+        <div className="park-header-child">
+          {(!isLoadingAdvisories && !advisoryLoadError) ?
+            <ParkAccessStatus
+              advisories={advisories}
+              slug={slug}
+              subAreas={subAreas}
+              operationDates={operationDates}
+              onStatusCalculated={onStatusCalculated}
+              punctuation="."
+            />
+            :
+            // display a space if it's loading advisories
+            <></>
+          }
         </div>
+        {parkDates && (
+          <div className="park-header-child">
+            <FontAwesomeIcon icon={faCalendar} />
+            <div>
+              <p>
+                The {parkType} {parkOperation?.hasParkGate !== false && "gate"} is open {parkDates}
+                {(parkOperation?.gateOpenTime && parkOperation?.gateCloseTime) ? (
+                  <>
+                    , from <span className="no-wrap">{formattedTime(parkOperation.gateOpenTime)}</span>{" "}
+                    to <span className="no-wrap">{formattedTime(parkOperation.gateCloseTime)}</span>, daily.
+                  </>
+                ) : "."}
+              </p>
+              {(campings.length > 0 || facilities.length > 0) && (
+                <p>
+                  {campings.length > 0 && "Check campgrounds"}
+                  {facilities.length > 0 && (campings.length > 0 ? " and facilities " : "Check facilities ")}
+                  for <a href="#park-dates-container">additional dates</a>.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+        {(!isLoadingProtectedArea && !protectedAreaLoadError && hasCampfireBan) &&
+          <div className="park-header-child">
+            <CampfireBan />
+          </div>
+        }
+        {(hasReservations || hasDayUsePass) &&
+          <div>
+            {hasReservations && (
+              <a href={parkReservationsURL} className="btn btn-secondary">Book camping</a>
+            )}
+            {hasDayUsePass && (
+              <a href={parkDayUsePassURL} className="btn btn-secondary">Get a day-use pass</a>
+            )}
+          </div>
+        }
       </div>
       <div className="park-header--right">
         {searchArea?.searchAreaName && (
@@ -184,6 +189,8 @@ ParkHeader.propTypes = {
   advisories: PropTypes.array,
   advisoryLoadError: PropTypes.any,
   isLoadingAdvisories: PropTypes.bool.isRequired,
+  protectedAreaLoadError: PropTypes.any,
+  isLoadingProtectedArea: PropTypes.bool.isRequired,
   searchArea: PropTypes.object.isRequired,
   parkOperation: PropTypes.object,
   operationDates: PropTypes.array.isRequired,

--- a/src/gatsby/src/components/park/parkPhoto.js
+++ b/src/gatsby/src/components/park/parkPhoto.js
@@ -1,12 +1,12 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { LazyLoadImage } from "react-lazy-load-image-component"
+import "react-lazy-load-image-component/src/effects/blur.css"
 
-/* Simple image wrapper - essentially GatsbyImage for remote images */
 export default function ParkPhoto({ type, src, alt }) {
-
   return (
     <div className={`park-photo park-photo--${type}`}>
-      <img src={src} alt={alt ?? ""} />
+      <LazyLoadImage src={src} alt={alt ?? ""} effect="opacity" />
     </div>
   )
 }

--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -183,6 +183,10 @@
       height: 196px;
     }
   }
+  .lazy-load-image-loaded {
+    width: 100%;
+    height: 100%;
+  }
   img {
     width: 100%;
     height: 100%;

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -268,45 +268,45 @@ export default function ParkTemplate({ data }) {
   return (
     <div>
       <Header mode="internal" content={menuContent} />
-      {!isLoadingProtectedArea && !protectedAreaLoadError && (
-        <div className="park-header-container d-flex flex-wrap d-md-block">
-          <div className="parks-container bg-brown">
-            <div id="main-content" tabIndex={-1} className="park-info-container breadcrumb-container">
-              <Breadcrumbs breadcrumbs={breadcrumbs} />
-            </div>
-            <ParkHeader
-              orcs={park.orcs}
-              slug={park.slug}
-              parkName={parkName}
-              parkType={parkType}
-              mapZoom={park.mapZoom}
-              latitude={park.latitude}
-              longitude={park.longitude}
-              campings={activeCampings}
-              facilities={activeFacilities}
-              hasCampfireBan={hasCampfireBan}
-              hasDayUsePass={hasDayUsePass}
-              hasReservations={hasReservations}
-              advisories={advisories}
-              advisoryLoadError={advisoryLoadError}
-              isLoadingAdvisories={isLoadingAdvisories}
-              searchArea={searchArea}
-              parkOperation={park.parkOperation}
-              operationDates={park.parkOperationDates}
-              subAreas={park.parkOperationSubAreas}
-              onStatusCalculated={handleAccessStatus}
-            />
+      <div className="park-header-container d-flex flex-wrap d-md-block">
+        <div className="parks-container bg-brown">
+          <div id="main-content" tabIndex={-1} className="park-info-container breadcrumb-container">
+            <Breadcrumbs breadcrumbs={breadcrumbs} />
           </div>
-          <div className={`parks-container gallery-container has-photo--${photos.length > 0}`}>
-            {photos.length > 0 && (
-              <div className="background-container bg-brown"></div>
-            )}
-            <div className="park-info-container">
-              <ParkPhotoGallery photos={photos} />
-            </div>
+          <ParkHeader
+            orcs={park.orcs}
+            slug={park.slug}
+            parkName={parkName}
+            parkType={parkType}
+            mapZoom={park.mapZoom}
+            latitude={park.latitude}
+            longitude={park.longitude}
+            campings={activeCampings}
+            facilities={activeFacilities}
+            hasCampfireBan={hasCampfireBan}
+            hasDayUsePass={hasDayUsePass}
+            hasReservations={hasReservations}
+            advisories={advisories}
+            advisoryLoadError={advisoryLoadError}
+            isLoadingAdvisories={isLoadingAdvisories}
+            protectedAreaLoadError={protectedAreaLoadError}
+            isLoadingProtectedArea={isLoadingProtectedArea}
+            searchArea={searchArea}
+            parkOperation={park.parkOperation}
+            operationDates={park.parkOperationDates}
+            subAreas={park.parkOperationSubAreas}
+            onStatusCalculated={handleAccessStatus}
+          />
+        </div>
+        <div className={`parks-container gallery-container has-photo--${photos.length > 0}`}>
+          {photos.length > 0 && (
+            <div className="background-container bg-brown"></div>
+          )}
+          <div className="park-info-container">
+            <ParkPhotoGallery photos={photos} />
           </div>
         </div>
-      )}
+      </div>
       <div className="parks-container main-container">
         <div className="page-menu--mobile d-block d-md-none">
           <PageMenu

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -207,29 +207,29 @@ export default function SiteTemplate({ data }) {
           <div id="main-content" tabIndex={-1} className="park-info-container breadcrumb-container">
             <Breadcrumbs breadcrumbs={breadcrumbs} />
           </div>
-          {!isLoadingProtectedArea && !protectedAreaLoadError && (
-            <ParkHeader
-              orcs={site.orcsSiteNumber}
-              slug={`${park.slug}/${site.slug}`}
-              parkName={`${park?.protectedAreaName}: ${site.siteName}`}
-              parkType="site"
-              mapZoom={site.mapZoom}
-              latitude={site.latitude}
-              longitude={site.longitude}
-              campings={activeCampings}
-              facilities={activeFacilities}
-              hasCampfireBan={hasCampfireBan}
-              hasDayUsePass={hasDayUsePass}
-              hasReservations={hasReservations}
-              advisories={advisories}
-              advisoryLoadError={advisoryLoadError}
-              isLoadingAdvisories={isLoadingAdvisories}
-              searchArea={searchArea}
-              parkOperation={operations}
-              operationDates={park.parkOperationDates}
-              subAreas={park.parkOperationSubAreas.filter(sa => sa.orcsSiteNumber === site.orcsSiteNumber)}
-            />
-          )}
+          <ParkHeader
+            orcs={site.orcsSiteNumber}
+            slug={`${park.slug}/${site.slug}`}
+            parkName={`${park?.protectedAreaName}: ${site.siteName}`}
+            parkType="site"
+            mapZoom={site.mapZoom}
+            latitude={site.latitude}
+            longitude={site.longitude}
+            campings={activeCampings}
+            facilities={activeFacilities}
+            hasCampfireBan={hasCampfireBan}
+            hasDayUsePass={hasDayUsePass}
+            hasReservations={hasReservations}
+            advisories={advisories}
+            advisoryLoadError={advisoryLoadError}
+            isLoadingAdvisories={isLoadingAdvisories}
+            protectedAreaLoadError={protectedAreaLoadError}
+            isLoadingProtectedArea={isLoadingProtectedArea}
+            searchArea={searchArea}
+            parkOperation={operations}
+            operationDates={park.parkOperationDates}
+            subAreas={park.parkOperationSubAreas.filter(sa => sa.orcsSiteNumber === site.orcsSiteNumber)}
+          />
         </div>
         <div className={`parks-container gallery-container has-photo--${photos.length > 0}`}>
           {photos.length > 0 && (


### PR DESCRIPTION
### Jira Ticket:
CMS-312

### Description:
- Remove arcgis since we don't have a map on the park page anymore
- According to the Lighthouse, the main performance issue of the park page was rendering images
- [Lighthouse Report Viewer.pdf](https://github.com/user-attachments/files/16806259/Lighthouse.Report.Viewer.pdf)
- I needed to handle external images directly in the component, so used [the lazy load image component](https://www.npmjs.com/package/react-lazy-load-image-component) for lazy loading since gatsby-plugin-image is primarily designed for local images
- Known issue: It slightly takes time to load the access status and the campfire ban in the TLDR section compared to other content because it has to get data through Stapi API