### PR TITLE
CMS-109: Add email notification for prescheduled advisories

### DIFF
--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -168,6 +168,7 @@ module.exports = createCoreController(
             const publishedCount = await strapi.service("api::public-advisory.scheduling").publish(advisoryStatusMap);
             const expiredCount = await strapi.service("api::public-advisory.scheduling").expire(advisoryStatusMap);
             const expiringSoonCount = await strapi.service("api::public-advisory.scheduling").expiringSoon(advisoryStatusMap);
+            const publishingSoonCount = await strapi.service("api::public-advisory.scheduling").publishingSoon(advisoryStatusMap);
 
             const cachePlugin = strapi.plugins["rest-cache"];
             if (cachePlugin && (publishedCount > 0 || expiredCount > 0)) {
@@ -176,7 +177,7 @@ module.exports = createCoreController(
             }
 
             ctx.send({
-                message: `Scheduled public advisory processing complete. ${publishedCount} published. ${expiredCount} expired. ${expiringSoonCount} expiring soon.`
+                message: `Scheduled public advisory processing complete. ${publishedCount} published. ${expiredCount} expired. ${expiringSoonCount} expiring soon. ${publishingSoonCount} publishing soon.`
             }, 201);
         }
     })


### PR DESCRIPTION
### Jira Ticket:
CMS-109

### Description:
- Add email notification for prescheduled advisories
- Send emails 2/5 days before the advisory date (posting date)
