### PR TITLE
CMS-628: Update public advisories filter to fix incorrect park access statuses display

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-status.js
@@ -65,7 +65,7 @@ const getPublishedPublicAdvisories = async () => {
       filters: {
         accessStatus: {
           precedence: {
-            $lt: 99,
+            $lt: 120,
           },
         },
       },


### PR DESCRIPTION
### Jira Ticket:
CMS-628

### Description:
- Update public advisories filter to fix incorrect park access statuses display
- `precedence` limit needed to be updated since new access statuses are added
