### PR TITLE
CMS-1159: Fix api error with park access status

### DIFF
--- a/src/cms/src/api/protected-area/custom/protected-area-status.js
+++ b/src/cms/src/api/protected-area/custom/protected-area-status.js
@@ -58,7 +58,7 @@ const getPublishedPublicAdvisories = async () => {
       limit: -1,
       populate: {
         protectedAreas: { fields: ["orcs"] },
-        accessStatus: { fields: ["accessStatus"] },
+        accessStatus: { fields: ["accessStatus", "precedence"] },
         eventType: { fields: ["eventType"] },
         links: { populate: { type: { fields: ["type"] } } }
       },


### PR DESCRIPTION
### Jira Ticket:
CMS-1159

### Description:
This fixes an API error with /api/park-access-statuses

The code was trying to sort by precendence, but precedence wasn't included in the query.

It appears that this never worked properly on the API, although park-access-status was working on the website. 

In order to replicate the error you need to have a park with two advisories with access-status.precedence lower than 120, and the less important advisory needs to be older than the higher importance advisory.
