### PR TITLE
NOBUG: Update Redis and PgBouncer docker images

### DIFF
--- a/infrastructure/helm/bcparks/values.yaml
+++ b/infrastructure/helm/bcparks/values.yaml
@@ -26,7 +26,7 @@ images:
     tag: latest
   redis:
     name: image-registry.openshift-image-registry.svc:5000/c1643c-tools/redis
-    tag: 6.2.14-alpine
+    tag: 6.2.20-alpine
   etl:
     name: image-registry.openshift-image-registry.svc:5000/c1643c-tools/etl-main
     tag: latest

--- a/infrastructure/imagestreams/docker commands.txt
+++ b/infrastructure/imagestreams/docker commands.txt
@@ -2,10 +2,10 @@
 
 oc tag -n c1643c-tools --source=docker node:22-slim node:22-slim
 
-oc tag -n c1643c-tools --source=docker redis:6.2.14-alpine redis:6.2.14-alpine
+oc tag -n c1643c-tools --source=docker redis:6.2.20-alpine redis:6.2.20-alpine
 
-oc tag -n c1643c-tools --source=docker bitnami/pgbouncer:1.22.1 pgbouncer:1.22.1
-oc tag -n c1643c-tools pgbouncer:1.22.1 pgbouncer:latest
+oc tag -n c1643c-tools --source=docker bitnamilegacy/pgbouncer:1.24.1-debian-12-r10 pgbouncer:1.24.1
+oc tag -n c1643c-tools pgbouncer:1.24.1 pgbouncer:latest
 
 oc tag -n c1643c-tools --source=docker caddy:2.6.2-alpine caddy:2.6.2-alpine
 oc tag -n c1643c-tools caddy:2.6.2-alpine caddy:latest


### PR DESCRIPTION
### Jira Ticket:
None

### Description:

This PR updates some stale docker images. We were getting alerts from the platform team that PgBouncer and Redis deployments hadn't been updated in over a year and our deployments were being scaled down.
