### PR TITLE
CMS-1654: Update link decorators to avoid "quirks"

### DIFF
--- a/src/cms/src/admin/extensions/ckeditor/ckeditor-config.js
+++ b/src/cms/src/admin/extensions/ckeditor/ckeditor-config.js
@@ -77,13 +77,10 @@ export const registerCKEditor = async (_app) => {
     editorConfig: {
       ...defaultHtmlPreset.editorConfig,
 
-      // Remove color controls from the text-selection popup (balloon toolbar).
-      // We only allow branded colors via predefined styles/classes.
-      balloonToolbar: (
-        defaultHtmlPreset.editorConfig.balloonToolbar || []
-      ).filter(
-        (item) => item !== "fontColor" && item !== "fontBackgroundColor",
-      ),
+      // Remove the font formatting "balloon" toolbar that appears when selecting text,
+      // since it interferes with the custom link toolbar.
+      // Text formatting options are available in the main toolbar.
+      balloonToolbar: false,
 
       toolbar: [
         "heading",
@@ -91,7 +88,11 @@ export const registerCKEditor = async (_app) => {
         "|",
         "bold",
         "italic",
-        "underline",
+        {
+          label: "Other formatting options",
+          icon: "text",
+          items: ["underline", "strikethrough", "superscript", "subscript"],
+        },
         "|",
         "link",
         "strapiMediaLib",

--- a/src/cms/src/admin/extensions/ckeditor/ckeditor-config.js
+++ b/src/cms/src/admin/extensions/ckeditor/ckeditor-config.js
@@ -170,10 +170,9 @@ export const registerCKEditor = async (_app) => {
           openInNewTab: {
             mode: "manual",
             label: "Open in a new tab",
-            defaultValue: false,
             attributes: {
-              target: "_blank",
-              rel: "noopener",
+              // Add a special attribute to identify links in a Gatsby transform function
+              "data-ck-link-open-in-new-tab": "true",
             },
           },
 
@@ -181,6 +180,10 @@ export const registerCKEditor = async (_app) => {
             mode: "manual",
             label: "Learn more link",
             classes: "learn-more-link",
+            attributes: {
+              // Add a "ck-link-decorator" data attribute to prevent conflicts with other decorators
+              "data-ck-link-decorator": "learn-more",
+            },
           },
 
           makeButton: {
@@ -188,6 +191,8 @@ export const registerCKEditor = async (_app) => {
             label: "Primary button",
             classes: "btn btn-primary",
             attributes: {
+              // Add a "ck-link-decorator" data attribute to prevent conflicts with other decorators
+              "data-ck-link-decorator": "primary-button",
               role: "button",
             },
           },
@@ -197,6 +202,8 @@ export const registerCKEditor = async (_app) => {
             label: "Secondary button",
             classes: "btn btn-secondary",
             attributes: {
+              // Add a "ck-link-decorator" data attribute to prevent conflicts with other decorators
+              "data-ck-link-decorator": "secondary-button",
               role: "button",
             },
           },
@@ -205,8 +212,8 @@ export const registerCKEditor = async (_app) => {
             mode: "automatic",
             callback: (url) => !!url?.endsWith(".pdf"),
             attributes: {
-              target: "_blank",
-              rel: "noopener",
+              // Add a special attribute to identify downloadable links in a Gatsby transform function
+              "data-ck-link-downloadable": "true",
             },
           },
         },

--- a/src/gatsby/src/components/htmlContent.js
+++ b/src/gatsby/src/components/htmlContent.js
@@ -1,15 +1,24 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { usePreRenderVideo } from "../utils/usePreRenderVideo"
+import { applyCkeditorLinkDecorators } from "../utils/ckeditorLinkDecoratorHelper"
 
-export default function HtmlContent(props) {
-  const { htmlContent } = usePreRenderVideo(props.children)
+export default function HtmlContent(props = {}) {
+  // Apply link decorators from CKEditor
+  const decoratedHtml = useMemo(
+    () => applyCkeditorLinkDecorators(props.children),
+    [props.children]
+  )
+
+  // Process YouTube video embeds
+  const { htmlContent } = usePreRenderVideo(decoratedHtml)
+
   if (!props) return null
   return (
     <div
       lang="en"
       aria-hidden={props.ariaHidden}
       className={`raw-html-content ${props.className ? props.className : ""}`}
-      dangerouslySetInnerHTML={{ __html: htmlContent || props.children }}
+      dangerouslySetInnerHTML={{ __html: htmlContent || decoratedHtml }}
     />
   )
 }

--- a/src/gatsby/src/styles/CKEditor.scss
+++ b/src/gatsby/src/styles/CKEditor.scss
@@ -74,14 +74,6 @@
     margin-bottom: 0;
   }
 
-  // Prevent a display issue for learn-more-links when CKEditor breaks a link into multiple elements
-  .ck-list-bogus-paragraph {
-    // Only show the ::after pseudo-element for the last .learn-more-link
-    .learn-more-link:not(:last-child)::after {
-      display: none;
-    }
-  }
-
   @include button-styles;
   @include base-link-styles;
   @include theme-link-styles;

--- a/src/gatsby/src/utils/ckeditorLinkDecoratorHelper.js
+++ b/src/gatsby/src/utils/ckeditorLinkDecoratorHelper.js
@@ -1,0 +1,54 @@
+import * as cheerio from "cheerio";
+const CKEDITOR_LINK_DECORATOR_ATTRIBUTES = [
+  "data-ck-link-open-in-new-tab",
+  "data-ck-link-downloadable",
+];
+
+/**
+ * Applies CKEditor link decorators to the given HTML.
+ * Looks for links with specific data attributes, added by CKEditor's link decorators.
+ * @param {string} html - The HTML content to process.
+ * @returns {string} - The modified HTML with link decorators applied.
+ */
+export const applyCkeditorLinkDecorators = (html = "") => {
+  // Skip processing if the input is not a string
+  if (!html || typeof html !== "string") return html;
+
+  // Skip processing if there are no applicable links to transform
+  const hasDecoratorMarkers = CKEDITOR_LINK_DECORATOR_ATTRIBUTES.some(
+    (attributeName) => html.includes(`${attributeName}="true"`),
+  );
+
+  if (!hasDecoratorMarkers) {
+    return html;
+  }
+
+  // Parse the page content HTML to find all applicable links
+  const $ = cheerio.load(html);
+  let hasChanges = false;
+
+  const decoratorSelectors = CKEDITOR_LINK_DECORATOR_ATTRIBUTES.map(
+    (attributeName) => `a[${attributeName}="true"]`,
+  ).join(", ");
+
+  // Loop through links with applicable data attributes,
+  // and add target/rel attributes as needed
+  $(decoratorSelectors).each((_, link) => {
+    const $link = $(link);
+
+    // Add target="_blank" if not already present
+    if (!$link.attr("target")) {
+      $link.attr("target", "_blank");
+      hasChanges = true;
+    }
+
+    // Add rel="noopener noreferrer" if not already present
+    if (!$link.attr("rel")) {
+      $link.attr("rel", "noopener noreferrer");
+      hasChanges = true;
+    }
+  });
+
+  // If any changes were made, return the modified HTML; otherwise, return the original HTML
+  return hasChanges ? $.root().html() || html : html;
+};


### PR DESCRIPTION
### Jira Ticket:
CMS-1654

### Description:

Disabled the "Balloon menu" which caused a minor UX problem if it popped up instead of the link properties when selecting a link. I moved the font formatting buttons from that menu into the main menu.

## Link decorators
CKEditor "link decorators" cause bugs (they say "quirky results" in their docs) when two decorators affect the same attributes. They say there's no mechanism for conflict resolution so it doesn't sound like that's a planned feature/fix.

I added data attributes to the links to prevent conflicts:
- `"data-ck-link-decorator"` will prevent more than one style decorator from being applied (it automatically turns the other ones off when you toggle it)
- "Open in a new tab" and "Downloadable" did the same thing, but one is manual and one is automatic. This caused "quirky results." Instead of directly adding the `rel` and `target` attributes in CKEditor, I'm just adding a data attribute, and then a text transform function will find those links and add the attributes when the Gatsby page is being rendered. It's written for SSG mode but it should also work if we ever change the rendering mode.