### PR TITLE
CMS-542: Accessibility updates and fixes

### DIFF
--- a/src/gatsby/src/components/advisories/advisoryCard.js
+++ b/src/gatsby/src/components/advisories/advisoryCard.js
@@ -120,7 +120,7 @@ const AdvisoryCard = ({ advisory, parkInfoHash }) => {
   return (
     <Row
       key={advisory.id}
-      tabindex="-1"
+      tabIndex="-1"
       className="advisory-card g-0"
     >
       <Col xs="auto" className="advisory-card--left">

--- a/src/gatsby/src/components/advisories/advisoryLegend.js
+++ b/src/gatsby/src/components/advisories/advisoryLegend.js
@@ -33,7 +33,7 @@ const AdvisoryLegend = () => {
                 <div className="d-flex align-items-center me-3">
                   <img
                     src={legendItem.icon}
-                    alt={`${legendItem.label} urgency`}
+                    alt=""
                     className="advisory-status-icon"
                   />
                 </div>

--- a/src/gatsby/src/components/htmlContent.js
+++ b/src/gatsby/src/components/htmlContent.js
@@ -7,6 +7,7 @@ export default function HtmlContent(props) {
   return (
     <div
       lang="en"
+      aria-hidden={props.ariaHidden}
       className={`raw-html-content ${props.className ? props.className : ""}`}
       dangerouslySetInnerHTML={{ __html: htmlContent || props.children }}
     />

--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -258,7 +258,7 @@ const MegaMenu = ({ content, menuMode }) => {
                 <a
                   className="menu-button__title"
                   href="back"
-                  role="button"
+                  role="menuitem"
                   tabIndex={0}
                   onKeyDown={e => {
                     if (e.key === "Enter" || e.key === " ") {

--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -128,6 +128,7 @@ export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus
               >
                 <CustomToggle
                   eventKey={index.toString()}
+                  ariaLabel={`${advisory.urgency.urgency} urgency, ${advisory.title}`}
                   ariaControls={advisory.title}
                   handleClick={() => toggleAccordion(index.toString(), advisory.title)}
                 >

--- a/src/gatsby/src/components/park/campingDetails.js
+++ b/src/gatsby/src/components/park/campingDetails.js
@@ -73,7 +73,7 @@ export const CampingType = ({ camping, parkOperation }) => {
             {camping?.campingType?.campingTypeName}
           </h3>
         </div>
-        <HtmlContent className="park-camping-description">
+        <HtmlContent ariaHidden={!expanded} className="park-camping-description">
           {expanded ? campingDescription : collapsedDescription}
         </HtmlContent>
         {!camping.hideStandardCallout &&
@@ -88,6 +88,7 @@ export const CampingType = ({ camping, parkOperation }) => {
       {hasExpandCondition &&
         <button
           className="btn btn-link expand-icon park-camping-link"
+          aria-expanded={expanded} 
           aria-label={expandLabel(camping?.campingType?.campingTypeName)}
           onClick={handleExpandClick}
         >

--- a/src/gatsby/src/components/park/contact.js
+++ b/src/gatsby/src/components/park/contact.js
@@ -61,7 +61,7 @@ export const ParkContact = ({ contact }) => {
                 href={`${getPrefix(link.contactType)}${link.contactUrl}`}
                 aria-label={`${link.contactType}: ${link.contactText}`}
               >
-                {link.contactText}
+                <span className="visually-hidden">{link.contactType}: </span>{link.contactText}
               </a>
               :
               link.contactText
@@ -108,11 +108,15 @@ export default function Contact({ contact, parkContacts, operations }) {
                     </p>
                     <p>
                       <FontAwesome icon="phone" />
-                      <a href="tel:+18006899025" aria-label="Phone number: 1-800-689-9025">1-800-689-9025</a> (toll-free from Canada or the US)
+                      <a href="tel:+18006899025" aria-label="Phone number: 1-800-689-9025">
+                        <span className="visually-hidden">Phone number: </span>1-800-689-9025
+                      </a> (toll-free from Canada or the US)
                     </p>
                     <p>
                       <FontAwesome icon="phone" />
-                      <a href="tel:+15198586161" aria-label="Phone number: 1-519-858-6161">1-519-858-6161</a> (international)
+                      <a href="tel:+15198586161" aria-label="Phone number: 1-519-858-6161">
+                        <span className="visually-hidden">Phone number: </span>1-519-858-6161
+                      </a> (international)
                     </p>
                     <p>
                       <FontAwesome icon="laptop" />
@@ -142,7 +146,9 @@ export default function Contact({ contact, parkContacts, operations }) {
                   </p>
                   <p>
                     <FontAwesome icon="envelope" />
-                    <a href="mailto:parkinfo@gov.bc.ca" aria-label="Email: parkinfo@gov.bc.ca">parkinfo@gov.bc.ca</a>
+                    <a href="mailto:parkinfo@gov.bc.ca" aria-label="Email: parkinfo@gov.bc.ca">
+                      <span className="visually-hidden">Email: </span>parkinfo@gov.bc.ca
+                    </a>
                   </p>
                 </td>
               </tr>

--- a/src/gatsby/src/components/park/contact.js
+++ b/src/gatsby/src/components/park/contact.js
@@ -57,10 +57,7 @@ export const ParkContact = ({ contact }) => {
           <p key={index}>
             <FontAwesome icon={getIcon(link.contactType)} />
             {link.contactUrl !== null ?
-              <a
-                href={`${getPrefix(link.contactType)}${link.contactUrl}`}
-                aria-label={`${link.contactType}: ${link.contactText}`}
-              >
+              <a href={`${getPrefix(link.contactType)}${link.contactUrl}`}>
                 <span className="visually-hidden">{link.contactType}: </span>{link.contactText}
               </a>
               :
@@ -108,26 +105,23 @@ export default function Contact({ contact, parkContacts, operations }) {
                     </p>
                     <p>
                       <FontAwesome icon="phone" />
-                      <a href="tel:+18006899025" aria-label="Phone number: 1-800-689-9025">
+                      <a href="tel:+18006899025">
                         <span className="visually-hidden">Phone number: </span>1-800-689-9025
                       </a> (toll-free from Canada or the US)
                     </p>
                     <p>
                       <FontAwesome icon="phone" />
-                      <a href="tel:+15198586161" aria-label="Phone number: 1-519-858-6161">
+                      <a href="tel:+15198586161">
                         <span className="visually-hidden">Phone number: </span>1-519-858-6161
                       </a> (international)
                     </p>
                     <p>
                       <FontAwesome icon="laptop" />
-                      <a href="https://camping.bcparks.ca/contact" aria-label="Contact form">Contact form</a>
+                      <a href="https://camping.bcparks.ca/contact">Contact form</a>
                     </p>
                     <p>
                       <FontAwesome icon="messages" />
-                      <a
-                        href="https://apps.cac1.pure.cloud/webchat/popup/#?locale=en-CA&webchatAppUrl=https%3A%2F%2Fapps.cac1.pure.cloud%2Fwebchat&webchatServiceUrl=https%3A%2F%2Frealtime.cac1.pure.cloud%3A443&logLevel=DEBUG&orgId=353&orgGuid=0b006318-4527-4b99-bcd7-c3b033bb5a7b&orgName=camis-caprod&queueName=BC_CHAT&waitForAllCandidates=true&forceRelayCandidates=false&cssClass=webchat-frame&css.width=100%25&css.height=100%25&companyLogo.url=https%3A%2F%2Fcamping.bcparks.ca%2Fimages%2Ffed25851-bc9a-4c9e-9d77-eef7d657e372.png&companyLogo.width=600&companyLogo.height=149&companyLogoSmall.url=https%3A%2F%2Fcamping.bcparks.ca%2Fimages%2Fc707917e-06eb-43b7-9037-167631c8075d.png&companyLogoSmall.width=25&companyLogoSmall.height=25&welcomeMessage=Welcome%20to%20the%20BC%20Parks%20Reservation%20Service%20chat.%20Agents%20are%20available%207%3A00%20am%20to%207%3A00%20pm%20PT.%20How%20may%20we%20help%20you%3F&agentAvatar.url=https%3A%2F%2Fcamping.bcparks.ca%2Fimages%2F530f022d-e797-4932-91c3-daca5905c3b8.png&agentAvatar.width=462&agentAvatar.height=462&onlineSchedules=%5Bobject%20Object%5D&chatNowElement=liveHelpContainer&widgetType=POPUP&webchatDeploymentKey=cd42d8bf-a796-41f3-8b20-be574ee3cdde&webchatApi=xmpp.v1"
-                        aria-label="Live chat"
-                      >
+                      <a href="https://apps.cac1.pure.cloud/webchat/popup/#?locale=en-CA&webchatAppUrl=https%3A%2F%2Fapps.cac1.pure.cloud%2Fwebchat&webchatServiceUrl=https%3A%2F%2Frealtime.cac1.pure.cloud%3A443&logLevel=DEBUG&orgId=353&orgGuid=0b006318-4527-4b99-bcd7-c3b033bb5a7b&orgName=camis-caprod&queueName=BC_CHAT&waitForAllCandidates=true&forceRelayCandidates=false&cssClass=webchat-frame&css.width=100%25&css.height=100%25&companyLogo.url=https%3A%2F%2Fcamping.bcparks.ca%2Fimages%2Ffed25851-bc9a-4c9e-9d77-eef7d657e372.png&companyLogo.width=600&companyLogo.height=149&companyLogoSmall.url=https%3A%2F%2Fcamping.bcparks.ca%2Fimages%2Fc707917e-06eb-43b7-9037-167631c8075d.png&companyLogoSmall.width=25&companyLogoSmall.height=25&welcomeMessage=Welcome%20to%20the%20BC%20Parks%20Reservation%20Service%20chat.%20Agents%20are%20available%207%3A00%20am%20to%207%3A00%20pm%20PT.%20How%20may%20we%20help%20you%3F&agentAvatar.url=https%3A%2F%2Fcamping.bcparks.ca%2Fimages%2F530f022d-e797-4932-91c3-daca5905c3b8.png&agentAvatar.width=462&agentAvatar.height=462&onlineSchedules=%5Bobject%20Object%5D&chatNowElement=liveHelpContainer&widgetType=POPUP&webchatDeploymentKey=cd42d8bf-a796-41f3-8b20-be574ee3cdde&webchatApi=xmpp.v1">
                         Live chat
                       </a>
                     </p>
@@ -146,7 +140,7 @@ export default function Contact({ contact, parkContacts, operations }) {
                   </p>
                   <p>
                     <FontAwesome icon="envelope" />
-                    <a href="mailto:parkinfo@gov.bc.ca" aria-label="Email: parkinfo@gov.bc.ca">
+                    <a href="mailto:parkinfo@gov.bc.ca">
                       <span className="visually-hidden">Email: </span>parkinfo@gov.bc.ca
                     </a>
                   </p>

--- a/src/gatsby/src/components/park/customToggle.js
+++ b/src/gatsby/src/components/park/customToggle.js
@@ -3,6 +3,7 @@ import React from "react"
 export default function CustomToggle({
   eventKey,
   toggleId,
+  ariaLabel,
   ariaControls,
   handleClick,
   children,
@@ -19,6 +20,7 @@ export default function CustomToggle({
       id={toggleId}
       tabIndex={0}
       role="button"
+      aria-label={ariaLabel}
       aria-controls={ariaControls}
       onClick={() => handleClick(eventKey)}
       onKeyDown={handleKeyDown}

--- a/src/gatsby/src/components/park/parkOverview.js
+++ b/src/gatsby/src/components/park/parkOverview.js
@@ -44,13 +44,14 @@ export default function ParkOverview({ data: parkOverview, type }) {
         <h2 id="park-overview-container" className="section-heading">
           Highlights in this {type}
         </h2>
-        <HtmlContent className="park-overview-html">
+        <HtmlContent ariaHidden={!expanded} className="park-overview-html">
           {expanded ? parkOverview : collapsedParkOverview}
         </HtmlContent>
       </div>
       {hasExpandCondition &&
         <button
           className="btn btn-link park-overview-link expand-icon"
+          aria-expanded={expanded} 
           aria-label={expanded ? "Show fewer highlights" : "Show more highlights"}
           onClick={() => {
             setExpanded(!expanded)

--- a/src/gatsby/src/components/park/parkPhoto.js
+++ b/src/gatsby/src/components/park/parkPhoto.js
@@ -6,6 +6,7 @@ import "react-lazy-load-image-component/src/effects/blur.css"
 export default function ParkPhoto({ type, photoIndex, setPhotoIndex, src, alt }) {
   return (
     <button
+      aria-label=""
       className={`park-photo park-photo--${type}`}
       onClick={() => setPhotoIndex(photoIndex)}
     >

--- a/src/gatsby/src/components/search/cityNameSearch.js
+++ b/src/gatsby/src/components/search/cityNameSearch.js
@@ -250,10 +250,23 @@ const CityNameSearch = ({
                 }}
                 onKeyDown={handleKeyDownInput}
                 enterKeyHint="search"
+                aria-describedby="city-search-error-message"
               />
               <label htmlFor="city-search-typeahead">
                 Near a city
               </label>
+              {(cityOptions(optionLimit).length === 1 && cityText) && 
+                <span
+                  key={cityText}
+                  id="city-search-error-message"
+                  role="alert"
+                  aria-live="assertive"
+                  aria-atomic="true"
+                  className="visually-hidden"
+                >
+                  No match. Please check your spelling.
+                </span>
+              }
             </Form.Group>
           )
         }}
@@ -265,9 +278,7 @@ const CityNameSearch = ({
                 key={results.length}
                 className="no-suggestion-text"
               >
-                <span role="alert" aria-live="assertive">
-                  No match. Please check your spelling or try a larger city in B.C.
-                </span>
+                No match. Please check your spelling or try a larger city in B.C.
               </MenuItem>
             }
             {results.map((city, index) => {

--- a/src/gatsby/src/components/search/cityNameSearch.js
+++ b/src/gatsby/src/components/search/cityNameSearch.js
@@ -264,7 +264,7 @@ const CityNameSearch = ({
                   aria-atomic="true"
                   className="visually-hidden"
                 >
-                  No match. Please check your spelling.
+                  No match. Please check your spelling or try a larger city in B.C.
                 </span>
               }
             </Form.Group>

--- a/src/gatsby/src/components/search/parkNameSearch.js
+++ b/src/gatsby/src/components/search/parkNameSearch.js
@@ -150,10 +150,23 @@ const ParkNameSearch = ({
               }}
               onKeyDown={handleKeyDownInput}
               enterKeyHint="search"
+              aria-describedby="park-search-error-message"
             />
             <label htmlFor="park-search-typeahead">
               By park name
             </label>
+            {(options.length === 0 && searchText) && 
+              <span
+                key={searchText}
+                id="park-search-error-message"
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+                className="visually-hidden"
+              >
+                No match. Please check your spelling.
+              </span>
+            }
           </Form.Group>
         )
       }}
@@ -165,9 +178,7 @@ const ParkNameSearch = ({
               key={0}
               className="no-suggestion-text"
             >
-              <span role="alert" aria-live="assertive">
-                No match. Please check your spelling.
-              </span>
+              No match. Please check your spelling.
             </MenuItem>
           }
           {results.map((result, index) => (

--- a/src/gatsby/src/pages/about/management-plans/approved.js
+++ b/src/gatsby/src/pages/about/management-plans/approved.js
@@ -167,7 +167,7 @@ const ApprovedListPage = () => {
       <div className="static-content-container">
         <div className="page-content-wrapper">
           <div>
-            <h3>Filter</h3>
+            <h2 className="sub-heading">Filter</h2>
             <div className="filters">
               {filters.map((filter, index) => (
                 <button

--- a/src/gatsby/src/pages/find-a-park/a-z-list.js
+++ b/src/gatsby/src/pages/find-a-park/a-z-list.js
@@ -103,7 +103,7 @@ const ParksPage = () => {
       <div className="static-content-container">
         <div className="page-content-wrapper">
           <div>
-            <h3>Filter</h3>
+            <h2 className="sub-heading">Filter</h2>
             <div className="filters">
               {filters.map((filter, index) => (
                 <button

--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -428,7 +428,7 @@ const ParkOperatingDatesPage = () => {
       <div className="static-content-container">
         <div className="page-content-wrapper">
           <div>
-            <h3>Filter by park name</h3>
+            <h2 className="sub-heading">Filter by park name</h2>
             <div className="filters">
               {filters.map((filter, index) => (
                 <button

--- a/src/gatsby/src/styles/listPage.scss
+++ b/src/gatsby/src/styles/listPage.scss
@@ -18,6 +18,11 @@
         margin: 0 0 2px 8px;
       }
     }
+    // use h2.sub-heading instead of h3 if there is an accessibility warning - skipped heading level
+    &.sub-heading {
+      color: $colorGrey;
+      font-size: 1.25rem;
+    }
   }
   h3 {
     color: $colorGrey;


### PR DESCRIPTION
### Jira Ticket:
CMS-485
CMS-542
CMS-548
CMS-549
CMS-550
CMS-554
CMS-643

### Description:
- CMS-485: Add menuitem role to megamenu back button
- CMS-542: Add separation between urgency icon and advisory title
- CMS-548: Skip reading urgency icon label on active advisories page
- CMS-549: Add visually hidden link type to contact link
  - It depends on how you guide the VO, but the VO could read only static text, not `aria-label`. Add visually hidden static text in case the VO doesn't read `aria-label`
- CMS-550: Adjust heading level on list pages
- CMS-554: Update status message in typeahead fields
  - VO reads the status message if there's no match, but it doesn't read full text "No match. Please check your spelling." 🤔
- CMS-643: Add aria-hidden to expandable html content
  - VoiceOver reads the content after users click the "Show more" button 
