### PR TITLE
CMS-1007: Fix facility and camping display issue

### DIFF
--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -156,8 +156,7 @@ export default function ParkTemplate({ data }) {
   // set active facilities
   useEffect(() => {
     if (park.parkFacilities.length > 0 &&
-      data.allStrapiFacilityType.nodes.length > 0 && 
-      Object.keys(processedSubAreas).length > 0
+      data.allStrapiFacilityType.nodes.length > 0
     ) {
       const facilities = combineFacilities(
         park.parkFacilities,
@@ -171,8 +170,7 @@ export default function ParkTemplate({ data }) {
   // set active campings
   useEffect(() => {
     if (park.parkCampingTypes.length > 0 &&
-      data.allStrapiCampingType.nodes.length > 0 &&
-      Object.keys(processedSubAreas).length > 0
+      data.allStrapiCampingType.nodes.length > 0
     ) {
       const campings = combineCampingTypes(
         park.parkCampingTypes,

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -147,8 +147,7 @@ export default function SiteTemplate({ data }) {
   // set active facilities
   useEffect(() => {
     if (site.parkFacilities.length > 0 &&
-      data.allStrapiFacilityType.nodes.length > 0 && 
-      Object.keys(processedSubAreas).length > 0
+      data.allStrapiFacilityType.nodes.length > 0
     ) {
       const facilities = combineFacilities(
         site.parkFacilities,
@@ -162,8 +161,7 @@ export default function SiteTemplate({ data }) {
     // set active campings
     useEffect(() => {
       if (site.parkCampingTypes.length > 0 &&
-        data.allStrapiCampingType.nodes.length > 0 &&
-        Object.keys(processedSubAreas).length > 0
+        data.allStrapiCampingType.nodes.length > 0
       ) {
         const campings = combineCampingTypes(
           site.parkCampingTypes,


### PR DESCRIPTION
### Jira Ticket:
CMS-1007

### Description:
- Fix an issue where facilities and camping didn't get displayed on the Park page
- This useEffect was implemented in https://github.com/bcgov/bcparks.ca/pull/1613, but the condition `Object.keys(processedSubAreas).length > 0` is not needed, given that not all parks have sub-areas but parks can have facilities and camping
