### PR TITLE
CMS-823: Fix facilities display issue

### DIFF
--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -87,6 +87,8 @@ export default function ParkTemplate({ data }) {
   const [subAreas, setSubAreas] = useState([])
   const [subAreasLoadError, setSubAreasLoadError] = useState(false)
   const [isLoadingSubAreas, setIsLoadingSubAreas] = useState(true)
+  const [activeFacilities, setActiveFacilities] = useState([])
+  const [activeCampings, setActiveCampings] = useState([])
 
   const loadAdvisoriesData = async () => {
     setIsLoadingAdvisories(true)
@@ -149,8 +151,51 @@ export default function ParkTemplate({ data }) {
     return []
   }, [isLoadingSubAreas, subAreasLoadError, subAreas])
 
-  const activeFacilities = combineFacilities(park.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas)
-  const activeCampings = combineCampingTypes(park.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas)
+  // set active facilities
+  useEffect(() => {
+    const fetchActiveFacilities = async () => {
+      if (park.parkFacilities.length > 0 &&
+        data.allStrapiFacilityType.nodes.length > 0 && 
+        Object.keys(processedSubAreas).length > 0
+      ) {
+        try {
+          const facilities = await combineFacilities(
+            park.parkFacilities,
+            data.allStrapiFacilityType.nodes,
+            processedSubAreas
+          )
+          setActiveFacilities(facilities)
+        } catch (error) {
+          console.error("Error fetching facilities:", error)
+          setActiveFacilities([])
+        }
+      }
+    }
+    fetchActiveFacilities()
+  }, [park.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas])
+
+  // set active campings
+  useEffect(() => {
+    const fetchActiveCampings = async () => {
+      if (park.parkCampingTypes.length > 0 &&
+        data.allStrapiCampingType.nodes.length > 0 &&
+        Object.keys(processedSubAreas).length > 0
+      ) {
+        try {
+          const campings = await combineCampingTypes(
+            park.parkCampingTypes,
+            data.allStrapiCampingType.nodes,
+            processedSubAreas
+          )
+          setActiveCampings(campings)
+        } catch (error) {
+          console.error("Error fetching campings:", error)
+          setActiveCampings([])
+        }
+      }
+    }
+    fetchActiveCampings()
+  }, [park.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas])
 
   useEffect(() => {
     if (window.location.hash && !isLoadingProtectedArea && !isLoadingAdvisories && !isLoadingSubAreas) {

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -153,22 +153,17 @@ export default function ParkTemplate({ data }) {
 
   // set active facilities
   useEffect(() => {
-    const fetchActiveFacilities = async () => {
+    const fetchActiveFacilities = () => {
       if (park.parkFacilities.length > 0 &&
         data.allStrapiFacilityType.nodes.length > 0 && 
         Object.keys(processedSubAreas).length > 0
       ) {
-        try {
-          const facilities = await combineFacilities(
+          const facilities = combineFacilities(
             park.parkFacilities,
             data.allStrapiFacilityType.nodes,
             processedSubAreas
           )
           setActiveFacilities(facilities)
-        } catch (error) {
-          console.error("Error fetching facilities:", error)
-          setActiveFacilities([])
-        }
       }
     }
     fetchActiveFacilities()
@@ -176,22 +171,17 @@ export default function ParkTemplate({ data }) {
 
   // set active campings
   useEffect(() => {
-    const fetchActiveCampings = async () => {
+    const fetchActiveCampings = () => {
       if (park.parkCampingTypes.length > 0 &&
         data.allStrapiCampingType.nodes.length > 0 &&
         Object.keys(processedSubAreas).length > 0
       ) {
-        try {
-          const campings = await combineCampingTypes(
+          const campings = combineCampingTypes(
             park.parkCampingTypes,
             data.allStrapiCampingType.nodes,
             processedSubAreas
           )
           setActiveCampings(campings)
-        } catch (error) {
-          console.error("Error fetching campings:", error)
-          setActiveCampings([])
-        }
       }
     }
     fetchActiveCampings()

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -153,38 +153,32 @@ export default function ParkTemplate({ data }) {
 
   // set active facilities
   useEffect(() => {
-    const fetchActiveFacilities = () => {
-      if (park.parkFacilities.length > 0 &&
-        data.allStrapiFacilityType.nodes.length > 0 && 
-        Object.keys(processedSubAreas).length > 0
-      ) {
-          const facilities = combineFacilities(
-            park.parkFacilities,
-            data.allStrapiFacilityType.nodes,
-            processedSubAreas
-          )
-          setActiveFacilities(facilities)
-      }
+    if (park.parkFacilities.length > 0 &&
+      data.allStrapiFacilityType.nodes.length > 0 && 
+      Object.keys(processedSubAreas).length > 0
+    ) {
+      const facilities = combineFacilities(
+        park.parkFacilities,
+        data.allStrapiFacilityType.nodes,
+        processedSubAreas
+      )
+      setActiveFacilities(facilities)
     }
-    fetchActiveFacilities()
   }, [park.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas])
 
   // set active campings
   useEffect(() => {
-    const fetchActiveCampings = () => {
-      if (park.parkCampingTypes.length > 0 &&
-        data.allStrapiCampingType.nodes.length > 0 &&
-        Object.keys(processedSubAreas).length > 0
-      ) {
-          const campings = combineCampingTypes(
-            park.parkCampingTypes,
-            data.allStrapiCampingType.nodes,
-            processedSubAreas
-          )
-          setActiveCampings(campings)
-      }
+    if (park.parkCampingTypes.length > 0 &&
+      data.allStrapiCampingType.nodes.length > 0 &&
+      Object.keys(processedSubAreas).length > 0
+    ) {
+      const campings = combineCampingTypes(
+        park.parkCampingTypes,
+        data.allStrapiCampingType.nodes,
+        processedSubAreas
+      )
+      setActiveCampings(campings)
     }
-    fetchActiveCampings()
   }, [park.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas])
 
   useEffect(() => {

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -144,38 +144,32 @@ export default function SiteTemplate({ data }) {
 
   // set active facilities
   useEffect(() => {
-    const fetchActiveFacilities = () => {
-      if (site.parkFacilities.length > 0 &&
-        data.allStrapiFacilityType.nodes.length > 0 && 
-        Object.keys(processedSubAreas).length > 0
-      ) {
-          const facilities = combineFacilities(
-            site.parkFacilities,
-            data.allStrapiFacilityType.nodes,
-            processedSubAreas
-          )
-          setActiveFacilities(facilities)
-      }
+    if (site.parkFacilities.length > 0 &&
+      data.allStrapiFacilityType.nodes.length > 0 && 
+      Object.keys(processedSubAreas).length > 0
+    ) {
+      const facilities = combineFacilities(
+        site.parkFacilities,
+        data.allStrapiFacilityType.nodes,
+        processedSubAreas
+      )
+      setActiveFacilities(facilities)
     }
-    fetchActiveFacilities()
   }, [site.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas])
 
     // set active campings
     useEffect(() => {
-      const fetchActiveCampings = () => {
-        if (site.parkCampingTypes.length > 0 &&
-          data.allStrapiCampingType.nodes.length > 0 &&
-          Object.keys(processedSubAreas).length > 0
-        ) {
-            const campings = combineCampingTypes(
-              site.parkCampingTypes,
-              data.allStrapiCampingType.nodes,
-              processedSubAreas
-            )
-            setActiveCampings(campings)
-        }
+      if (site.parkCampingTypes.length > 0 &&
+        data.allStrapiCampingType.nodes.length > 0 &&
+        Object.keys(processedSubAreas).length > 0
+      ) {
+        const campings = combineCampingTypes(
+          site.parkCampingTypes,
+          data.allStrapiCampingType.nodes,
+          processedSubAreas
+        )
+        setActiveCampings(campings)
       }
-      fetchActiveCampings()
     }, [site.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas])
 
   const parkOverviewRef = useRef("")

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -69,6 +69,8 @@ export default function SiteTemplate({ data }) {
   const [subAreas, setSubAreas] = useState([])
   const [subAreasLoadError, setSubAreasLoadError] = useState(false)
   const [isLoadingSubAreas, setIsLoadingSubAreas] = useState(true)
+  const [activeFacilities, setActiveFacilities] = useState([])
+  const [activeCampings, setActiveCampings] = useState([])
 
   const loadAdvisoriesData = async () => {
     setIsLoadingAdvisories(true)
@@ -140,8 +142,51 @@ export default function SiteTemplate({ data }) {
     return []
   }, [isLoadingSubAreas, subAreasLoadError, subAreas])
 
-  const activeFacilities = combineFacilities(site.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas);
-  const activeCampings = combineCampingTypes(site.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas);
+  // set active facilities
+  useEffect(() => {
+    const fetchActiveFacilities = async () => {
+      if (site.parkFacilities.length > 0 &&
+        data.allStrapiFacilityType.nodes.length > 0 && 
+        Object.keys(processedSubAreas).length > 0
+      ) {
+        try {
+          const facilities = await combineFacilities(
+            site.parkFacilities,
+            data.allStrapiFacilityType.nodes,
+            processedSubAreas
+          )
+          setActiveFacilities(facilities)
+        } catch (error) {
+          console.error("Error fetching facilities:", error)
+          setActiveFacilities([])
+        }
+      }
+    }
+    fetchActiveFacilities()
+  }, [site.parkFacilities, data.allStrapiFacilityType.nodes, processedSubAreas])
+
+    // set active campings
+    useEffect(() => {
+      const fetchActiveCampings = async () => {
+        if (site.parkCampingTypes.length > 0 &&
+          data.allStrapiCampingType.nodes.length > 0 &&
+          Object.keys(processedSubAreas).length > 0
+        ) {
+          try {
+            const campings = await combineCampingTypes(
+              site.parkCampingTypes,
+              data.allStrapiCampingType.nodes,
+              processedSubAreas
+            )
+            setActiveCampings(campings)
+          } catch (error) {
+            console.error("Error fetching campings:", error)
+            setActiveCampings([])
+          }
+        }
+      }
+      fetchActiveCampings()
+    }, [site.parkCampingTypes, data.allStrapiCampingType.nodes, processedSubAreas])
 
   const parkOverviewRef = useRef("")
   const knowBeforeRef = useRef("")

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -144,22 +144,17 @@ export default function SiteTemplate({ data }) {
 
   // set active facilities
   useEffect(() => {
-    const fetchActiveFacilities = async () => {
+    const fetchActiveFacilities = () => {
       if (site.parkFacilities.length > 0 &&
         data.allStrapiFacilityType.nodes.length > 0 && 
         Object.keys(processedSubAreas).length > 0
       ) {
-        try {
-          const facilities = await combineFacilities(
+          const facilities = combineFacilities(
             site.parkFacilities,
             data.allStrapiFacilityType.nodes,
             processedSubAreas
           )
           setActiveFacilities(facilities)
-        } catch (error) {
-          console.error("Error fetching facilities:", error)
-          setActiveFacilities([])
-        }
       }
     }
     fetchActiveFacilities()
@@ -167,22 +162,17 @@ export default function SiteTemplate({ data }) {
 
     // set active campings
     useEffect(() => {
-      const fetchActiveCampings = async () => {
+      const fetchActiveCampings = () => {
         if (site.parkCampingTypes.length > 0 &&
           data.allStrapiCampingType.nodes.length > 0 &&
           Object.keys(processedSubAreas).length > 0
         ) {
-          try {
-            const campings = await combineCampingTypes(
+            const campings = combineCampingTypes(
               site.parkCampingTypes,
               data.allStrapiCampingType.nodes,
               processedSubAreas
             )
             setActiveCampings(campings)
-          } catch (error) {
-            console.error("Error fetching campings:", error)
-            setActiveCampings([])
-          }
         }
       }
       fetchActiveCampings()

--- a/src/gatsby/src/utils/subAreaHelper.js
+++ b/src/gatsby/src/utils/subAreaHelper.js
@@ -43,7 +43,7 @@ const preProcessSubAreas = (subAreas) => {
   return result;
 }
 
-const combineCampingTypes = async (campings, campingTypes, subAreas) => {
+const combineCampingTypes = (campings, campingTypes, subAreas) => {
   let arr = [];
   let obj = subAreas;
 
@@ -63,7 +63,7 @@ const combineCampingTypes = async (campings, campingTypes, subAreas) => {
   // add the campingTypes to the common object and convert it to an array
   for (const campingTypeCode in obj) {
     const parkCampingType = obj[campingTypeCode];
-    parkCampingType.campingType = await campingTypes.find(ct => ct.campingTypeCode === campingTypeCode);
+    parkCampingType.campingType = campingTypes.find(ct => ct.campingTypeCode === campingTypeCode);
     // only include camping, not facilities
     if (parkCampingType.campingType) {
       // the camping type should be active, but we will include it anyway if it has subareas
@@ -76,7 +76,7 @@ const combineCampingTypes = async (campings, campingTypes, subAreas) => {
   return arr.sort((a, b) => a.campingType.campingTypeName.localeCompare(b.campingType.campingTypeName))
 }
 
-const combineFacilities = async (facilities, facilityTypes, subAreas) => {
+const combineFacilities = (facilities, facilityTypes, subAreas) => {
   let arr = [];
   let obj = subAreas;
 
@@ -96,7 +96,7 @@ const combineFacilities = async (facilities, facilityTypes, subAreas) => {
   // add the facilityTypes to the common object and convert it to an array
   for (const facilityCode in obj) {
     const parkFacility = obj[facilityCode];
-    parkFacility.facilityType = await facilityTypes.find(f => f.facilityCode === facilityCode);
+    parkFacility.facilityType = facilityTypes.find(f => f.facilityCode === facilityCode);
     // only include facilities, not camping
     if (parkFacility.facilityType) {
       // the facility type should be active, but we will include it anyway if it has subareas

--- a/src/gatsby/src/utils/subAreaHelper.js
+++ b/src/gatsby/src/utils/subAreaHelper.js
@@ -53,13 +53,11 @@ const combineCampingTypes = (campings, campingTypes, subAreas) => {
   )
   // add the parkCampingTypes to the common object
   for (const parkCampingType of parkCampingTypes) {
-    if (parkCampingType.isActive && parkCampingType.isCampingOpen) {
-      const campingTypeCode = parkCampingType.campingType?.campingTypeCode;
-      if (!obj[campingTypeCode]) {
-        obj[campingTypeCode] = { subAreas: [] };
-      }
-      obj[campingTypeCode] = { ...parkCampingType, ...obj[campingTypeCode] };
+    const campingTypeCode = parkCampingType.campingType?.campingTypeCode;
+    if (!obj[campingTypeCode]) {
+      obj[campingTypeCode] = { subAreas: [] };
     }
+    obj[campingTypeCode] = { ...parkCampingType, ...obj[campingTypeCode] };
   }
 
   // add the campingTypes to the common object and convert it to an array
@@ -88,13 +86,11 @@ const combineFacilities = (facilities, facilityTypes, subAreas) => {
   )
   // add the parkFacilities to the common object
   for (const parkFacility of parkFacilities) {
-    if (parkFacility.isActive && parkFacility.isFacilityOpen) { 
-      const facilityCode = parkFacility.facilityType?.facilityCode;
-      if (!obj[facilityCode]) {
-        obj[facilityCode] = { subAreas: [] };
-      }
-      obj[facilityCode] = { ...parkFacility, ...obj[facilityCode] };
+    const facilityCode = parkFacility.facilityType?.facilityCode;
+    if (!obj[facilityCode]) {
+      obj[facilityCode] = { subAreas: [] };
     }
+    obj[facilityCode] = { ...parkFacility, ...obj[facilityCode] };
   }
 
   // add the facilityTypes to the common object and convert it to an array

--- a/src/gatsby/src/utils/subAreaHelper.js
+++ b/src/gatsby/src/utils/subAreaHelper.js
@@ -53,11 +53,13 @@ const combineCampingTypes = (campings, campingTypes, subAreas) => {
   )
   // add the parkCampingTypes to the common object
   for (const parkCampingType of parkCampingTypes) {
-    const campingTypeCode = parkCampingType.campingType?.campingTypeCode;
-    if (!obj[campingTypeCode]) {
-      obj[campingTypeCode] = { subAreas: [] };
+    if (parkCampingType.isActive && parkCampingType.isCampingOpen) {
+      const campingTypeCode = parkCampingType.campingType?.campingTypeCode;
+      if (!obj[campingTypeCode]) {
+        obj[campingTypeCode] = { subAreas: [] };
+      }
+      obj[campingTypeCode] = { ...parkCampingType, ...obj[campingTypeCode] };
     }
-    obj[campingTypeCode] = { ...parkCampingType, ...obj[campingTypeCode] };
   }
 
   // add the campingTypes to the common object and convert it to an array
@@ -86,11 +88,13 @@ const combineFacilities = (facilities, facilityTypes, subAreas) => {
   )
   // add the parkFacilities to the common object
   for (const parkFacility of parkFacilities) {
-    const facilityCode = parkFacility.facilityType?.facilityCode;
-    if (!obj[facilityCode]) {
-      obj[facilityCode] = { subAreas: [] };
+    if (parkFacility.isActive && parkFacility.isFacilityOpen) { 
+      const facilityCode = parkFacility.facilityType?.facilityCode;
+      if (!obj[facilityCode]) {
+        obj[facilityCode] = { subAreas: [] };
+      }
+      obj[facilityCode] = { ...parkFacility, ...obj[facilityCode] };
     }
-    obj[facilityCode] = { ...parkFacility, ...obj[facilityCode] };
   }
 
   // add the facilityTypes to the common object and convert it to an array

--- a/src/gatsby/src/utils/subAreaHelper.js
+++ b/src/gatsby/src/utils/subAreaHelper.js
@@ -43,7 +43,7 @@ const preProcessSubAreas = (subAreas) => {
   return result;
 }
 
-const combineCampingTypes = (campings, campingTypes, subAreas) => {
+const combineCampingTypes = async (campings, campingTypes, subAreas) => {
   let arr = [];
   let obj = subAreas;
 
@@ -63,7 +63,7 @@ const combineCampingTypes = (campings, campingTypes, subAreas) => {
   // add the campingTypes to the common object and convert it to an array
   for (const campingTypeCode in obj) {
     const parkCampingType = obj[campingTypeCode];
-    parkCampingType.campingType = campingTypes.find(ct => ct.campingTypeCode === campingTypeCode);
+    parkCampingType.campingType = await campingTypes.find(ct => ct.campingTypeCode === campingTypeCode);
     // only include camping, not facilities
     if (parkCampingType.campingType) {
       // the camping type should be active, but we will include it anyway if it has subareas
@@ -76,7 +76,7 @@ const combineCampingTypes = (campings, campingTypes, subAreas) => {
   return arr.sort((a, b) => a.campingType.campingTypeName.localeCompare(b.campingType.campingTypeName))
 }
 
-const combineFacilities = (facilities, facilityTypes, subAreas) => {
+const combineFacilities = async (facilities, facilityTypes, subAreas) => {
   let arr = [];
   let obj = subAreas;
 
@@ -96,7 +96,7 @@ const combineFacilities = (facilities, facilityTypes, subAreas) => {
   // add the facilityTypes to the common object and convert it to an array
   for (const facilityCode in obj) {
     const parkFacility = obj[facilityCode];
-    parkFacility.facilityType = facilityTypes.find(f => f.facilityCode === facilityCode);
+    parkFacility.facilityType = await facilityTypes.find(f => f.facilityCode === facilityCode);
     // only include facilities, not camping
     if (parkFacility.facilityType) {
       // the facility type should be active, but we will include it anyway if it has subareas


### PR DESCRIPTION
### Jira Ticket:
CMS-823

### Description:
- Fix an issue where not all facilities are displayed on the park page
  - If there was one facility, it was displayed, but if there were more than two facilities, some of them were not displayed
- It was because the function `combineFacilities` returned a result before the for loop finished, because one of the props was passed as an empty array first
- Update the facilities/camping data with `useState` and `useEffect` on the park/site page 