### PR TITLE
CMS-363: Update snowplow tracking

### DIFF
--- a/src/gatsby/gatsby-browser.js
+++ b/src/gatsby/gatsby-browser.js
@@ -8,6 +8,10 @@ import "./src/styles/style.scss"
 import React from "react"
 import useSnowplowTracking from "./src/utils/useSnowplowTracking"
 
+export const onRouteUpdate = ({ location, prevLocation }) => {
+  sessionStorage.setItem("prevPath", prevLocation ? prevLocation.pathname : null);
+}
+
 const SnowplowWrapper = ({ element }) => {
   useSnowplowTracking()
   return element

--- a/src/gatsby/gatsby-browser.js
+++ b/src/gatsby/gatsby-browser.js
@@ -5,14 +5,17 @@ import "bootstrap/dist/js/bootstrap.bundle"
 import "@fortawesome/fontawesome-free/css/all.min.css"
 import "./src/styles/style.scss"
 
-export const onRouteUpdate = ({ location, prevLocation }) => {
-  if (typeof window.snowplow === 'function') {
-    window.snowplow("trackPageView");
-    // refresh snowplow link click tracking to pick up new links
-    window.snowplow("refreshLinkClickTracking");
-  }
-  sessionStorage.setItem("prevPath", prevLocation ? prevLocation.pathname : null);
-};
+import React from "react"
+import useSnowplowTracking from "./src/utils/useSnowplowTracking"
+
+const SnowplowWrapper = ({ element }) => {
+  useSnowplowTracking()
+  return element
+}
+
+export const wrapPageElement = ({ element }) => {
+  return <SnowplowWrapper element={element} />
+}
 
 // work-around for gatsby issue -- fix scroll restoration
 // see https://github.com/gatsbyjs/gatsby/issues/38201#issuecomment-1658071105

--- a/src/gatsby/src/utils/useSnowplowTracking.js
+++ b/src/gatsby/src/utils/useSnowplowTracking.js
@@ -1,0 +1,13 @@
+import { useEffect } from "react"
+
+const useSnowplowTracking = () => {
+	useEffect(() => {
+		if (typeof window.snowplow === "function") {
+			window.snowplow("trackPageView")
+			window.snowplow("refreshLinkClickTracking")
+		}
+		// empty dependency array ensures this runs on mount and unmount
+	}, [])
+}
+
+export default useSnowplowTracking


### PR DESCRIPTION
### Jira Ticket:
CMS-363

### Description:
- Added `useEffect` hook to call the snowplow event every time a page renders or re-renders, not just when the router is updated, based on Mike's comment: https://github.com/bcgov/bcparks.ca/pull/1503
- Used `wrapPageElement` to wrap all pages with the custom hook: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#wrapPageElement
- Need to test it on the DEV/TEST/PROD since we have `GATSBY_ENABLE_SNOWPLOW` in the `.env`