### PR TITLE
CMS-576: Add hasReservations back to park-operation

### DIFF
--- a/src/cms/database/migrations/2024.12.16T00.00.22.rename-has-frontcountry-reservations.js
+++ b/src/cms/database/migrations/2024.12.16T00.00.22.rename-has-frontcountry-reservations.js
@@ -1,0 +1,10 @@
+'use strict'
+
+async function up(knex) {
+  if (await knex.schema.hasColumn('park_operations', 'has_reservations')) {
+    await knex.raw(`update park_operations set has_reservations = has_frontcountry_reservations;`);
+    await knex.raw(`update park_operations set has_reservations = true where reservation_url is not null;`);
+  }
+}
+
+module.exports = { up };

--- a/src/cms/src/api/park-operation/content-types/park-operation/schema.json
+++ b/src/cms/src/api/park-operation/content-types/park-operation/schema.json
@@ -18,6 +18,9 @@
     "isActive": {
       "type": "boolean"
     },
+    "hasReservations": {
+      "type": "boolean"
+    },
     "hasFrontcountryReservations": {
       "type": "boolean"
     },


### PR DESCRIPTION
### Jira Ticket:
CMS-576

### Description:
- Add hasReservations back to park-operation
- Data migration from `hasFrontcountryReservations`to `hasReservations`
- Update `hasReservations` value to TRUE if `reservationUrl` is not null
