### PR TITLE
CMS-807: Update useEffect to only close menu on width change

### DIFF
--- a/src/gatsby/src/components/megaMenu.js
+++ b/src/gatsby/src/components/megaMenu.js
@@ -244,7 +244,7 @@ const MegaMenu = ({ content, menuMode }) => {
 
   useEffect(() => {
       setIsMenuOpen(screenSize.width > 992)
-  }, [screenSize])
+  }, [screenSize.width])
 
   // recursive menu generator which makes single version of DOM
   // that can be used for desktop, mobile and sitemap views of megamenu


### PR DESCRIPTION
### Jira Ticket:
CMS-807

### Description:
The mobile menu was closing on touch devices when you did a vertical drag motion to scroll the menu. I don't have my phone set up to work with the debug console, so I might have to rely on Manuji to test this one in depth, but it looks like the cause of this bug was actually the `useEffect` that watches the screen size changing. When you scroll on a mobile browser, the URL bar pops up or disappears and that changes the _vertical_ viewport size, even if the "screen size" isn't really changing. To fix this, I updated the useEffect to only watch the `width` part of the screen size, so it won't close the menu when the address bar changes the effective viewport height.