### PR TITLE
CMS-695: Display sub area dates from park feature date collection

### DIFF
--- a/src/cms/config/plugins.js
+++ b/src/cms/config/plugins.js
@@ -159,6 +159,15 @@ module.exports = ({ env }) => {
             "api::search-area.search-area": {
               GET: true,
             },
+            "api::park-operation-sub-area.park-operation-sub-area": {
+              GET: true,
+            },
+            "api::park-operation-sub-area-date.park-operation-sub-area-date": {
+              GET: true,
+            },
+            "api::park-feature-date.park-feature-date": {
+              GET: true,
+            },
           },
         },
       },

--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -45,9 +45,9 @@ module.exports = {
           "footer-menu",
           "park-operation",
           "park-operation-date",
-          "park-operation-sub-area",
           "park-operation-sub-area-date",
           "park-operation-sub-area-type",
+          "park-feature-date",
           "park-contact",
           "park-operator-contact",
           "park-photo",
@@ -200,6 +200,31 @@ module.exports = {
               }
             }
           },
+          {
+            singularName: "park-operation-sub-area",
+            queryParams: {
+              populate: {
+                populate: {
+                  protectedArea: {
+                    fields: "*"
+                  },
+                  parkSubAreaType: {
+                    fields: "*",
+                    populate: {
+                      campingType: {fields: "*"},
+                      facilityType: {fields: "*"}
+                    }
+                  },
+                  parkFeatureDates: {
+                    fields: "*"
+                  },
+                  parkOperationSubAreaDates: {
+                    fields: "*"
+                  }
+                }
+              }
+            }
+          }
         ]
       }
     },

--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -47,7 +47,6 @@ module.exports = {
           "park-operation-date",
           "park-operation-sub-area-date",
           "park-operation-sub-area-type",
-          "park-feature-date",
           "park-contact",
           "park-operator-contact",
           "park-photo",
@@ -200,31 +199,6 @@ module.exports = {
               }
             }
           },
-          {
-            singularName: "park-operation-sub-area",
-            queryParams: {
-              populate: {
-                populate: {
-                  protectedArea: {
-                    fields: "*"
-                  },
-                  parkSubAreaType: {
-                    fields: "*",
-                    populate: {
-                      campingType: {fields: "*"},
-                      facilityType: {fields: "*"}
-                    }
-                  },
-                  parkFeatureDates: {
-                    fields: "*"
-                  },
-                  parkOperationSubAreaDates: {
-                    fields: "*"
-                  }
-                }
-              }
-            }
-          }
         ]
       }
     },

--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -227,20 +227,6 @@ exports.createSchemaCustomization = ({ actions }) => {
     gateCloseDate: Date
   }
 
