### PR TITLE
CMS-1696: Clear park-operation cache

### DIFF
--- a/src/cms/src/middlewares/rest-cache-invalidation.js
+++ b/src/cms/src/middlewares/rest-cache-invalidation.js
@@ -11,6 +11,11 @@ const cachedCollectionTypes = [
   "api::park-feature.park-feature",
 ];
 
+const watchedCollectionTypes = [
+  ...cachedCollectionTypes,
+  "api::park-operation.park-operation",
+];
+
 const pageActions = ["create", "update", "delete", "publish", "unpublish"];
 
 // MAIN MIDDLEWARE FUNCTION (scaffolding)
@@ -18,7 +23,7 @@ const pageActions = ["create", "update", "delete", "publish", "unpublish"];
 module.exports = () => {
   return async (context, next) => {
     if (
-      !cachedCollectionTypes.includes(context.uid) ||
+      !watchedCollectionTypes.includes(context.uid) ||
       !pageActions.includes(context.action)
     ) {
       return await next(); // Call the next middleware in the stack

--- a/src/cms/src/middlewares/rest-cache-invalidation.js
+++ b/src/cms/src/middlewares/rest-cache-invalidation.js
@@ -13,6 +13,12 @@ const cachedCollectionTypes = [
 
 const watchedCollectionTypes = [
   ...cachedCollectionTypes,
+  "api::park-area.park-area",
+  "api::park-gate.park-gate",
+  "api::park-date.park-date",
+  "api::park-facility.park-facility",
+  "api::park-activity.park-activity",
+  "api::park-camping-type.park-camping-type",
   "api::park-operation.park-operation",
 ];
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1696

### Description:
- I'm not entirely sure about this approach, so any feedback is welcome
- If any fields in `park-operation` are updated, the `protected-area` API should be able to return the latest `park-operation` data accordingly