### PR TITLE
CMS-1216: Migration park-operation-sub-areas to park-gates

### DIFF
--- a/src/cms/database/migrations/2025.10.02T00.00.31.park-operation-sub-areas-into-park-gates.js
+++ b/src/cms/database/migrations/2025.10.02T00.00.31.park-operation-sub-areas-into-park-gates.js
@@ -1,0 +1,93 @@
+"use strict";
+
+async function up(knex) {
+  // Check if both tables exist before proceeding
+  if (
+    !(await knex.schema.hasTable("park_operation_sub_areas")) ||
+    !(await knex.schema.hasTable("park_gates"))
+  ) {
+    return;
+  }
+
+  console.log(
+    "Migrating gate data from park-operation-sub-areas to park-gates..."
+  );
+
+  // Get all park operation sub areas with gate-related data
+  const parkOperationSubAreas = await strapi.db
+    .query("api::park-operation-sub-area.park-operation-sub-area")
+    .findMany({
+      select: [
+        "id",
+        "hasGate",
+        "gateOpenTime",
+        "gateCloseTime",
+        "gateOpensAtDawn",
+        "gateClosesAtDusk",
+        "gateOpen24Hours",
+        "gateNote",
+      ],
+      populate: {
+        protectedArea: {
+          select: ["id"],
+        },
+      },
+      limit: 10000,
+    });
+
+  console.log(
+    `Found ${parkOperationSubAreas.length} park operation sub areas to process`
+  );
+
+  let migratedCount = 0;
+
+  await strapi.db.transaction(async () => {
+    for (const subArea of parkOperationSubAreas) {
+      // Only migrate if there's gate-related data
+      const hasGateData =
+        subArea.hasGate ||
+        subArea.gateOpenTime ||
+        subArea.gateCloseTime ||
+        subArea.gateOpensAtDawn ||
+        subArea.gateClosesAtDusk ||
+        subArea.gateOpen24Hours ||
+        subArea.gateNote;
+
+      // Skip if no gate data or no protected area
+      if (!hasGateData || !subArea.protectedArea) {
+        continue;
+      }
+
+      try {
+        // Create new park-gate record for this park feature (sub-area)
+        await strapi.db.query("api::park-gate.park-gate").create({
+          data: {
+            hasGate: subArea.hasGate ?? null,
+            gateOpenTime: subArea.gateOpenTime ?? null,
+            gateCloseTime: subArea.gateCloseTime ?? null,
+            gateOpensAtDawn: subArea.gateOpensAtDawn ?? null,
+            gateClosesAtDusk: subArea.gateClosesAtDusk ?? null,
+            gateOpen24Hours: subArea.gateOpen24Hours ?? null,
+            gateNote: subArea.gateNote ?? null,
+            parkFeature: subArea.id,
+            protectedArea: subArea.protectedArea.id,
+            publishedAt: new Date().toISOString(),
+          },
+        });
+
+        migratedCount++;
+      } catch (error) {
+        console.error(
+          `Failed to migrate gate data for sub area ${subArea.id}:`,
+          error
+        );
+      }
+    }
+  });
+
+  console.log(
+    `Successfully migrated ${migratedCount} park gate records from sub areas`
+  );
+}
+
+module.exports = { up };


### PR DESCRIPTION
### Jira Ticket:
CMS-1216

Part 2 of 2 for the migration task, merging into #1655

### Description:

This adds a migration to copy data from the park-operation-sub-areas collection into the park-gates.

Note that the parkArea relation field will be empty for all of these because we're not migrating any applicable area/campground data yet.
On my local environment, there are **334** records to migrate but only **330** of them have hasGate = true. There are 4 records that have gate data, but hasGate = false and I wrote these two migrations to include those cases because it makes sense to me to preserve the data, and then we can change hasGate to true later on if we want.
