### PR TITLE
CMS-1154: Update park-feature fields

### DIFF
--- a/src/cms/database/migrations/2025.09.16T00.00.27.park-feature.js
+++ b/src/cms/database/migrations/2025.09.16T00.00.27.park-feature.js
@@ -4424,7 +4424,7 @@ module.exports = {
         // to create the final data for the new park-feature record
         const parkFeatureData = {
           ...sharedData,
-          parkFeature: featureName,
+          parkFeatureName: featureName,
           publishedAt: new Date().toISOString(),
           featureId:
             record.featureId ?? `${record.protectedArea.orcs}_${record.id}`,

--- a/src/cms/src/api/park-feature-type/content-types/park-feature-type/schema.json
+++ b/src/cms/src/api/park-feature-type/content-types/park-feature-type/schema.json
@@ -26,6 +26,12 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::facility-type.facility-type"
+    },
+    "parkFeatures": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::park-feature.park-feature",
+      "mappedBy": "parkFeatureType"
     }
   }
 }

--- a/src/cms/src/api/park-feature/content-types/park-feature/schema.json
+++ b/src/cms/src/api/park-feature/content-types/park-feature/schema.json
@@ -19,7 +19,7 @@
       "unique": true,
       "required": true
     },
-    "parkFeature": {
+    "parkFeatureName": {
       "type": "string",
       "required": true
     },
@@ -211,8 +211,9 @@
     },
     "parkFeatureType": {
       "type": "relation",
-      "relation": "oneToOne",
-      "target": "api::park-feature-type.park-feature-type"
+      "relation": "manyToOne",
+      "target": "api::park-feature-type.park-feature-type",
+      "inversedBy": "parkFeatures"
     },
     "parkDates": {
       "type": "relation",


### PR DESCRIPTION
### Jira Ticket:
CMS-1254

### Description:
- Update the park-feature fields
  - Change `parkFeature` to `parkFeatureName`
  - Add an inverse relation to `parkFeature` so that the editors can see them in the `parkFeatureType` collection 
 - Update the migration file - we'll need to do this task again since `parkFeatureName` won't retain the value in `parkFeature`
