### PR TITLE
CMS-602: Remove unused fields from graphql queries

### DIFF
--- a/src/cms/src/api/park-operation/content-types/park-operation/schema.json
+++ b/src/cms/src/api/park-operation/content-types/park-operation/schema.json
@@ -206,7 +206,11 @@
       "type": "time"
     },
     "gateNote": {
-      "type": "text"
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
     },
     "gateOpensAtDawn": {
       "type": "boolean"

--- a/src/gatsby/src/components/park/subArea.js
+++ b/src/gatsby/src/components/park/subArea.js
@@ -11,7 +11,6 @@ import { countsList } from "../../utils/constants"
 export default function SubArea({ data, showHeading }) {
 
   const subAreasNotesList = [
-    { noteVar: "generalNote", display: "Note" },
     { noteVar: "serviceNote", display: "Service note" },
     { noteVar: "reservationNote", display: "Booking note" },
     { noteVar: "offSeasonNote", display: "Winter season note" },

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -660,36 +660,6 @@ export const query = graphql`
             openNote
           }
         }
-        serviceNote {
-          data {
-            serviceNote
-          }
-        }
-        reservationsNote {
-          data {
-            reservationsNote
-          }
-        }
-        reservationNote {
-          data {
-            reservationNote
-          }
-        }
-        offSeasonNote {
-          data {
-            offSeasonNote
-          }
-        }
-        generalNote {
-          data {
-            generalNote
-          }
-        }
-        adminNote {
-          data {
-            adminNote
-          }
-        }
         gateOpenTime
         gateCloseTime
         gateOpensAtDawn
@@ -747,11 +717,6 @@ export const query = graphql`
         yurts
         shelters
         boatLaunches
-        openNote {
-          data {
-            openNote
-          }
-        }
         serviceNote {
           data {
             serviceNote
@@ -765,11 +730,6 @@ export const query = graphql`
         offSeasonNote {
           data {
             offSeasonNote
-          }
-        }
-        adminNote {
-          data {
-            adminNote
           }
         }
         closureAffectsAccessStatus

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -458,11 +458,6 @@ export const query = graphql`
           yurts
           shelters
           boatLaunches
-          openNote {
-            data {
-              openNote
-            }
-          }
           serviceNote {
             data {
               serviceNote
@@ -476,11 +471,6 @@ export const query = graphql`
           offSeasonNote {
             data {
               offSeasonNote
-            }
-          }
-          adminNote {
-            data {
-              adminNote
             }
           }
           closureAffectsAccessStatus
@@ -602,36 +592,6 @@ export const query = graphql`
         openNote {
           data {
             openNote
-          }
-        }
-        serviceNote {
-          data {
-            serviceNote
-          }
-        }
-        reservationsNote {
-          data {
-            reservationsNote
-          }
-        }
-        reservationNote {
-          data {
-            reservationNote
-          }
-        }
-        offSeasonNote {
-          data {
-            offSeasonNote
-          }
-        }
-        generalNote {
-          data {
-            generalNote
-          }
-        }
-        adminNote {
-          data {
-            adminNote
           }
         }
         gateOpenTime


### PR DESCRIPTION
### Jira Ticket:
CMS-602

### Description:
- Add more fixes to https://github.com/bcgov/bcparks.ca/pull/1555
- Change `parkOperation.gateNote` to RTE field
- Remove `parkOperationSubArea.generalNote` since it doesn't exist
- Remove unused fields from graphql queries
- Notes fields in use:
  - `parkOperation.openNote` - in the TLDR on the Park/Site page
  - `parkOperationSubArea.serviceNote`, `parkOperationSubArea.reservationNote`, `parkOperationSubArea.offSeasonNote` - in the Camping accordions on the Park/Site page 
