### PR TITLE
CMS-777: Fix keycloak login issue

### DIFF
--- a/src/admin/package-lock.json
+++ b/src/admin/package-lock.json
@@ -25,7 +25,7 @@
         "bootstrap": "^4.6.0",
         "history": "^5.0.0",
         "jsonwebtoken": "^8.5.1",
-        "keycloak-js": "^12.0.4",
+        "keycloak-js": "^26.2.0",
         "material-table": "^1.69.2",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
@@ -20492,11 +20492,6 @@
       "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==",
       "peer": true
     },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -20885,13 +20880,9 @@
       }
     },
     "node_modules/keycloak-js": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-12.0.4.tgz",
-      "integrity": "sha512-O/BHtyiDrZrUnKBrVF8POojqd3gmhuiDw4FiI+FbnB14nu7G5jKFrKYZa9Q0JYKIZXHJOBzSaKQcMp2WUI+zmA==",
-      "dependencies": {
-        "base64-js": "1.3.1",
-        "js-sha256": "0.9.0"
-      }
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.0.tgz",
+      "integrity": "sha512-CrFcXTN+d6J0V/1v3Zpioys6qHNWE6yUzVVIsCUAmFn9H14GZ0vuYod+lt+SSpMgWGPuneDZBSGBAeLBFuqjsw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",

--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -20,7 +20,7 @@
     "bootstrap": "^4.6.0",
     "history": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
-    "keycloak-js": "^12.0.4",
+    "keycloak-js": "^26.2.0",
     "material-table": "^1.69.2",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",


### PR DESCRIPTION
### Jira Ticket:
CMS-777

### Description:
- Fix an issue that the users couldn't log in to the Staff Portal by updating `keycloak-js`
- This is the same as this fix: https://github.com/bcgov/bcparks-staff-portal/pull/144, but for PROD since they will make a change on March 25th
- If DOOT will be deployed on the OpenShift Silver PROD before 25th, this is not needed, but it doesn't harm the admin app even if it's merged
