### PR TITLE
CMS-669: Fix an issue that voiceover reads all menu items on mobile

### DIFF
--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -456,6 +456,7 @@ const MegaMenu = ({ content, menuMode }) => {
             " menu-" +
             (isMenuOpen ? "open" : "closed")
           }
+          aria-hidden={!isMenuOpen}
         >
           <div className="menu-wrapper">
             {menuTree.map((page, index) => (

--- a/src/gatsby/src/styles/bootstrapTheme.scss
+++ b/src/gatsby/src/styles/bootstrapTheme.scss
@@ -46,3 +46,7 @@ a {
   background-color: $colorWhite;
   border-color: $colorBlue;
 }
+
+.visually-hidden-focusable:not(:focus):not(:focus-within):not(caption):focus-visible {
+  position: static !important;
+}


### PR DESCRIPTION
### Jira Ticket:
CMS-668
CMS-669

### Description:
- Display 'Skip to main content' when it gets focused on mobile
  - Override Bootstrap CSS class
  - The button gets focused when using VO, it works on Chrome with MacOS but not with iOS
- Fix an issue that voiceover reads all menu items on mobile even when the menu toggle is closed
  - Add `aria-hidden` true to `<nav>` when the menu is closed on mobile 
- TODO: Need to test it on an actual device when it's merged since it's not possible to recreate the issues locally with MacOS
