### PR TITLE
CMS-1009: Remove admin images from GitHub actions

### DIFF
--- a/.github/workflows/deploy-alpha-test.yaml
+++ b/.github/workflows/deploy-alpha-test.yaml
@@ -25,7 +25,6 @@ jobs:
 
       - name: Tag Test images
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin-alpha:latest admin-alpha:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder-alpha:latest public-builder-alpha:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi-alpha:latest strapi-alpha:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag maintenance-alpha:latest maintenance-alpha:${{ env.ENVIRONMENT }}
@@ -41,7 +40,6 @@ jobs:
 
       - name: Trigger new rollout
         run: |
-          oc -n ${{ env.NAMESPACE }} rollout restart deployment alpha-admin
           oc -n ${{ env.NAMESPACE }} rollout restart deployment alpha-cms
           oc -n ${{ env.NAMESPACE }} rollout restart deployment alpha-maintenance
           oc -n ${{ env.NAMESPACE }} rollout restart deployment alpha-scheduler

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -43,7 +43,6 @@ jobs:
 
       - name: Tag Prod images
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin-main:${{ github.event.inputs.releaseTag }} admin-main:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder-main:${{ github.event.inputs.releaseTag }} public-builder-main:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi-main:${{ github.event.inputs.releaseTag }} strapi-main:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag maintenance-main:${{ github.event.inputs.releaseTag }} maintenance-main:${{ env.ENVIRONMENT }}
@@ -59,7 +58,6 @@ jobs:
 
       - name: Trigger new rollout
         run: |
-          oc -n ${{ env.NAMESPACE }} rollout restart deployment main-admin
           oc -n ${{ env.NAMESPACE }} rollout restart deployment main-cms
           oc -n ${{ env.NAMESPACE }} rollout restart deployment main-maintenance
           oc -n ${{ env.NAMESPACE }} rollout restart deployment main-scheduler

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Tag Test images
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin-main:${{ github.event.inputs.releaseTag }} admin-main:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder-main:${{ github.event.inputs.releaseTag }} public-builder-main:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi-main:${{ github.event.inputs.releaseTag }} strapi-main:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag maintenance-main:${{ github.event.inputs.releaseTag }} maintenance-main:${{ env.ENVIRONMENT }}
@@ -56,7 +55,6 @@ jobs:
 
       - name: Trigger new rollout
         run: |
-          oc -n ${{ env.NAMESPACE }} rollout restart deployment main-admin
           oc -n ${{ env.NAMESPACE }} rollout restart deployment main-cms
           oc -n ${{ env.NAMESPACE }} rollout restart deployment main-maintenance
           oc -n ${{ env.NAMESPACE }} rollout restart deployment main-scheduler

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -31,7 +31,6 @@ jobs:
 
       - name: Tag images
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag admin-main:${{ env.SHORT_SHA }} admin-main:${{ env.RELEASE_VERSION }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag public-builder-main:${{ env.SHORT_SHA }} public-builder-main:${{ env.RELEASE_VERSION }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag strapi-main:${{ env.SHORT_SHA }} strapi-main:${{ env.RELEASE_VERSION }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag maintenance-main:${{ env.SHORT_SHA }} maintenance-main:${{ env.RELEASE_VERSION }}
@@ -40,7 +39,6 @@ jobs:
 
       - name: Delete images tags with commit hash
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag -d admin-main:${{ env.SHORT_SHA }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag -d public-builder-main:${{ env.SHORT_SHA }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag -d strapi-main:${{ env.SHORT_SHA }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag -d maintenance-main:${{ env.SHORT_SHA }}


### PR DESCRIPTION
### Jira Ticket:
CMS-1009 (Using the same ticket from #1636)

### Description:

I'm deploying the changes from CMS-933 and CMS-1009 to the test environment for UAT, but the GitHub action "on tag push" fails right now because it's trying to tag the admin section image, which no longer exists. This is a quick update to remove the `admin-*` lines from the GitHub actions.

After this is merged into alpha, I'll merge into main and move the `v2.13.0` tag to this commit and deploy to test 👍 
Let me know if you have any concerns!