### PR TITLE
NOBUG: Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+# Dependabot configuration for npm dependencies in selected subprojects.
+# Regular dependency version updates are opened against the `alpha` branch,
+# which is the active development branch and typically ahead of `main`.
+# Security-related updates (triggered by CVEs/GitHub advisories) will always
+# target the default branch (`main`), as this behavior cannot be overridden.
+#
+# Only the primary npm projects under /src are managed here; other package.json
+# files are intentionally excluded. Semver-major updates are disabled to avoid
+# breaking changes and are handled manually. Security updates are not grouped so
+# that each vulnerability results in a clearly visible, dedicated PR.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/src/etl"
+    target-branch: "alpha"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "NOBUG"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/src/scheduler"
+    target-branch: "alpha"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "NOBUG"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/src/gatsby"
+    target-branch: "alpha"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "NOBUG"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/src/cms"
+    target-branch: "alpha"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "NOBUG"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
### Jira Ticket:
None

### Description:

This PR adds a `dependabot.yml` configuration, following conventions used by @dylanrogowsky-oxd in `bcgov/SCJ-Online-Booking`.

The primary goal is to have regular Dependabot version update PRs target our `alpha` branch, which is the active development branch and is typically ahead of `main`.

Minor and patch version updates are grouped to reduce PR noise, while security updates are intentionally left ungrouped so that individual vulnerabilities are clearly visible in PR titles. As required by GitHub, security-related Dependabot PRs will continue to target the default branch (`main`).

#### Post deployment tasks

Enable these two options in the "[Advanced Security](https://github.com/bcgov/bcparks.ca/settings/security_analysis)" settings for the repo

- Dependabot security updates
- Grouped security updates