### PR TITLE
CMS-782: Remove empty p element from advisory description

### DIFF
--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -27,12 +27,12 @@ const populateStandardMessages = function (query) {
 const appendStandardMessages = function (entity) {
     if (entity) {
         const { description = "", standardMessages } = entity;
+        let content = description ? `<div>${description}</div>` : "";
         if (standardMessages && standardMessages.length > 0) {
-            entity.description = (
-                "<p>" + description + "</p>" +
-                standardMessages.map((m) => m.description).join(" ")
-            ).trim();
+          content +=
+            standardMessages.map((m) => `<div>${m.description}</div>`).join(" ")
         }
+        entity.description = content.trim()
     }
     return entity;
 }

--- a/src/gatsby/src/styles/advisories/advisoryCard.scss
+++ b/src/gatsby/src/styles/advisories/advisoryCard.scss
@@ -42,6 +42,12 @@
           display: flex;
         }
       }
+      
+      .raw-html-content {
+        & > div {
+          margin-bottom: 16px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-782

### Description:
- Remove empty p element from advisory description
- Fix that an empty `<p></p>` was added when the description data doesn't exist
