### PR TITLE
CMS-1205: Import data into park-date-type

### DIFF
--- a/src/cms/database/migrations/2025.09.12T00.00.25.park-date-type.js
+++ b/src/cms/database/migrations/2025.09.12T00.00.25.park-date-type.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const rows = [
+  { dateTypeId: 1, dateType: "Gate" },
+  { dateTypeId: 2, dateType: "Tier 1" },
+  { dateTypeId: 3, dateType: "Tier 2" },
+  { dateTypeId: 4, dateType: "Winter fee" },
+  { dateTypeId: 5, dateType: "Day-use pass" },
+  { dateTypeId: 6, dateType: "Operation" },
+  { dateTypeId: 7, dateType: "Reservation" },
+  { dateTypeId: 8, dateType: "Backcountry registration" },
+  { dateTypeId: 9, dateType: "First come, first served" },
+  { dateTypeId: 10, dateType: "Full services and fees" },
+];
+
+module.exports = {
+  async up(knex) {
+    if (await knex.schema.hasTable("park_date_types")) {
+      await strapi.db.transaction(async () => {
+        for (const row of rows) {
+          try {
+            await strapi.entityService.create(
+              "api::park-date-type.park-date-type",
+              {
+                data: {
+                  dateTypeId: row.dateTypeId,
+                  dateType: row.dateType,
+                  publishedAt: new Date().toISOString(),
+                },
+              }
+            );
+          } catch (error) {
+            console.error(`Failed to insert: ${row}`, error);
+          }
+        }
+      });
+    }
+  },
+};


### PR DESCRIPTION
### Jira Ticket:
CMS-1205

### Description:
- Partial implementation of CMS-1205
- Import data into park-date-type (`dateTypeId` and `dateType`) from the list in CMS-1038
- There is no `description` data now, but it can be added by the content team later