### PR TITLE
CMS-363: Add snowplow track to onRouteUpdate

### DIFF
--- a/src/gatsby/gatsby-browser.js
+++ b/src/gatsby/gatsby-browser.js
@@ -9,6 +9,10 @@ import React from "react"
 import useSnowplowTracking from "./src/utils/useSnowplowTracking"
 
 export const onRouteUpdate = ({ location, prevLocation }) => {
+  if (typeof window.snowplow === "function") {
+    window.snowplow("trackPageView")
+    window.snowplow("refreshLinkClickTracking")
+  }
   sessionStorage.setItem("prevPath", prevLocation ? prevLocation.pathname : null);
 }
 


### PR DESCRIPTION
### Jira Ticket:
CMS-363

### Description:
- Add snowplow track to onRouteUpdate
- Revert the initial idea since it was needed for single-page applications like Gatsby, where navigation between pages does not trigger a full-page reload