### PR TITLE
CMS-49: Remove smoking ban from park access status table

### DIFF
--- a/src/admin/src/components/page/parkAccessStatus/ParkAccessStatus.js
+++ b/src/admin/src/components/page/parkAccessStatus/ParkAccessStatus.js
@@ -115,7 +115,6 @@ export default function ParkAccessStatus() {
                 title: "Campfire Ban",
                 field: "hasCampfireBan",
               },
-              { title: "Smoking Ban", field: "hasSmokingBan" },
               {
                 title: "Campfire Ban Effective Date",
                 field: "campfireBanEffectiveDate",

--- a/src/cms/src/api/park-activity/content-types/park-activity/lifecycles.js
+++ b/src/cms/src/api/park-activity/content-types/park-activity/lifecycles.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { indexPark } = require("../../../../helpers/taskQueue.js");
+const validator = require("../../../../helpers/validator.js");
 
 /**
  * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
@@ -36,10 +37,12 @@ module.exports = {
   async beforeCreate(event) {
     let { data, where } = event.params;
     data = await updateName(data, where);
+    validator.activityTypeConnectValidator(data.activityType)
   },
   async beforeUpdate(event) {
     let { data, where } = event.params;
     data = await updateName(data, where);
+    validator.activityTypeDisconnectValidator(data.activityType)
     for (const park of event.params.data?.protectedArea?.disconnect || []) {
       await indexPark(park.id)
     }

--- a/src/cms/src/api/park-activity/content-types/park-activity/schema.json
+++ b/src/cms/src/api/park-activity/content-types/park-activity/schema.json
@@ -49,7 +49,8 @@
     "activityType": {
       "type": "relation",
       "relation": "oneToOne",
-      "target": "api::activity-type.activity-type"
+      "target": "api::activity-type.activity-type",
+      "required": true
     },
     "modifiedBy": {
       "type": "string"

--- a/src/cms/src/api/park-camping-type/content-types/park-camping-type/lifecycles.js
+++ b/src/cms/src/api/park-camping-type/content-types/park-camping-type/lifecycles.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { indexPark } = require("../../../../helpers/taskQueue.js");
+const validator = require("../../../../helpers/validator.js");
 
 /**
  * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
@@ -36,10 +37,12 @@ module.exports = {
   async beforeCreate(event) {
     let { data, where } = event.params;
     data = await updateName(data, where);
+    validator.campingTypeConnectValidator(data.campingType)
   },
   async beforeUpdate(event) {
     let { data, where } = event.params;
     data = await updateName(data, where);
+    validator.campingTypeDisconnectValidator(data.campingType)
     for (const park of event.params.data?.protectedArea?.disconnect || []) {
       await indexPark(park.id)
     }

--- a/src/cms/src/api/park-camping-type/content-types/park-camping-type/schema.json
+++ b/src/cms/src/api/park-camping-type/content-types/park-camping-type/schema.json
@@ -46,7 +46,8 @@
     "campingType": {
       "type": "relation",
       "relation": "oneToOne",
-      "target": "api::camping-type.camping-type"
+      "target": "api::camping-type.camping-type",
+      "required": true
     },
     "modifiedBy": {
       "type": "string"

--- a/src/cms/src/api/park-facility/content-types/park-facility/lifecycles.js
+++ b/src/cms/src/api/park-facility/content-types/park-facility/lifecycles.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { indexPark } = require("../../../../helpers/taskQueue.js");
+const validator = require("../../../../helpers/validator.js");
 
 /**
  * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
@@ -36,10 +37,12 @@ module.exports = {
   async beforeCreate(event) {
     let { data, where } = event.params;
     data = await updateName(data, where);
+    validator.facilityTypeConnectValidator(data.facilityType)
   },
   async beforeUpdate(event) {
     let { data, where } = event.params;
     data = await updateName(data, where);
+    validator.facilityTypeDisconnectValidator(data.facilityType)
     for (const park of event.params.data?.protectedArea?.disconnect || []) {
       await indexPark(park.id)
     }

--- a/src/cms/src/api/park-facility/content-types/park-facility/schema.json
+++ b/src/cms/src/api/park-facility/content-types/park-facility/schema.json
@@ -49,7 +49,8 @@
     "facilityType": {
       "type": "relation",
       "relation": "oneToOne",
-      "target": "api::facility-type.facility-type"
+      "target": "api::facility-type.facility-type",
+      "required": true
     },
     "modifiedBy": {
       "type": "string"

--- a/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
+++ b/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
@@ -15,9 +15,6 @@
     "parkSubAreaId": {
       "type": "integer"
     },
-    "parkSubAreaTypeId": {
-      "type": "integer"
-    },
     "parkSubArea": {
       "type": "string"
     },

--- a/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
+++ b/src/cms/src/api/park-operation-sub-area/content-types/park-operation-sub-area/schema.json
@@ -12,9 +12,6 @@
     "draftAndPublish": true
   },
   "attributes": {
-    "parkSubAreaId": {
-      "type": "integer"
-    },
     "parkSubArea": {
       "type": "string"
     },

--- a/src/cms/src/api/protected-area/content-types/protected-area/schema.json
+++ b/src/cms/src/api/protected-area/content-types/protected-area/schema.json
@@ -197,13 +197,6 @@
       },
       "customField": "plugin::ckeditor5.CKEditor"
     },
-    "natureAndCulture": {
-      "type": "customField",
-      "options": {
-        "preset": "toolbar"
-      },
-      "customField": "plugin::ckeditor5.CKEditor"
-    },
     "partnerships": {
       "type": "customField",
       "options": {

--- a/src/cms/src/helpers/validator.js
+++ b/src/cms/src/helpers/validator.js
@@ -14,6 +14,42 @@ module.exports = {
       throw new ApplicationError('Please add protectedArea relation.');
     }
   },
+  // saving without a activityType relation is not allowed
+  activityTypeConnectValidator: function (activityType) {
+    if (activityType?.connect?.length === 0) {
+      throw new ApplicationError('Please add activityType relation.');
+    }
+  },
+  // removing a protectedArea relation is not allowed
+  activityTypeDisconnectValidator: function (activityType) {
+    if (activityType?.disconnect?.length > 0 && activityType?.connect?.length === 0) {
+      throw new ApplicationError('Please add activityType relation.');
+    }
+  },
+  // saving without a facilityType relation is not allowed
+  facilityTypeConnectValidator: function (facilityType) {
+    if (facilityType?.connect?.length === 0) {
+      throw new ApplicationError('Please add facilityType relation.');
+    }
+  },
+  // removing a facilityType relation is not allowed
+  facilityTypeDisconnectValidator: function (facilityType) {
+    if (facilityType?.disconnect?.length > 0 && facilityType?.connect?.length === 0) {
+      throw new ApplicationError('Please add facilityType relation.');
+    }
+  },
+  // saving without a campingType relation is not allowed
+  campingTypeConnectValidator: function (campingType) {
+    if (campingType?.connect?.length === 0) {
+      throw new ApplicationError('Please add campingType relation.');
+    }
+  },
+  // removing a campingType relation is not allowed
+  campingTypeDisconnectValidator: function (campingType) {
+    if (campingType?.disconnect?.length > 0 && campingType?.connect?.length === 0) {
+      throw new ApplicationError('Please add campingType relation.');
+    }
+  },
   // saving without a documentType relation is not allowed
   documentTypeConnectValidator: function (documentType) {
     if (documentType?.connect?.length === 0) {

--- a/src/cms/src/helpers/validator.js
+++ b/src/cms/src/helpers/validator.js
@@ -14,13 +14,13 @@ module.exports = {
       throw new ApplicationError('Please add protectedArea relation.');
     }
   },
-  // saving without a activityType relation is not allowed
+  // saving without an activityType relation is not allowed
   activityTypeConnectValidator: function (activityType) {
     if (activityType?.connect?.length === 0) {
       throw new ApplicationError('Please add activityType relation.');
     }
   },
-  // removing a protectedArea relation is not allowed
+  // removing an activityType relation is not allowed
   activityTypeDisconnectValidator: function (activityType) {
     if (activityType?.disconnect?.length > 0 && activityType?.connect?.length === 0) {
       throw new ApplicationError('Please add activityType relation.');

--- a/src/gatsby/src/components/park/about.js
+++ b/src/gatsby/src/components/park/about.js
@@ -44,7 +44,7 @@ export const AccordionList = ({ eventKey, data, openAccordions, toggleAccordion 
 }
 
 export default function About({
-  parkType, natureAndCulture, conservation, culturalHeritage, history, wildlife, biogeoclimaticZones, terrestrialEcosections, marineEcosections
+  parkType, conservation, culturalHeritage, history, wildlife, biogeoclimaticZones, terrestrialEcosections, marineEcosections
 }) {
   const dataList = [
     { "title": "Cultural heritage", "code": "cultural-heritage", "description": culturalHeritage },
@@ -164,8 +164,7 @@ export default function About({
           </p>
         )}
       </div>
-      {/* display conservation/culturalHeritage/history/wildlife accordion, otherwise display natureAndCulture */}
-      {dataList.length > 0 ? (
+      {dataList.length > 0 && (
         // if parkType is ecological reserve, display conservation description without accordion
         parkType === "ecological reserve" ? (
           <HtmlContent>{dataList[0].description}</HtmlContent>
@@ -202,8 +201,6 @@ export default function About({
             </Col>
           </Row>
         )
-      ) : (
-        <HtmlContent>{natureAndCulture}</HtmlContent>
       )}
     </div>
   )

--- a/src/gatsby/src/components/park/parkAccessStatus.js
+++ b/src/gatsby/src/components/park/parkAccessStatus.js
@@ -43,6 +43,7 @@ function checkSubAreaClosure(subAreas, staticData) {
       if (subArea.closureAffectsAccessStatus === null) {
         subArea.closureAffectsAccessStatus = subArea.parkSubAreaType.closureAffectsAccessStatus;
       }
+    // this subArea.subAreaTypeId is a custom field from elasticsearch - used on the find a park page
     } else if (subArea.subAreaTypeId) {
       let subAreaType = subAreaTypeList.find(type => {
         return type.strapi_id === subArea.subAreaTypeId

--- a/src/gatsby/src/components/park/parkAccessStatus.js
+++ b/src/gatsby/src/components/park/parkAccessStatus.js
@@ -43,7 +43,6 @@ function checkSubAreaClosure(subAreas, staticData) {
       if (subArea.closureAffectsAccessStatus === null) {
         subArea.closureAffectsAccessStatus = subArea.parkSubAreaType.closureAffectsAccessStatus;
       }
-    // this subArea.subAreaTypeId is a custom field from elasticsearch - used on the find a park page
     } else if (subArea.subAreaTypeId) {
       let subAreaType = subAreaTypeList.find(type => {
         return type.strapi_id === subArea.subAreaTypeId

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -49,7 +49,6 @@ export default function ParkTemplate({ data }) {
   const safetyInfo = park.safetyInfo.data.safetyInfo
   const specialNotes = park.specialNotes.data.specialNotes
   const locationNotes = park.locationNotes.data.locationNotes
-  const natureAndCulture = park.natureAndCulture.data.natureAndCulture
   const conservation = park.conservation.data.conservation
   const culturalHeritage = park.culturalHeritage.data.culturalHeritage
   const history = park.history.data.history
@@ -205,8 +204,8 @@ export default function ParkTemplate({ data }) {
       sectionIndex: 6,
       display: `About this ${parkType}`,
       link: "#about-this-park",
-      visible: !isNullOrWhiteSpace(natureAndCulture) ||
-        !isNullOrWhiteSpace(conservation) || !isNullOrWhiteSpace(culturalHeritage) ||
+      visible: !isNullOrWhiteSpace(conservation) || 
+        !isNullOrWhiteSpace(culturalHeritage) ||
         !isNullOrWhiteSpace(history) || !isNullOrWhiteSpace(wildlife)
     },
     {
@@ -431,7 +430,6 @@ export default function ParkTemplate({ data }) {
               <div ref={aboutRef} className="w-100">
                 <About
                   parkType={parkType}
-                  natureAndCulture={natureAndCulture}
                   conservation={conservation}
                   culturalHeritage={culturalHeritage}
                   history={history}
@@ -527,11 +525,6 @@ export const query = graphql`
       parkContact {
         data {
           parkContact
-        }
-      }
-      natureAndCulture {
-        data {
-          natureAndCulture
         }
       }
       conservation {


### PR DESCRIPTION
### Jira Ticket:
CMS-49

### Description:
- CMS-49: Remove smoking ban from park access status table
- CMS-526: Remove natureAndCulture from protectedArea
- CMS-522: Change park-activity, park-facility, and park-camping-type required - Strapi doesn't have a function to make a relational field required so added custom validation in the Strapi lifecycle.
- CMS-532: Remove subAreaTypeId from parkOperationSubArea