### PR TITLE
CMS-747: Update ubi 8 to 9 in build-dev

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: strapi-${{ github.ref_name }}
-      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:1-32
+      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:9.5
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: etl-${{ github.ref_name }}
-      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:1-32
+      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:9.5
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: scheduler-${{ github.ref_name }}
-      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:1-32
+      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:9.5
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: strapi-${{ github.ref_name }}
-      BUILDER_IMAGE: registry.access.redhat.com/ubi8/nodejs-18:1-32
+      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:1-32
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: etl-${{ github.ref_name }}
-      BUILDER_IMAGE: registry.access.redhat.com/ubi8/nodejs-18:1-32
+      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:1-32
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: scheduler-${{ github.ref_name }}
-      BUILDER_IMAGE: registry.access.redhat.com/ubi8/nodejs-18:1-32
+      BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-18:1-32
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Jira Ticket:
CMS-747

### Description:
- Update ubi 8 to 9 in build-dev based on our comments here: https://github.com/bcgov/bcparks.ca/pull/1606
