### PR TITLE
CMS-545: Update api fetching on park operating dates page

### DIFF
--- a/src/gatsby/src/utils/advisoryHelper.js
+++ b/src/gatsby/src/utils/advisoryHelper.js
@@ -34,6 +34,30 @@ const loadAdvisories = (apiBaseUrl, orcsId) => {
   return axios.get(`${apiBaseUrl}/public-advisories/items?${params}`)
 }
 
+const loadAllAdvisories = (apiBaseUrl) => {
+  const params = qs.stringify({
+    filters: {
+      advisoryStatus: {
+        code: {
+          $eq: "PUB"
+        }
+      }
+    },
+    fields: ["advisoryNumber"],
+    populate: {
+      accessStatus: { fields: ["accessStatus", "precedence", "color", "groupLabel"] },
+      protectedAreas: { fields: ["orcs"] }
+    },
+    pagination: {
+      limit: 1000,
+    }
+  }, {
+    encodeValuesOnly: true,
+  })
+
+  return axios.get(`${apiBaseUrl}/public-advisories/?${params}`)
+}
+
 const WINTER_FULL_PARK_ADVISORY = {
   id: -1,
   title: "Limited access to this park during winter season",
@@ -58,6 +82,7 @@ const WINTER_SUB_AREA_ADVISORY = {
 
 export {
   loadAdvisories,
+  loadAllAdvisories,
   getAdvisoryTypeFromUrl,
   WINTER_FULL_PARK_ADVISORY,
   WINTER_SUB_AREA_ADVISORY


### PR DESCRIPTION
### Jira Ticket:
CMS-545

### Description:
- Update API fetching on the park operating dates page
- Previously the API was called 1000 times as the same as the number of parks. 
After talking to @fatbird we've decided to change the API call rather than changing the API rate limit:
  - Fetch all the advisories so that we just need one API call
  - Filter advisories with `protectedArea.orc` so that we can determine each park access status 
