### PR TITLE
CMS-920: Update links on active advisories page

### DIFF
--- a/src/gatsby/src/components/advisories/advisoryLegend.js
+++ b/src/gatsby/src/components/advisories/advisoryLegend.js
@@ -59,7 +59,10 @@ const AdvisoryLegend = () => {
         <a href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/water/drought-flooding-dikes-dams/river-forecast-centre">
           BC River Forecast Centre
         </a>{", "}
-        <a href="https://drivebc.ca">Drive BC</a>
+        <a href="https://drivebc.ca">DriveBC</a>{", "}
+        <a href="https://www.emergencyinfobc.gov.bc.ca">
+          EmergencyInfoBC
+        </a>
       </div>
     </div>
   )


### PR DESCRIPTION
### Jira Ticket:
CMS-920

### Description:
- Update links on the active advisories page
  - Update the existing Drive BC link title to DriveBC (no spaces)
  - Add additional link next to the BCWS/River Forecast/DriveBC links, it’s for EmergencyInfoBC ([EmergencyInfoBC Home - EmergencyInfoBC](https://www.emergencyinfobc.gov.bc.ca/) )
