### PR TITLE
CMS-646: Update park page table of contents on mobile

### DIFF
--- a/src/gatsby/src/components/pageContent/pageMenu.js
+++ b/src/gatsby/src/components/pageContent/pageMenu.js
@@ -25,30 +25,18 @@ export default function PageMenu({ pageSections, activeSection, menuStyle }) {
   }
 
   if (menuStyle === "select") {
-    let sectionIndex = activeSection
-    const handleSectionChange = e => {
-      let index = e.target.value
-      let s = pageSections.find(c => c.sectionIndex === Number(index))
-      let link = s.link
-      window.location.hash = link
-    }
-
     return (
       <div className="section-select-container">
-        <select
-          className="section-select"
-          value={sectionIndex}
-          onChange={handleSectionChange}
-          title="mobile-navigation"
-        >
-          <option value="" disabled>Table of Contents</option>
-          {pageSections.filter(s => s.visible).map(
-            section =>
-              <option key={section.sectionIndex} value={section.sectionIndex}>
+        <p><b>On this page</b></p>
+        <ul>
+          {pageSections.filter(section => section.visible).map(section => (
+            <li key={section.sectionIndex}>
+              <a href={section.link}>
                 {section.display}
-              </option>
-          )}
-        </select>
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
     )
   }

--- a/src/gatsby/src/components/pageContent/pageMenu.js
+++ b/src/gatsby/src/components/pageContent/pageMenu.js
@@ -24,9 +24,9 @@ export default function PageMenu({ pageSections, activeSection, menuStyle }) {
     )
   }
 
-  if (menuStyle === "select") {
+  if (menuStyle === "list") {
     return (
-      <div className="section-select-container">
+      <div className="section-list-container">
         <p><b>On this page</b></p>
         <ul>
           {pageSections.filter(section => section.visible).map(section => (

--- a/src/gatsby/src/styles/pageContent/pageMenu.scss
+++ b/src/gatsby/src/styles/pageContent/pageMenu.scss
@@ -48,43 +48,29 @@
   border-left: $colorBlue solid 3px;
 }
 .page-menu--mobile {
-  top: 0px;
-  position: sticky;
-  position: -webkit-sticky;
-  z-index: 1024;
-  background: #fff;
-  width: 100%;
-  margin-top: 32px;
-
+  padding: 0 16px;
   .section-select-container {
-    position: relative;
-    border-top: 1px solid $colorGrey;
-    border-bottom: 1px solid $colorGrey;
-    &::after {
-      position: absolute;
-      content: "\f078";
-      top: calc(50% - 8px);
-      right: 22px;
-      color: $colorBlue;
-      font-weight: 900;
-      font-size: 12px;
-      font-style: normal;
-      font-variant: normal;
-      font-family: "Font Awesome 5 Free";
-      text-rendering: auto;
-      text-decoration: none;
-      -webkit-font-smoothing: antialiased;
+    padding-top: 64px;
+    p {
+      font-size: 1.25rem;
     }
-
-    .section-select {
-      width: 100%;
-      height: 68px !important;
-      border: none;
-      padding: 0 40px 0 20px;
-      color: $colorBlue;
-      background: #fff;
-      text-overflow: ellipsis;
-      appearance: none;
+    ul {
+      margin-bottom: 0;
+      li {
+        & + li {
+          margin-top: 8px;
+        }
+        a {
+          text-decoration: underline;
+          &:focus-visible {
+            color: $colorBlue;
+            border-radius: 4px;
+            border: $colorWhite solid 2px;
+            outline: $colorBlueMed solid 2px;
+            outline-offset: 0px;
+          }
+        }
+      }
     }
   }
 }

--- a/src/gatsby/src/styles/pageContent/pageMenu.scss
+++ b/src/gatsby/src/styles/pageContent/pageMenu.scss
@@ -49,7 +49,7 @@
 }
 .page-menu--mobile {
   padding: 0 16px;
-  .section-select-container {
+  .section-list-container {
     padding-top: 64px;
     p {
       font-size: 1.25rem;

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -312,8 +312,7 @@ export default function ParkTemplate({ data }) {
         <div className="page-menu--mobile d-block d-md-none">
           <PageMenu
             pageSections={menuItems}
-            activeSection={activeSection}
-            menuStyle="select"
+            menuStyle="list"
           />
         </div>
         <div className="row g-0 park-info-container">

--- a/src/gatsby/src/templates/parkSubPage.js
+++ b/src/gatsby/src/templates/parkSubPage.js
@@ -117,8 +117,7 @@ export default function ParkSubPage({ data }) {
         <div className="page-menu--mobile d-block d-md-none">
           <PageMenu
             pageSections={pageSections}
-            activeSection={activeSection}
-            menuStyle="select"
+            menuStyle="list"
           />
         </div>
       )}

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -244,8 +244,7 @@ export default function SiteTemplate({ data }) {
         <div className="page-menu--mobile d-block d-md-none">
           <PageMenu
             pageSections={menuItems}
-            activeSection={activeSection}
-            menuStyle="select"
+            menuStyle="list"
           />
         </div>
         <div className="row g-0 park-info-container">

--- a/src/gatsby/src/templates/staticContent1.js
+++ b/src/gatsby/src/templates/staticContent1.js
@@ -162,15 +162,6 @@ export default function StaticContent1({ pageContext }) {
           </>
         )}
       </div>
-      {hasSections && (
-        <div className="page-menu--mobile d-block d-md-none">
-          <PageMenu
-            pageSections={pageSections}
-            activeSection={activeSection}
-            menuStyle="select"
-          />
-        </div>
-      )}
       <div className="static-content-container">
         <div className="page-content-wrapper">
           {hasSections ? (


### PR DESCRIPTION
### Jira Ticket:
CMS-646

### Description:
- Update the table of contents on mobile
  - Change it to the list of links, no longer select/option
- It applies to the park page, the site page, and the park subpage. The static content page has the same layout, but it already has a typed-out contents link section, which would be redundant. So, we’ve decided to leave out the mobile change for the static content page.
