### PR TITLE
CMS-485: Replace nav with div not to contain elements with other roles

### DIFF
--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -247,7 +247,7 @@ const MegaMenu = ({ content, menuMode }) => {
     return (
       <>
         {item.hasChildren && (
-          <nav
+          <div
             className={
               "menu-level menu-level--" + item.treeLevel +
               " has-clicked-twice--" + hasClickedTwice
@@ -352,36 +352,34 @@ const MegaMenu = ({ content, menuMode }) => {
                 </React.Fragment>
               ))}
             </div>
-          </nav>
+          </div>
         )}
         {/* for site map page */}
         {!item.hasChildren && (
-          <nav>
-            <div className="menu-button-list" role="menu">
-              <div className="menu-button menu-header">
-                {isExternalUrl(item.url) ?
-                  <a
-                    className="menu-button__title external-link"
-                    href={item.url || ROOT_MENU_URL}
-                    role="menuitem"
-                    onClick={() => handleClickSnowplowEvent(item.title)}
-                  >
-                    {item.title}
-                    <FontAwesome icon="arrow-up-right-from-square" size="16" className="ms-1" />
-                  </a> :
-                  <Link
-                    className="menu-button__title"
-                    to={item.url || ROOT_MENU_URL}
-                    role="menuitem"
-                    onClick={() => handleClickSnowplowEvent(item.title)}
-                  >
-                    {item.title}
-                  </Link>
-                }
-              </div>
+          <div className="menu-button-list" role="menu">
+            <div className="menu-button menu-header">
+              {isExternalUrl(item.url) ?
+                <a
+                  className="menu-button__title external-link"
+                  href={item.url || ROOT_MENU_URL}
+                  role="menuitem"
+                  onClick={() => handleClickSnowplowEvent(item.title)}
+                >
+                  {item.title}
+                  <FontAwesome icon="arrow-up-right-from-square" size="16" className="ms-1" />
+                </a> :
+                <Link
+                  className="menu-button__title"
+                  to={item.url || ROOT_MENU_URL}
+                  role="menuitem"
+                  onClick={() => handleClickSnowplowEvent(item.title)}
+                >
+                  {item.title}
+                </Link>
+              }
             </div>
-          </nav>
-        )}
+          </div>
+      )}
       </>
     )
   }
@@ -432,12 +430,12 @@ const MegaMenu = ({ content, menuMode }) => {
           }}
           onClick={e => toggleMenu(e)}
         >
-          <nav className="menu-open">
+          <div className="menu-open">
             <FontAwesomeIcon icon={faBars} />
-          </nav>
-          <nav className="menu-close">
+          </div>
+          <div className="menu-close">
             <FontAwesomeIcon icon={faXmark} />
-          </nav>
+          </div>
         </div>
         <nav
           className={

--- a/src/gatsby/src/styles/megaMenu/megaMenu.scss
+++ b/src/gatsby/src/styles/megaMenu/megaMenu.scss
@@ -329,7 +329,6 @@ a.btn.book-campsite-btn {
       min-height: 0px;
       padding: 0px;
       display: block;
-      nav,
       div {
         display: none;
       }
@@ -501,7 +500,7 @@ a.btn.book-campsite-btn {
         }
       }
       .menu-level-0-children {
-        & > nav > .menu-button-list > .menu-header {
+        & > .menu-button-list > .menu-header {
           font-size: 1.5rem;
           font-weight: bold;
           margin-bottom: 16px;
@@ -524,11 +523,12 @@ a.btn.book-campsite-btn {
         font-size: 1.5rem;
         font-weight: bold;
         a {
-          color: $colorBlue;
+          color: $colorBlue !important;
         }
       }
       .menu-level-1-children {
-        & > nav > .menu-button-list > .menu-button {
+        & > .menu-level > .menu-button-list > .menu-button,
+        & > .menu-button-list > .menu-button {
           &.menu-header {
             font-size: 1.25rem;
             font-weight: bold;


### PR DESCRIPTION
### Jira Ticket:
CMS-485

### Description:
- Replace `<nav>` with `<div>` not to contain elements with other roles inside the element with `role=menu`/`role=menuitem`
- SortSite warning:
```
Elements with role=menu must contain or own an element
with role=menuitem or role=menuitemcheckbox or role=menuitemradio
and must not contain elements with other roles. Owned roles: navigation
```
