### PR TITLE
CMS-828: Use GITHUB_TOKEN for repo actions

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Trigger Gatsby static build workflow
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby
           client-payload: '{"env": "dev", "branch": "${{ github.ref_name }}" }'
 

--- a/.github/workflows/deploy-alpha-test.yaml
+++ b/.github/workflows/deploy-alpha-test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Trigger Gatsby static build workflow
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby
           client-payload: '{"env": "${{ env.ENVIRONMENT }}", "branch": "alpha"}'
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set env
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      
+
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
@@ -53,7 +53,7 @@ jobs:
       - name: Trigger Gatsby static build workflow
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby
           client-payload: '{"env": "${{ env.ENVIRONMENT }}", "branch": "main"}'
 

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Trigger Gatsby static build workflow
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby
           client-payload: '{"env": "${{ env.ENVIRONMENT }}", "branch": "main"}'
 


### PR DESCRIPTION
### Jira Ticket:
CMS-828

### Description:
This ticket updates the Github actions to use the built-in "GITHUB_TOKEN" instead of the personal access token we created.
Some details about GITHUB_TOKEN here: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

The personal access token we're using will be invalidated next month, and it's not viable to keep generating new tokens every 90 days when the new policy goes into effect. This GITHUB_TOKEN will hopefully work and never expire. It was recommended by folks in the Platform Services support chat.

(I haven't tested the actions yet, but maybe we can run actions on this branch before we merge?)
