### PR TITLE
CMS-850: Add 'First come, first served' as feature date type

### DIFF
--- a/src/cms/src/api/park-feature-date/content-types/park-feature-date/schema.json
+++ b/src/cms/src/api/park-feature-date/content-types/park-feature-date/schema.json
@@ -31,6 +31,8 @@
         "Operation",
         "Reservation",
         "Winter fee",
+        "Full service and fees",
+        "Backcountry registration",
         "First come, first served"
       ],
       "required": true

--- a/src/cms/src/api/park-feature-date/content-types/park-feature-date/schema.json
+++ b/src/cms/src/api/park-feature-date/content-types/park-feature-date/schema.json
@@ -30,7 +30,8 @@
       "enum": [
         "Operation",
         "Reservation",
-        "Winter fee"
+        "Winter fee",
+        "First come, first served"
       ],
       "required": true
     },


### PR DESCRIPTION
### Jira Ticket:
CMS-793
CMS-850

### Description:
- Add "Full service and fees", "Backcountry registration", and  "First come, first served" as a feature date type so that DOOT can send dates with a specific date type
- No FE change at this moment, but these dates will be used on the Park page in the future
