### PR TITLE
CMS-686: Remove url from snowplow event schema

### DIFF
--- a/src/gatsby/src/components/footer.js
+++ b/src/gatsby/src/components/footer.js
@@ -108,9 +108,8 @@ export default function Footer() {
       null,
       null,
       null,
-      null,
       url,
-      null
+      {}
     )
   }
 

--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -187,9 +187,8 @@ const MegaMenu = ({ content, menuMode }) => {
       null,
       null,
       null,
-      null,
       url,
-      null
+      {}
     )
   }
 

--- a/src/gatsby/src/components/park/about.js
+++ b/src/gatsby/src/components/park/about.js
@@ -68,8 +68,7 @@ export default function About({
       null,
       null,
       accordionName,
-      null,
-      null
+      {}
     )
   }
 

--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -66,8 +66,7 @@ export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus
       null,
       null,
       advisoryName,
-      null,
-      null
+      {}
     )
   }
 

--- a/src/gatsby/src/components/park/parkActivity.js
+++ b/src/gatsby/src/components/park/parkActivity.js
@@ -75,8 +75,7 @@ export default function ParkActivity({ data, slug, hasDiscoverParksLink }) {
       null,
       null,
       activityName,
-      null,
-      null
+      {}
     )
   }
 

--- a/src/gatsby/src/components/park/parkDates.js
+++ b/src/gatsby/src/components/park/parkDates.js
@@ -157,8 +157,7 @@ export default function ParkDates({ data, parkOperation }) {
       null,
       null,
       subAreaName,
-      null,
-      null
+      {}
     )
   }
 

--- a/src/gatsby/src/components/park/parkFacility.js
+++ b/src/gatsby/src/components/park/parkFacility.js
@@ -89,8 +89,7 @@ export default function ParkFacility({ data, groupPicnicReservationUrl }) {
       null,
       null,
       facilityName,
-      null,
-      null
+      {}
     )
   }
 

--- a/src/gatsby/src/components/search/mainSearch.js
+++ b/src/gatsby/src/components/search/mainSearch.js
@@ -67,8 +67,7 @@ const MainSearch = ({ hasCityNameSearch }) => {
       parkName: queryText.length ? queryText : null,
       cityName: null,
       label: null,
-      url: null,
-      filters: null
+      filters: {}
     }
     if (clickedCity?.length > 0) {
       eventParams.cityName = clickedCity[0].cityName
@@ -81,7 +80,6 @@ const MainSearch = ({ hasCityNameSearch }) => {
       eventParams.parkName,
       eventParams.cityName,
       eventParams.label,
-      eventParams.url,
       eventParams.filters
     )
   }

--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -336,8 +336,7 @@ export default function FindAPark({ location, data }) {
       parkName: null,
       cityName: null,
       label: null,
-      url: null,
-      filters: null
+      filters: {}
     }
 
     if (searchText === "" || (inputText && (searchText !== inputText))) {
@@ -378,8 +377,7 @@ export default function FindAPark({ location, data }) {
         selected[0].protectedAreaName,
         null,
         null,
-        null,
-        null
+        {}
       )
     }
   }
@@ -749,7 +747,6 @@ export default function FindAPark({ location, data }) {
         updatedEventParams.parkName,
         updatedEventParams.cityName,
         updatedEventParams.label,
-        updatedEventParams.url,
         updatedEventParams.filters
       )
     }

--- a/src/gatsby/src/utils/snowplowHelper.js
+++ b/src/gatsby/src/utils/snowplowHelper.js
@@ -4,8 +4,7 @@ export const trackSnowplowEvent = (
   parkName = null,
   cityName = null,
   label = null,
-  url = null,
-  filters = null
+  filters = {}
 ) => {
   if (typeof window.snowplow === "function") {
     window.snowplow("trackSelfDescribingEvent", {
@@ -22,8 +21,6 @@ export const trackSnowplowEvent = (
         city_name: cityName,
         // Optional field: the label for the button or accordion
         label: label,
-        // Optional field: the url for the link
-        url: url,
         // Optional field: filters for the search
         // Possible filters: 'popular', 'area', 'camping', 'activities', 'facilities'
         filters: filters,


### PR DESCRIPTION
### Jira Ticket:
CMS-686

### Description:
- Remove `url` from snowplow event schema
  - URL value will be collected as a `label`
- Change `filter` default value from `null` to an empty obj `{}`
