### PR TITLE
CMS-672: Fix display date sorting for advisories

### DIFF
--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -14,7 +14,7 @@ import AdvisoryDate from "../advisories/advisoryDate"
 import blueAlertIcon from "../../images/park/blue-alert.svg"
 import redAlertIcon from "../../images/park/red-alert.svg"
 import yellowAlertIcon from "../../images/park/yellow-alert.svg"
-import { compareAdvisories } from "../../utils/advisoryHelper"
+import { getAdvisoryDate } from "../../utils/advisoryHelper"
 import { trackSnowplowEvent } from "../../utils/snowplowHelper"
 import "../../styles/advisories/advisoryDetails.scss"
 
@@ -26,19 +26,13 @@ export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus
   const sortedAdvisories = orderBy(
     advisories,
     // advisory sort order
-    // 1 - listingRank:DESC
-    // 2 - urgency.sequence:DESC
-    // 3 - accessStatus.precedence:ASC
-    // 4 - eventType.precedence:ASC
-    // 5 - display date:DESC
-    // DESC - check a value is null or undefined with value - Infinity
-    // ASC - check a value is null or undefined with value ?? Infinity
     [
-      (advisory) => advisory.listingRank ?? - Infinity,
-      (advisory) => advisory.urgency.sequence ?? - Infinity,
-      (advisory) => advisory.accessStatus?.precedence ?? Infinity,
-      (advisory) => advisory.eventType?.precedence ?? Infinity,
-      (advisory) => compareAdvisories(advisory, advisory)
+      'listingRank',
+      'urgency.sequence',
+      'accessStatus.precedence',
+      'eventType.precedence',
+      // display date
+      getAdvisoryDate
     ],
     ['desc', 'desc', 'asc', 'asc', 'desc']
   )
@@ -191,7 +185,7 @@ export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus
                         advisoryDate={advisory.formattedAdvisoryDate}
                         hasUpdatedDateDisplay={advisory.isUpdatedDateDisplayed && advisory.formattedUpdatedDate}
                         updatedDate={advisory.formattedUpdatedDate}
-                        hasDisplayedDate={advisory.isAdvisoryDateDisplayed || advisory.isUpdatedDateDisplayed || 
+                        hasDisplayedDate={advisory.isAdvisoryDateDisplayed || advisory.isUpdatedDateDisplayed ||
                           advisory.isEffectiveDateDisplayed || advisory.isEndDateDisplayed}
                       />
                     </div>


### PR DESCRIPTION
### Jira Ticket:
CMS-672

### Description:
A small fix for the advisories sort order: We're using lodash `orderBy` here so we don't need to pass in a sort function, just an identity function to return the values to compare. I changed `compareAdvisories` to `getAdvisoryDate` to get the display date value, and `orderBy` does the comparison automatically.

Additionally, if the identity function just returns a property and doesn't do anything special, we can just supply the name as a string instead of having to write the function ourselves. I was able to simplify the other 4 sort parameters, so we've got 4 strings and just one function.
