### PR TITLE
NOBUG: Add well-known key columns to parkAreaTypes and parkFeatureTypes

### DIFF
--- a/src/cms/database/migrations/2025.09.05T00.00.23.park-area-type.js
+++ b/src/cms/database/migrations/2025.09.05T00.00.23.park-area-type.js
@@ -41,6 +41,7 @@ module.exports = {
               {
                 data: {
                   parkAreaType: name,
+                  areaTypeId: typeNames.indexOf(name) + 1,
                   publishedAt: new Date().toISOString(),
                 },
               }

--- a/src/cms/database/migrations/2025.09.16T00.00.26.park-feature-type.js
+++ b/src/cms/database/migrations/2025.09.16T00.00.26.park-feature-type.js
@@ -1,5 +1,27 @@
 "use strict";
 
+const parkFeatureTypeMap = {
+  Anchorage: 1,
+  Backcountry: 2,
+  "Boat launch": 3,
+  Cabin: 4,
+  Dock: 5,
+  "Frontcountry campground": 6,
+  "Group campground": 7,
+  "Hot spring": 8,
+  Hut: 9,
+  "Marine-accessible camping": 10,
+  "Mooring buoy": 11,
+  "Picnic area": 12,
+  "Picnic shelter": 13,
+  Resort: 14,
+  Shelter: 15,
+  Trail: 16,
+  "Walk-in camping": 17,
+  "Wilderness camping": 18,
+  "Winter camping": 19,
+};
+
 module.exports = {
   async up(knex) {
     if (await knex.schema.hasTable("park_feature_types")) {
@@ -22,6 +44,7 @@ module.exports = {
           facilityType: type.facilityType
             ? { connect: [{ id: type.facilityType.id }] }
             : undefined,
+          featureTypeId: parkFeatureTypeMap[type.subAreaType] || null,
           publishedAt: new Date().toISOString(),
         };
       });

--- a/src/cms/src/api/park-area-type/content-types/park-area-type/schema.json
+++ b/src/cms/src/api/park-area-type/content-types/park-area-type/schema.json
@@ -14,6 +14,11 @@
     "parkAreaType": {
       "type": "string"
     },
+    "areaTypeId": {
+      "type": "integer",
+      "required": true,
+      "unique": true
+    },
     "campingType": {
       "type": "relation",
       "relation": "oneToOne",

--- a/src/cms/src/api/park-feature-type/content-types/park-feature-type/schema.json
+++ b/src/cms/src/api/park-feature-type/content-types/park-feature-type/schema.json
@@ -14,6 +14,11 @@
       "type": "string",
       "required": true
     },
+    "featureTypeId": {
+      "type": "integer",
+      "required": true,
+      "unique": true
+    },
     "closureAffectsAccessStatus": {
       "type": "boolean"
     },


### PR DESCRIPTION
### Jira Ticket:
CMS-836 & CMS-1154

### Description:
Added new well-known key columns `areaTypeId` and `featureTypeId` to `parkAreaTypes` and `parkFeatureTypes` Strapi collections and adjusted migrations to seed these columns.  

NOTE: The exact process for re-running migrations will need to be documented when this is approved and deployed onto the alpha-dev environment. Only environments that have already had the changes deployed will be impacted. 
