### PR TITLE
CMS-361: Update page menu on mobile

### DIFF
--- a/src/gatsby/src/components/pageContent/pageMenu.js
+++ b/src/gatsby/src/components/pageContent/pageMenu.js
@@ -41,7 +41,7 @@ export default function PageMenu({ pageSections, activeSection, menuStyle }) {
           onChange={handleSectionChange}
           title="mobile-navigation"
         >
-          <option value="label" disabled>Table of Contents</option>
+          <option value="" disabled>Table of Contents</option>
           {pageSections.filter(s => s.visible).map(
             section =>
               <option key={section.sectionIndex} value={section.sectionIndex}>

--- a/src/gatsby/src/components/pageContent/pageMenu.js
+++ b/src/gatsby/src/components/pageContent/pageMenu.js
@@ -41,7 +41,7 @@ export default function PageMenu({ pageSections, activeSection, menuStyle }) {
           onChange={handleSectionChange}
           title="mobile-navigation"
         >
-          <option value={0}>Table of Contents</option>
+          <option value="label" disabled>Table of Contents</option>
           {pageSections.filter(s => s.visible).map(
             section =>
               <option key={section.sectionIndex} value={section.sectionIndex}>


### PR DESCRIPTION
### Jira Ticket:
CMS-361

### Description:
- Fix the issue that the first select option doesn't get updated by scrolling
- The value of the "Table of Contents" was a duplicate of the first section value, so that the first option didn't get selected by scrolling
- Disable the "Table of Contents" as an option since it doesn't take the users to any section