### PR TITLE
NOBUG: Fix gatsby error when serviceNote is empty

### DIFF
--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -196,6 +196,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   }
 
   type STRAPI_PARK_OPERATION implements Node {
+    serviceNote: String
     totalCapacity: String
     gateOpenTime: String
     gateCloseTime: String


### PR DESCRIPTION
None

### Description:
- Fix gatsby error when serviceNote is empty: https://github.com/bcgov/bcparks.ca/actions/runs/12436862789/job/34725546105#step:11:202

