### PR TITLE
CMS-485: Add role=menu to higher level element

### DIFF
--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -259,7 +259,7 @@ const MegaMenu = ({ content, menuMode }) => {
               " has-clicked-twice--" + hasClickedTwice
             }
           >
-            <div className="menu-button-list" role="menu">
+            <div className="menu-button-list">
               <div className="menu-button menu-back">
                 <a
                   className="menu-button__title"
@@ -366,7 +366,7 @@ const MegaMenu = ({ content, menuMode }) => {
         )}
         {/* for site map page */}
         {!item.hasChildren && (
-          <div className="menu-button-list" role="menu">
+          <div className="menu-button-list">
             <div className="menu-button menu-header">
               {isExternalUrl(item.url) ?
                 <a
@@ -460,7 +460,7 @@ const MegaMenu = ({ content, menuMode }) => {
         >
           <div className="menu-wrapper">
             {menuTree.map((page, index) => (
-              <div key={index}>{generateMenus(page, menuMode)}</div>
+              <div key={index} role="menu">{generateMenus(page, menuMode)}</div>
             ))}
           </div>
         </nav>


### PR DESCRIPTION
### Jira Ticket:
CMS-485

### Description:
- SortSite warning:
```
Elements with role=menu must contain or own an element
with role=menuitem or role=menuitemcheckbox or role=menuitemradio
and must not contain elements with other roles. Owned roles: menu
```
- Since `generateMenus` is recursive, add `role=menu` to the outside element of `generateMenus` and remove `role=menu` from `generateMenus` not to contain elements with `role=menu` inside the element with `role=menu`/`role=menuitem`
- Similar fix to this PR: https://github.com/bcgov/bcparks.ca/pull/1570
- Need to check it on Alpha-TEST since couldn't test it locally with SortSite 