### PR TITLE
CMS-643: Fix an issue that users can't focus on the highlights section when there is no expand toggle

### DIFF
--- a/src/gatsby/src/components/park/campingDetails.js
+++ b/src/gatsby/src/components/park/campingDetails.js
@@ -74,7 +74,7 @@ export const CampingType = ({ camping, parkOperation }) => {
           </h3>
         </div>
         {/* let voiceover skip reading content if it is not expanded */}
-        <HtmlContent ariaHidden={hasExpandCondition ? !expanded : false} className="park-camping-description">
+        <HtmlContent ariaHidden={hasExpandCondition && !expanded} className="park-camping-description">
           {hasExpandCondition ? (expanded ? campingDescription : collapsedDescription) : campingDescription}
         </HtmlContent>
         {!camping.hideStandardCallout &&

--- a/src/gatsby/src/components/park/campingDetails.js
+++ b/src/gatsby/src/components/park/campingDetails.js
@@ -73,8 +73,9 @@ export const CampingType = ({ camping, parkOperation }) => {
             {camping?.campingType?.campingTypeName}
           </h3>
         </div>
-        <HtmlContent ariaHidden={!expanded} className="park-camping-description">
-          {expanded ? campingDescription : collapsedDescription}
+        {/* let voiceover skip reading content if it is not expanded */}
+        <HtmlContent ariaHidden={hasExpandCondition ? !expanded : false} className="park-camping-description">
+          {hasExpandCondition ? (expanded ? campingDescription : collapsedDescription) : campingDescription}
         </HtmlContent>
         {!camping.hideStandardCallout &&
           !isNullOrWhiteSpace(camping.campingType?.appendStandardCalloutText?.data?.appendStandardCalloutText) && (

--- a/src/gatsby/src/components/park/parkOverview.js
+++ b/src/gatsby/src/components/park/parkOverview.js
@@ -45,7 +45,7 @@ export default function ParkOverview({ data: parkOverview, type }) {
           Highlights in this {type}
         </h2>
         {/* let voiceover skip reading content if it is not expanded */}
-        <HtmlContent ariaHidden={hasExpandCondition ? !expanded : false} className="park-overview-html">
+        <HtmlContent ariaHidden={hasExpandCondition && !expanded} className="park-overview-html">
           {hasExpandCondition ? (expanded ? parkOverview : collapsedParkOverview) : parkOverview }
         </HtmlContent>
       </div>

--- a/src/gatsby/src/components/park/parkOverview.js
+++ b/src/gatsby/src/components/park/parkOverview.js
@@ -44,8 +44,9 @@ export default function ParkOverview({ data: parkOverview, type }) {
         <h2 id="park-overview-container" className="section-heading">
           Highlights in this {type}
         </h2>
-        <HtmlContent ariaHidden={!expanded} className="park-overview-html">
-          {expanded ? parkOverview : collapsedParkOverview}
+        {/* let voiceover skip reading content if it is not expanded */}
+        <HtmlContent ariaHidden={hasExpandCondition ? !expanded : false} className="park-overview-html">
+          {hasExpandCondition ? (expanded ? parkOverview : collapsedParkOverview) : parkOverview }
         </HtmlContent>
       </div>
       {hasExpandCondition &&


### PR DESCRIPTION
### Jira Ticket:
CMS-643

### Description:
- Fix an issue that users can't focus on the highlights section when there is no expand toggle
- The second issue that is mentioned in the ticket is not feasible. This is because the content is hidden with CSS, yet there is complete HTML content. Therefore, we can’t select just the visible part to let VO read. 
> Also, even if there is a link, we should first read what is already visible and then navigate to the expand link to expand and access the rest of the hidden content.