### PR TITLE
CMS-668: Fix a broken link accessibility error

### DIFF
--- a/src/gatsby/src/components/header.js
+++ b/src/gatsby/src/components/header.js
@@ -3,12 +3,13 @@ import React from "react"
 import SkipToContent from "./skipToContent"
 import MegaMenu from "./megaMenu.js"
 import EmergencyAlert from "./emergencyAlert"
+import { useScreenSize } from "../utils/helpers"
 
 export default function Header({ content = [] }) {
-
+  const screenSize = useScreenSize()
   return (
     <>
-      <SkipToContent></SkipToContent>
+      {screenSize.width > 991 && <SkipToContent></SkipToContent>}
       <EmergencyAlert />
       <MegaMenu content={content} menuMode="responsive" />
     </>

--- a/src/gatsby/src/components/skipToContent.js
+++ b/src/gatsby/src/components/skipToContent.js
@@ -2,6 +2,6 @@ import React from "react"
 
 export default function SkipToContent() {
   return (
-    <a className="d-none d-lg-inline-block visually-hidden-focusable" href="#main-content">Skip to main content</a>
+    <a className="visually-hidden-focusable" href="#main-content">Skip to main content</a>
   )
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-123

### Description:
- Fix a broken link accessibility error
- Change it to hide the link on mobile with the screen size state condition, not with CSS
- Error:
> A skip navigation link exists, but the target for the link does not exist or the link is not keyboard accessible.
> Ensure that the target for the link exists and that the link is not hidden with CSS display:none or visibility:hidden.
