### PR TITLE
CMS-747: Fix build error

### DIFF
--- a/src/cms/package-lock.json
+++ b/src/cms/package-lock.json
@@ -28,7 +28,7 @@
         "styled-components": "^5.3.11"
       },
       "devDependencies": {
-        "better-sqlite3": "^11.8.1",
+        "better-sqlite3": "^11.0.0",
         "jest": "^29.7.0",
         "koa": ">=2.15.4"
       },

--- a/src/cms/package.json
+++ b/src/cms/package.json
@@ -37,7 +37,7 @@
     "npm": ">=6.0.0"
   },
   "devDependencies": {
-    "better-sqlite3": "^11.8.1",
+    "better-sqlite3": "^11.0.0",
     "jest": "^29.7.0",
     "koa": ">=2.15.4"
   },


### PR DESCRIPTION
### Jira Ticket:
CMS-747

### Description:
- Revert `better-sqlite3` update: https://github.com/bcgov/bcparks.ca/pull/1588
- Fix CMS build error: https://github.com/bcgov/bcparks.ca/actions/runs/14460053601/job/40551037699
```
npm ERR! code 1
npm ERR! path /opt/app-root/src/node_modules/better-sqlite3
npm ERR! command failed
npm ERR! command sh -c -- prebuild-install || node-gyp rebuild --release
npm ERR! make: Entering directory '/opt/app-root/src/node_modules/better-sqlite3/build'
npm ERR!   TOUCH ba23eeee118cd63e16015df367567cb043fed872.intermediate
npm ERR!   ACTION deps_sqlite3_gyp_locate_sqlite3_target_copy_builtin_sqlite3 ba23eeee118cd63e16015df367567cb043fed872.intermediate
npm ERR!   TOUCH Release/obj.target/deps/locate_sqlite3.stamp
npm ERR!   CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
npm ERR!   AR(target) Release/obj.target/deps/sqlite3.a
npm ERR!   COPY Release/sqlite3.a
npm ERR!   CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
npm ERR! rm ba23eeee118cd63e16015df367567cb043fed872.intermediate
npm ERR! make: Leaving directory '/opt/app-root/src/node_modules/better-sqlite3/build'
npm ERR! prebuild-install warn install /lib[64](https://github.com/bcgov/bcparks.ca/actions/runs/14460053601/job/40551037699#step:5:65)/libm.so.6: version `GLIBC_2.29' not found (required by /opt/app-root/src/node_modules/better-sqlite3/build/Release/better_sqlite3.node)
```