-  type STRAPI_PARK_OPERATION_SUB_AREA implements Node {
-    nonReservableSites: String
-    vehicleSitesReservable: String
-    pullThroughSites: String
-    rvSitesReservable: String
-    longStaySites: String
-    groupSitesReservable: String
-    boatLaunches: String
-    closureAffectsAccessStatus: Boolean
-  }
-
-  type STRAPI_PARK_OPERATION_SUB_AREA_TYPE implements Node {
-    closureAffectsAccessStatus: Boolean
-  }
 
   type STRAPI__COMPONENT_PARKS_PAGE_HEADER_INTROHTML_TEXTNODE implements Node @dontInfer {
     introHtml: String
@@ -330,7 +316,6 @@ exports.createSchemaCustomization = ({ actions }) => {
     safetyInfo: STRAPI_SITE_SAFETYINFO
     parkOperation: STRAPI_PARK_OPERATION @link(by: "id", from: "parkOperation___NODE")
     parkOperationDates: [STRAPI_PARK_OPERATION_DATE] @link(by: "id", from: "parkOperationDates___NODE")
-    parkOperationSubAreas: [STRAPI_PARK_OPERATION_SUB_AREA] @link(by: "id", from: "parkOperationSubAreas___NODE")
     parkActivities: [STRAPI_PARK_ACTIVITY] @link(by: "id", from: "parkActivities___NODE")
     parkFacilities: [STRAPI_PARK_FACILITY] @link(by: "id", from: "parkFacilities___NODE")
     parkCampingTypes: [STRAPI_PARK_CAMPING_TYPE] @link(by: "id", from: "parkCampingTypes___NODE")

--- a/src/gatsby/src/components/park/campingDetails.js
+++ b/src/gatsby/src/components/park/campingDetails.js
@@ -110,8 +110,7 @@ export const CampingType = ({ camping, parkOperation, isLoadingSubAreas, subArea
 }
 
 export default function CampingDetails({ data }) {
-  const activeCampings = data.activeCampings
-  const parkOperation = data.parkOperation
+  const { activeCampings, parkOperation, isLoadingSubAreas, subAreasLoadError } = data
 
   return (
     <div id="camping" className="anchor-link">
@@ -131,8 +130,8 @@ export default function CampingDetails({ data }) {
               eventKey={index.toString()}
               camping={camping}
               parkOperation={parkOperation}
-              isLoadingSubAreas={data.isLoadingSubAreas}
-              subAreasLoadError={data.subAreasLoadError}
+              isLoadingSubAreas={isLoadingSubAreas}
+              subAreasLoadError={subAreasLoadError}
             />
           ))}
         </Col>

--- a/src/gatsby/src/components/park/campingDetails.js
+++ b/src/gatsby/src/components/park/campingDetails.js
@@ -11,7 +11,7 @@ import StaticIcon from "./staticIcon"
 import { isNullOrWhiteSpace } from "../../utils/helpers"
 import "../../styles/cmsSnippets/parkInfoPage.scss"
 
-export const CampingType = ({ camping, parkOperation }) => {
+export const CampingType = ({ camping, parkOperation, isLoadingSubAreas, subAreasLoadError }) => {
   const [expanded, setExpanded] = useState(false)
   const [height, setHeight] = useState(0)
   const [sectionHeight, setSectionHeight] = useState(0)
@@ -99,7 +99,12 @@ export const CampingType = ({ camping, parkOperation }) => {
           }
         </button>
       }
-      <ParkDates data={camping} parkOperation={parkOperation} />
+      <ParkDates
+        data={camping}
+        parkOperation={parkOperation}
+        isLoadingSubAreas={isLoadingSubAreas}
+        subAreasLoadError={subAreasLoadError}
+      />
     </div>
   )
 }
@@ -107,8 +112,6 @@ export const CampingType = ({ camping, parkOperation }) => {
 export default function CampingDetails({ data }) {
   const activeCampings = data.activeCampings
   const parkOperation = data.parkOperation
-  const subAreas = data.subAreas || []
-  subAreas.sort((a, b) => (a.parkSubArea >= b.parkSubArea ? 1 : -1))
 
   return (
     <div id="camping" className="anchor-link">
@@ -128,6 +131,8 @@ export default function CampingDetails({ data }) {
               eventKey={index.toString()}
               camping={camping}
               parkOperation={parkOperation}
+              isLoadingSubAreas={data.isLoadingSubAreas}
+              subAreasLoadError={data.subAreasLoadError}
             />
           ))}
         </Col>

--- a/src/gatsby/src/components/park/parkDates.js
+++ b/src/gatsby/src/components/park/parkDates.js
@@ -141,7 +141,7 @@ export const AccordionList = ({ eventKey, subArea, openAccordions, toggleAccordi
   )
 }
 
-export default function ParkDates({ data, parkOperation }) {
+export default function ParkDates({ data, parkOperation, isLoadingSubAreas, subAreasLoadError }) {
   const subAreas = data.subAreas.sort((a, b) => (a.parkSubArea >= b.parkSubArea ? 1 : -1))
   const [hash, setHash] = useState("")
   const [openAccordions, setOpenAccordions] = useState({})
@@ -218,7 +218,7 @@ export default function ParkDates({ data, parkOperation }) {
 
   return (
     <>
-      {subAreas.length > 0 && (
+      {!isLoadingSubAreas && !subAreasLoadError && subAreas.length > 0 && (
         <>
           <Row className="align-items-center my-4">
             <Col>

--- a/src/gatsby/src/components/park/parkHeader.js
+++ b/src/gatsby/src/components/park/parkHeader.js
@@ -92,6 +92,8 @@ export default function ParkHeader({
   parkOperation,
   operationDates,
   subAreas,
+  isLoadingSubAreas,
+  subAreasLoadError,
   onStatusCalculated
 }) {
   const linkZoom = mapZoom + 1
@@ -119,7 +121,7 @@ export default function ParkHeader({
           </div>
         )}
         <div className="park-header-child">
-          {(!isLoadingAdvisories && !advisoryLoadError) ?
+          {(!isLoadingAdvisories && !advisoryLoadError && !isLoadingSubAreas && !subAreasLoadError) ?
             <ParkAccessStatus
               advisories={advisories}
               slug={slug}
@@ -215,5 +217,7 @@ ParkHeader.propTypes = {
   parkOperation: PropTypes.object,
   operationDates: PropTypes.array.isRequired,
   subAreas: PropTypes.array.isRequired,
+  isLoadingSubAreas: PropTypes.bool.isRequired,
+  subAreasLoadError: PropTypes.any,
   onStatusCalculated: PropTypes.func
 }

--- a/src/gatsby/src/components/park/subArea.js
+++ b/src/gatsby/src/components/park/subArea.js
@@ -134,14 +134,14 @@ export default function SubArea({ data, showHeading }) {
       <Row className="subarea-container mt-3">
         <Col>
           {subAreasNotesList
-            .filter(note => data[note.noteVar]?.data[note.noteVar])
+            .filter(note => data[note.noteVar])
             .map((note, index) => (
               <div key={index} className="subarea-list subarea-note">
                 {note.display && (
                   <h4>{note.display}</h4>
                 )}
                 <HtmlContent>
-                  {data[note.noteVar].data[note.noteVar]}
+                  {data[note.noteVar]}
                 </HtmlContent>
               </div>
             ))}

--- a/src/gatsby/src/components/park/subArea.js
+++ b/src/gatsby/src/components/park/subArea.js
@@ -53,7 +53,7 @@ export default function SubArea({ data, showHeading }) {
     return (
       <>
         {message}
-        {gateNote && <HtmlContent>{gateNote.data.gateNote}</HtmlContent>}
+        {gateNote && <HtmlContent>{gateNote}</HtmlContent>}
       </>
     )
   }

--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react"
 import { graphql, useStaticQuery, Link } from "gatsby"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCircleChevronRight } from "@fortawesome/free-solid-svg-icons"
+import { ProgressBar } from "react-bootstrap"
 
 import Breadcrumbs from "../../components/breadcrumbs"
 import Header from "../../components/header"
@@ -73,19 +74,19 @@ const ParkLink = ({ park, advisories, subAreas, advisoryLoadError, isLoadingAdvi
 
   return (
     <div className="park-list operating-dates-list">
-      <div className="d-md-flex justify-content-between mb-2">
-        <h2 className="mb-0">
+      <div className="d-md-flex justify-content-between">
+        <h2 className="mb-3">
           <Link to={`/${park.slug}`}>
             {park.protectedAreaName}
             <FontAwesomeIcon icon={faCircleChevronRight} className="park-heading-icon" />
           </Link>
         </h2>
       </div>
-      <div className="mb-3">
+      <div className="mb-2">
         <>
           <span className="me-1">
             {(!isLoadingAdvisories && !advisoryLoadError && 
-              !isLoadingSubAreas && !subAreaLoadError) &&
+              !isLoadingSubAreas && !subAreaLoadError) ?
               <ParkAccessStatus
                 advisories={advisories}
                 slug={park.slug}
@@ -94,6 +95,7 @@ const ParkLink = ({ park, advisories, subAreas, advisoryLoadError, isLoadingAdvi
                 onStatusCalculated={setParkAccessStatus}
                 punctuation="."
               />
+              : <ProgressBar animated now={100} />
             }
           </span>
           {parkDates && (

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react"
+import React, { useEffect, useState, useRef, useMemo } from "react"
 import axios from "axios"
 import { sortBy, truncate } from "lodash"
 import { graphql, Link as GatsbyLink, navigate } from "gatsby"
@@ -84,11 +84,8 @@ export default function ParkTemplate({ data }) {
   const [parkAccessStatus, setParkAccessStatus] = useState(null)
   const [addedSeasonalAdvisory, setAddedSeasonalAdvisory] = useState(false)
   const [subAreas, setSubAreas] = useState([])
-  const [processSubAreas, setProcessSubAreas] = useState([])
   const [subAreasLoadError, setSubAreasLoadError] = useState(false)
   const [isLoadingSubAreas, setIsLoadingSubAreas] = useState(true)
-  const activeFacilities = combineFacilities(park.parkFacilities, data.allStrapiFacilityType.nodes, subAreas)
-  const activeCampings = combineCampingTypes(park.parkCampingTypes, data.allStrapiCampingType.nodes, subAreas)
 
   const loadAdvisoriesData = async () => {
     setIsLoadingAdvisories(true)
@@ -159,11 +156,15 @@ export default function ParkTemplate({ data }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiBaseUrl, park.orcs])
 
-  useEffect(() => {
+  const processedSubAreas = useMemo(() => {
     if (!isLoadingSubAreas && !subAreasLoadError && subAreas.length) {
-      setProcessSubAreas(preProcessSubAreas(subAreas))
+      return preProcessSubAreas(subAreas)
     }
+    return []
   }, [isLoadingSubAreas, subAreasLoadError, subAreas])
+
+  const activeFacilities = combineFacilities(park.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas)
+  const activeCampings = combineCampingTypes(park.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas)
 
   useEffect(() => {
     if (window.location.hash && !isLoadingProtectedArea && !isLoadingAdvisories && !isLoadingSubAreas) {
@@ -725,93 +726,6 @@ export const query = graphql`
             data {
               content
             }
-          }
-        }
-      }
-      parkOperationSubAreas {
-        parkSubArea
-        orcsSiteNumber
-        isActive
-        isOpen
-        hasReservations
-        hasBackcountryReservations
-        hasBackcountryPermits
-        hasFirstComeFirstServed
-        parkAccessUnitId
-        isCleanAirSite
-        totalCapacity
-        frontcountrySites
-        reservableSites
-        nonReservableSites
-        vehicleSites
-        vehicleSitesReservable
-        doubleSites
-        pullThroughSites
-        rvSites
-        rvSitesReservable
-        electrifiedSites
-        longStaySites
-        walkInSites
-        walkInSitesReservable
-        groupSites
-        groupSitesReservable
-        backcountrySites
-        wildernessSites
-        boatAccessSites
-        horseSites
-        cabins
-        huts
-        yurts
-        shelters
-        boatLaunches
-        hasGate
-        gateOpenTime
-        gateCloseTime
-        gateOpensAtDawn
-        gateClosesAtDusk
-        gateOpen24Hours
-        gateNote {
-          data {
-            gateNote
-          }
-        }
-        serviceNote {
-          data {
-            serviceNote
-          }
-        }
-        reservationNote {
-          data {
-            reservationNote
-          }
-        }
-        offSeasonNote {
-          data {
-            offSeasonNote
-          }
-        }
-        closureAffectsAccessStatus
-        parkOperationSubAreaDates {
-          isActive
-          operatingYear
-          openDate
-          closeDate
-          serviceStartDate
-          serviceEndDate
-          reservationStartDate
-          reservationEndDate
-          offSeasonStartDate
-          offSeasonEndDate
-        }
-        parkSubAreaType {
-          subAreaType
-          subAreaTypeCode
-          closureAffectsAccessStatus
-          facilityType {
-            facilityCode
-          }
-          campingType {
-            campingTypeCode
           }
         }
       }

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -91,13 +91,8 @@ export default function ParkTemplate({ data }) {
     setIsLoadingAdvisories(true)
     try {
       const response = await loadAdvisories(apiBaseUrl, park.orcs)
-      if (response.status === 200) {
-        setAdvisories(response.data.data)
-        setAdvisoryLoadError(false)
-      } else {
-        setAdvisories([])
-        setAdvisoryLoadError(true)
-      }
+      setAdvisories(response.data.data)
+      setAdvisoryLoadError(false)
     } catch (error) {
       console.error("Error loading advisories:", error)
       setAdvisories([])
@@ -113,13 +108,8 @@ export default function ParkTemplate({ data }) {
       const response = await axios.get(
         `${apiBaseUrl}/protected-areas/${park.orcs}?fields=hasCampfireBan`
       )
-      if (response.status === 200) {
-        setHasCampfireBan(response.data.hasCampfireBan)
-        setProtectedAreaLoadError(false)
-      } else {
-        setHasCampfireBan(false)
-        setProtectedAreaLoadError(true)
-      }
+      setHasCampfireBan(response.data.hasCampfireBan)
+      setProtectedAreaLoadError(false)
     } catch (error) {
       console.error("Error loading protected area:", error)
       setHasCampfireBan(false)
@@ -133,13 +123,8 @@ export default function ParkTemplate({ data }) {
     setIsLoadingSubAreas(true)
     try {
       const response = await loadSubAreas(apiBaseUrl, park.orcs)
-      if (response.status === 200) {
-        setSubAreas(response.data.data)
-        setSubAreasLoadError(false)
-      } else {
-        setSubAreas([])
-        setSubAreasLoadError(true)
-      }
+      setSubAreas(response.data.data)
+      setSubAreasLoadError(false)
     } catch (error) {
       console.error("Error loading sub-areas:", error)
       setSubAreas([])

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -73,23 +73,17 @@ export default function SiteTemplate({ data }) {
     setIsLoadingAdvisories(true)
     try {
       const response = await loadAdvisories(apiBaseUrl, park?.orcs)
-      if (response.status === 200) {
-        // for sites, we want to include all advisories at the park level  
-        // and advisories for this specific site, but we exclude advisories 
-        // for other sites at the same park
-        const advisories = response.data.data.filter(
-          (advisory) => {
-            return advisory.sites.length === 0 ||
-              advisory.sites.some(
-                (s) => s.orcsSiteNumber === site.orcsSiteNumber
-              )
-          })
-        setAdvisories(advisories)
-        setAdvisoryLoadError(false)
-      } else {
-        setAdvisories([])
-        setAdvisoryLoadError(true)
-      }
+      // for sites, we want to include all advisories at the park level  
+      // and advisories for this specific site, but we exclude advisories 
+      // for other sites at the same park
+      const advisories = response.data.data.filter(advisory => {
+        return advisory.sites.length === 0 ||
+          advisory.sites.some(
+            (s) => s.orcsSiteNumber === site.orcsSiteNumber
+          )
+      })
+      setAdvisories(advisories)
+      setAdvisoryLoadError(false)
     } catch (error) {
       console.error("Error loading advisories:", error)
       setAdvisories([])
@@ -105,13 +99,8 @@ export default function SiteTemplate({ data }) {
       const response = await axios.get(
         `${apiBaseUrl}/protected-areas/${park?.orcs}?fields=hasCampfireBan`
       )
-      if (response.status === 200) {
-        setHasCampfireBan(response.data.hasCampfireBan)
-        setProtectedAreaLoadError(false)
-      } else {
-        setHasCampfireBan(false)
-        setProtectedAreaLoadError(true)
-      }
+      setHasCampfireBan(response.data.hasCampfireBan)
+      setProtectedAreaLoadError(false)
     } catch (error) {
       console.error("Error loading protected area:", error)
       setHasCampfireBan(false)
@@ -125,13 +114,8 @@ export default function SiteTemplate({ data }) {
     setIsLoadingSubAreas(true)
     try {
       const response = await loadSubAreas(apiBaseUrl, park?.orcs)
-      if (response.status === 200) {
-        setSubAreas(response.data.data)
-        setSubAreasLoadError(false)
-      } else {
-        setSubAreas([])
-        setSubAreasLoadError(true)
-      }
+      setSubAreas(response.data.data)
+      setSubAreasLoadError(false)
     } catch (error) {
       console.error("Error loading sub-areas:", error)
       setSubAreas([])

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react"
+import React, { useEffect, useState, useRef, useMemo } from "react"
 import axios from "axios"
 import { sortBy, truncate } from "lodash"
 import { graphql, Link as GatsbyLink, navigate } from "gatsby"
@@ -8,7 +8,7 @@ import useScrollSpy from "react-use-scrollspy"
 
 import { isNullOrWhiteSpace } from "../utils/helpers";
 import { loadAdvisories } from '../utils/advisoryHelper';
-import { preProcessSubAreas, combineCampingTypes, combineFacilities } from '../utils/subAreaHelper';
+import { preProcessSubAreas, combineCampingTypes, combineFacilities, loadSubAreas } from '../utils/subAreaHelper';
 
 import AdvisoryDetails from "../components/park/advisoryDetails"
 import Breadcrumbs from "../components/breadcrumbs"
@@ -45,7 +45,6 @@ export default function SiteTemplate({ data }) {
   const hasSiteGuidelines = site.parkGuidelines?.length > 0
   const managementAreas = park.managementAreas || []
   const searchArea = managementAreas[0]?.searchArea || {}
-  const parkOperationSubAreas = site.parkOperationSubAreas || []
 
   const activeActivities = sortBy(
     site.parkActivities.filter(
@@ -54,10 +53,6 @@ export default function SiteTemplate({ data }) {
     ["activityType.rank", "activityType.activityName"],
     ["asc"]
   )
-
-  const subAreas = preProcessSubAreas(parkOperationSubAreas)
-  const activeFacilities = combineFacilities(site.parkFacilities, data.allStrapiFacilityType.nodes, subAreas);
-  const activeCampings = combineCampingTypes(site.parkCampingTypes, data.allStrapiCampingType.nodes, subAreas);
 
   const hasReservations = operations.hasReservations
   const hasDayUsePass = operations.hasDayUsePass
@@ -70,47 +65,98 @@ export default function SiteTemplate({ data }) {
   const [protectedAreaLoadError, setProtectedAreaLoadError] = useState(false)
   const [isLoadingProtectedArea, setIsLoadingProtectedArea] = useState(true)
   const [hasCampfireBan, setHasCampfireBan] = useState(false)
+  const [subAreas, setSubAreas] = useState([])
+  const [subAreasLoadError, setSubAreasLoadError] = useState(false)
+  const [isLoadingSubAreas, setIsLoadingSubAreas] = useState(true)
 
-  useEffect(() => {
+  const loadAdvisoriesData = async () => {
     setIsLoadingAdvisories(true)
-    loadAdvisories(apiBaseUrl, park?.orcs)
-      .then(response => {
-        if (response.status === 200) {
-          // for sites, we want to include all advisories at the park level  
-          // and advisories for this specific site, but we exclude advisories 
-          // for other sites at the same park
-          const advisories = response.data.data.filter(
-            (advisory) => {
-              return advisory.sites.length === 0 ||
-                advisory.sites.some(
-                  (s) => s.orcsSiteNumber === site.orcsSiteNumber
-                )
-            })
-          setAdvisories(advisories)
-          setAdvisoryLoadError(false)
-        } else {
-          setAdvisories([])
-          setAdvisoryLoadError(true)
-        }
-      })
-      .finally(() => {
-        setIsLoadingAdvisories(false)
-      })
+    try {
+      const response = await loadAdvisories(apiBaseUrl, park?.orcs)
+      if (response.status === 200) {
+        // for sites, we want to include all advisories at the park level  
+        // and advisories for this specific site, but we exclude advisories 
+        // for other sites at the same park
+        const advisories = response.data.data.filter(
+          (advisory) => {
+            return advisory.sites.length === 0 ||
+              advisory.sites.some(
+                (s) => s.orcsSiteNumber === site.orcsSiteNumber
+              )
+          })
+        setAdvisories(advisories)
+        setAdvisoryLoadError(false)
+      } else {
+        setAdvisories([])
+        setAdvisoryLoadError(true)
+      }
+    } catch (error) {
+      console.error("Error loading advisories:", error)
+      setAdvisories([])
+      setAdvisoryLoadError(true)
+    } finally {
+      setIsLoadingAdvisories(false)
+    }
+  }
+  
+  const loadProtectedAreaData = async () => {
     setIsLoadingProtectedArea(true)
-    axios.get(`${apiBaseUrl}/protected-areas/${park?.orcs}?fields=hasCampfireBan`)
-      .then(response => {
-        if (response.status === 200) {
-          setHasCampfireBan(response.data.hasCampfireBan)
-          setProtectedAreaLoadError(false)
-        } else {
-          setHasCampfireBan(false)
-          setProtectedAreaLoadError(true)
-        }
-      })
-      .finally(() => {
-        setIsLoadingProtectedArea(false)
-      })
+    try {
+      const response = await axios.get(
+        `${apiBaseUrl}/protected-areas/${park?.orcs}?fields=hasCampfireBan`
+      )
+      if (response.status === 200) {
+        setHasCampfireBan(response.data.hasCampfireBan)
+        setProtectedAreaLoadError(false)
+      } else {
+        setHasCampfireBan(false)
+        setProtectedAreaLoadError(true)
+      }
+    } catch (error) {
+      console.error("Error loading protected area:", error)
+      setHasCampfireBan(false)
+      setProtectedAreaLoadError(true)
+    } finally {
+      setIsLoadingProtectedArea(false)
+    }
+  }
+  
+  const loadSubAreasData = async () => {
+    setIsLoadingSubAreas(true)
+    try {
+      const response = await loadSubAreas(apiBaseUrl, park?.orcs)
+      if (response.status === 200) {
+        setSubAreas(response.data.data)
+        setSubAreasLoadError(false)
+      } else {
+        setSubAreas([])
+        setSubAreasLoadError(true)
+      }
+    } catch (error) {
+      console.error("Error loading sub-areas:", error)
+      setSubAreas([])
+      setSubAreasLoadError(true)
+    } finally {
+      setIsLoadingSubAreas(false)
+    }
+  }
+  
+  useEffect(() => {
+    loadAdvisoriesData()
+    loadProtectedAreaData()
+    loadSubAreasData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiBaseUrl, park?.orcs, site.orcsSiteNumber])
+  
+  const processedSubAreas = useMemo(() => {
+    if (!isLoadingSubAreas && !subAreasLoadError && subAreas.length) {
+      return preProcessSubAreas(subAreas)
+    }
+    return []
+  }, [isLoadingSubAreas, subAreasLoadError, subAreas])
+
+  const activeFacilities = combineFacilities(site.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas);
+  const activeCampings = combineCampingTypes(site.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas);
 
   const parkOverviewRef = useRef("")
   const knowBeforeRef = useRef("")
@@ -229,7 +275,9 @@ export default function SiteTemplate({ data }) {
             searchArea={searchArea}
             parkOperation={operations}
             operationDates={site?.parkOperationDates || park.parkOperationDates}
-            subAreas={parkOperationSubAreas}
+            subAreas={subAreas}
+            isLoadingSubAreas={isLoadingSubAreas}
+            subAreasLoadError={subAreasLoadError}
           />
         </div>
         <div className={`parks-container gallery-container has-photo--${photos.length > 0}`}>
@@ -328,11 +376,10 @@ export default function SiteTemplate({ data }) {
                 <CampingDetails
                   data={{
                     activeCampings: activeCampings,
-                    reservations: site.reservations,
-                    hasDayUsePass: hasDayUsePass,
-                    hasReservations: hasReservations,
                     parkOperation: operations,
-                    subAreas: parkOperationSubAreas
+                    subAreas: subAreas,
+                    isLoadingSubAreas: isLoadingSubAreas,
+                    subAreasLoadError: subAreasLoadError,
                   }}
                 />
               </div>
@@ -413,93 +460,6 @@ export const query = graphql`
         }
       }
       isUnofficialSite
-      parkOperationSubAreas {
-        parkSubArea
-        orcsSiteNumber
-        isActive
-        isOpen
-        hasReservations
-        hasBackcountryReservations
-        hasBackcountryPermits
-        hasFirstComeFirstServed
-        parkAccessUnitId
-        isCleanAirSite
-        totalCapacity
-        frontcountrySites
-        reservableSites
-        nonReservableSites
-        vehicleSites
-        vehicleSitesReservable
-        doubleSites
-        pullThroughSites
-        rvSites
-        rvSitesReservable
-        electrifiedSites
-        longStaySites
-        walkInSites
-        walkInSitesReservable
-        groupSites
-        groupSitesReservable
-        backcountrySites
-        wildernessSites
-        boatAccessSites
-        horseSites
-        cabins
-        huts
-        yurts
-        shelters
-        boatLaunches
-        hasGate
-        gateOpenTime
-        gateCloseTime
-        gateOpensAtDawn
-        gateClosesAtDusk
-        gateOpen24Hours
-        gateNote {
-          data {
-            gateNote
-          }
-        }
-        serviceNote {
-          data {
-            serviceNote
-          }
-        }
-        reservationNote {
-          data {
-            reservationNote
-          }
-        }
-        offSeasonNote {
-          data {
-            offSeasonNote
-          }
-        }
-        closureAffectsAccessStatus
-        parkOperationSubAreaDates {
-          isActive
-          operatingYear
-          openDate
-          closeDate
-          serviceStartDate
-          serviceEndDate
-          reservationStartDate
-          reservationEndDate
-          offSeasonStartDate
-          offSeasonEndDate
-        }
-        parkSubAreaType {
-          subAreaType
-          subAreaTypeCode
-          closureAffectsAccessStatus
-          facilityType {
-            facilityCode
-          }
-          campingType {
-            campingTypeCode
-          }
-        }
-      }
       protectedArea {
         orcs
         slug

--- a/src/gatsby/src/utils/parkDatesHelper.js
+++ b/src/gatsby/src/utils/parkDatesHelper.js
@@ -84,11 +84,13 @@ const processDateRanges = (arr, fmt, yr, delimiter, yearPrefix) => {
 
 const groupSubAreaDates = (subArea) => {
   const saDates = subArea.parkOperationSubAreaDates
+  const featureDates = subArea.parkFeatureDates || []
   subArea.operationDates = []
   subArea.offSeasonDates = []
   subArea.resDates = []
   subArea.serviceDates = []
 
+  // change saDates to featureDates once data migration is complete
   for (let dIdx in saDates) {
     const dateRec = saDates[dIdx]
     if (dateRec.isActive) {
@@ -108,6 +110,31 @@ const groupSubAreaDates = (subArea) => {
         start: dateRec.offSeasonStartDate,
         end: dateRec.offSeasonEndDate
       })
+    }
+  }
+  // override dates from parkOperationSubAreaDates with dates from parkFeatureDates
+  if (featureDates.length) {
+    const operationDates = featureDates.find(date => date.dateType === "Operation")
+    const reservationDates = featureDates.find(date => date.dateType === "Reservation")
+    const winterFeeDates = featureDates.find(date => date.dateType === "Winter fee")
+
+    if (operationDates) {
+      subArea.serviceDates = [{
+        start: operationDates.startDate,
+        end: operationDates.endDate,
+      }]
+    }
+    if (reservationDates) {
+      subArea.resDates = [{
+        start: reservationDates.startDate,
+        end: reservationDates.endDate,
+      }]
+    }
+    if (winterFeeDates) {
+      subArea.offSeasonDates = [{
+        start: winterFeeDates.startDate,
+        end: winterFeeDates.endDate,
+      }]
     }
   }
   return subArea;

--- a/src/gatsby/src/utils/parkDatesHelper.js
+++ b/src/gatsby/src/utils/parkDatesHelper.js
@@ -105,8 +105,12 @@ const groupSubAreaDates = (subArea) => {
     "Winter fee": "offSeasonDates",
     // TODO: add more date types as needed
   }
-  _.forEach(dateTypes, (key, type) => {
-    const featureDate = featureDates.find((date) => date.dateType === type)
+  // create an object keyed by dateType
+  const featureDatesByType = _.keyBy(featureDates, "dateType")
+  // narrow down to the date types
+  const relevantFeatureDates = _.pick(featureDatesByType, Object.keys(dateTypes))
+  _.forEach(relevantFeatureDates, (featureDate, type) => {
+    const key = dateTypes[type]
     if (featureDate) {
       subArea[key] = [{ start: featureDate.startDate, end: featureDate.endDate }]
     }

--- a/src/gatsby/src/utils/subAreaHelper.js
+++ b/src/gatsby/src/utils/subAreaHelper.js
@@ -1,5 +1,4 @@
 import axios from "axios"
-import moment from "moment"
 import qs from "qs"
 import { processDateRanges, groupSubAreaDates } from "./parkDatesHelper"
 
@@ -213,36 +212,11 @@ const loadSubAreas = (apiBaseUrl, orcs) => {
   })
   return axios.get(`${apiBaseUrl}/park-operation-sub-areas?${params}`)
 }
-// load subarea dates by feature id
-const loadSubAreaDates = (apiBaseUrl, featureId) => {
-  const currentYear = moment().year()
-  const params = qs.stringify({
-    filters: {
-      $and: [
-        {operatingYear: {$gte: currentYear}},
-        {
-          parkOperationSubArea: {
-            featureId: {
-              $eq: featureId,
-            },
-          },
-        },
-      ],
-    },
-    pagination: {
-      limit: 10,
-    }
-  }, {
-    encodeValuesOnly: true,
-  })
-  return axios.get(`${apiBaseUrl}/park-operation-sub-area-dates?${params}`)
-}
 
 export {
   preProcessSubAreas,
   combineCampingTypes,
   combineFacilities,
   loadAllSubAreas,
-  loadSubAreas,
-  loadSubAreaDates
+  loadSubAreas
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-695

### Description:
- Get sub area dates from `parkFeatureDate` and `parkOperationSubAreaDate` collections through Strapi API, not GraphQL so that editors can update the dates without the Gatsby build
- Display sub area dates on the Park, Site, and Park operating dates page
- Prioritize dates from `parkFeatureDate` to display, if it doesn't exist display dates from `parkOperationSubAreaDate`
- TODO: Delete `parkOperationSubAreaDate` once we finish data migration from `parkOperationSubAreaDate` to `parkFeatureDate`
- TODO: Test it by publishing dates on DOOT ALPHA-DEV and check if the date is created/updated on Strapi/FE
