### PR TITLE
CMS-297: Add a comma between the year and the 24 hours in park header wording

### DIFF
--- a/src/gatsby/src/components/park/parkHeader.js
+++ b/src/gatsby/src/components/park/parkHeader.js
@@ -63,7 +63,7 @@ const renderGateTimes = (parkOperation) => {
   const { gateOpenTime, gateCloseTime, gateOpensAtDawn, gateClosesAtDusk } = parkOperation
 
   if (gateOpenTime === "00:00:00" && gateCloseTime === "23:59:00") {
-    return <>24 hours a day.</>
+    return <>, 24 hours a day.</>
     // Either gateOpenTime or gateOpensAtDawn is available, then either gateCloseTime or gateClosesAtDusk must also be available
   } else if ((gateOpenTime || gateOpensAtDawn) && (gateCloseTime || gateClosesAtDusk)) {
     return (

--- a/src/gatsby/src/components/park/parkPhotoGallery.js
+++ b/src/gatsby/src/components/park/parkPhotoGallery.js
@@ -39,7 +39,7 @@ export default function ParkPhotoGallery({ photos }) {
     const getCaptionText = (photo) => {
       const caption = photo.caption.data?.caption || "";
       const showCredit = (photo?.showPhotoCredit && photo?.photographer) ?
-        `<span class="photo-credit"> | Photo by ${photo.photographer}</span>` : ""
+        `<span class="photo-credit">| Photo by ${photo.photographer}</span>` : ""
       return `${caption}${showCredit}`
     }
     const captionText = getCaptionText(photo)

--- a/src/gatsby/src/styles/parks.scss
+++ b/src/gatsby/src/styles/parks.scss
@@ -237,8 +237,12 @@
     width: 900px;
     max-width: calc(100% - 32px);
     margin: 0 auto;
+    & > div > * {
+      display: inline-flex;
+    } 
     .photo-credit {
       color: rgba($colorWhite, .72);
+      margin-left: 6px;
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-93
CMS-297

### Description:
- Add a comma between the year and the 24 hours in the park header wording, forgot to add it in this PR: https://github.com/bcgov/bcparks.ca/pull/1517/files
- Update photographer credit layout - the layout was off if the caption was wrapped by another element
