### PR TITLE
CMS-833: Add more specificity to filter chip class

### DIFF
--- a/src/gatsby/src/styles/search.scss
+++ b/src/gatsby/src/styles/search.scss
@@ -142,7 +142,7 @@ p.subtitle {
 
 .search-results-main {
   // filter chip
-  .btn.park-filter-chip {
+  button.btn.park-filter-chip {
     height: auto;
     border-radius: 32px;
     font-size: 0.875rem;


### PR DESCRIPTION
### Jira Ticket:
CMS-833

### Description:
- Global styling was applied over the filter chip class, so added more specificity to the class
- In the `global.scss`
```
button.btn:not(.btn-link):not(.btn-tooltip) { ... }
```
