### PR TITLE
CMS-302: Update mega menu aria label for screen readers

### DIFF
--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -238,9 +238,7 @@ const MegaMenu = ({ content, menuMode }) => {
               "menu-level menu-level--" + item.treeLevel +
               " has-clicked-twice--" + hasClickedTwice
             }
-            aria-labelledby="mainmenulabel"
           >
-            <h2 id="mainmenulabel" className="sr-only">Main Menu</h2>
             <ul className="menu-button-list" role="presentation">
               <li className="menu-button menu-back">
                 <a


### PR DESCRIPTION
### Jira Ticket:
CMS-302

### Description:
- Fix the issue that the screen readers announce "main menu" and "menu"
- `generateMenus` is wrapped by `<div role="menu"></div>` so this `<h2>` title for the screen readers was redundant
