### PR TITLE
CMS-297: Add gateOpen24Hours to parkOperation

### DIFF
--- a/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
+++ b/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
@@ -206,6 +206,9 @@
     },
     "inReservationSystem": {
       "type": "boolean"
+    },
+    "gateOpen24Hours": {
+      "type": "boolean"
     }
   }
 }

--- a/src/cms/src/api/park-operation/content-types/park-operation/schema.json
+++ b/src/cms/src/api/park-operation/content-types/park-operation/schema.json
@@ -227,6 +227,9 @@
     },
     "inReservationSystem": {
       "type": "boolean"
+    },
+    "gateOpen24Hours": {
+      "type": "boolean"
     }
   }
 }

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -212,6 +212,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     totalCapacity: String
     gateOpenTime: String
     gateCloseTime: String
+    gateOpen24Hours: Boolean
     hasCanoeCircuitReservations: Boolean
     hasFrontcountryReservations: Boolean
     hasFrontcountryGroupReservations: Boolean

--- a/src/gatsby/src/components/park/parkHeader.js
+++ b/src/gatsby/src/components/park/parkHeader.js
@@ -60,9 +60,9 @@ const formattedTime = (time) => {
 // Helper function to render the gate open/close times
 const renderGateTimes = (parkOperation) => {
   if (!parkOperation) return null
-  const { gateOpenTime, gateCloseTime, gateOpensAtDawn, gateClosesAtDusk } = parkOperation
+  const { gateOpenTime, gateCloseTime, gateOpensAtDawn, gateClosesAtDusk, gateOpen24Hours } = parkOperation
 
-  if (gateOpenTime === "00:00:00" && gateCloseTime === "23:59:00") {
+  if (gateOpen24Hours) {
     return <>, 24 hours a day.</>
     // Either gateOpenTime or gateOpensAtDawn is available, then either gateCloseTime or gateClosesAtDusk must also be available
   } else if ((gateOpenTime || gateOpensAtDawn) && (gateCloseTime || gateClosesAtDusk)) {

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -670,6 +670,7 @@ export const query = graphql`
         gateCloseTime
         gateOpensAtDawn
         gateClosesAtDusk
+        gateOpen24Hours
         hasGroupPicnicReservations
         hasCanoeCircuitReservations
         hasFrontcountryReservations

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -589,6 +589,7 @@ export const query = graphql`
         gateCloseTime
         gateOpensAtDawn
         gateClosesAtDusk
+        gateOpen24Hours
         hasGroupPicnicReservations
         hasCanoeCircuitReservations
         hasFrontcountryReservations


### PR DESCRIPTION
### Jira Ticket:
CMS-297

### Description:
- Add gateOpen24Hours to parkOperation and parkOperationSubArea
- Override gateOpenTime, gateCloseTime, gateOpensAtDawn, gateClosesAtDusk if gateOpen24Hours is TRUE
