### PR TITLE
CMS-845: Get a proper access status data on park operating dates page

### DIFF
--- a/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
+++ b/src/gatsby/src/pages/plan-your-trip/park-operating-dates.js
@@ -24,6 +24,8 @@ const ParkLink = ({ park, advisories, subAreas, advisoryLoadError, isLoadingAdvi
   const parkOperationDates = park.parkOperationDates.find(d => d.operatingYear === +thisYear) || {}
   const [parkAccessStatus, setParkAccessStatus] = useState({})
   const [addedSeasonalAdvisory, setAddedSeasonalAdvisory] = useState(false)
+  // Check if park access status is "Closed"
+  const [isParkOpen, setIsParkOpen] = useState(null)
 
   // Overall operating dates for parks, to display above subareas
   let fmt = "MMM D, yyyy"
@@ -94,10 +96,11 @@ const ParkLink = ({ park, advisories, subAreas, advisoryLoadError, isLoadingAdvi
                 operationDates={park.parkOperationDates}
                 onStatusCalculated={setParkAccessStatus}
                 punctuation="."
+                setIsParkOpen={setIsParkOpen}
               />
             }
           </span>
-          {parkDates && (
+          {(parkDates && isParkOpen !== false) && (
             <span className="gate-text">The {park.type.toLowerCase()} {parkOperation.hasParkGate !== false && "gate"} is open {parkDates}.</span>
           )}
         </>


### PR DESCRIPTION
### Jira Ticket:
CMS-845

### Description:
- Same implementation as the `parkHeader.js`
- If the park access status text is "Closed", the operating date text shouldn't be displayed
- Get the `isParkOpen` state from `parkAccessStatus.js`
- Change the `isParkOpen` state based on the status text and use it as a boolean to display/hide the date text
- TODO: Cherry-pick this commit and the land acknowledgment commit for the hot fix release