### PR TITLE
CMS-1630: Populate hasDates in park operation and park feature

### DIFF
--- a/src/cms/database/migrations/2026.05.05T00.00.008-populate-has-dates.js
+++ b/src/cms/database/migrations/2026.05.05T00.00.008-populate-has-dates.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = {
+  async up(knex) {
+    if (
+      (await knex.schema.hasTable("park_features")) &&
+      (await knex.schema.hasColumn("park_features", "has_dates"))
+    ) {
+      await knex("park_features")
+        .whereNull("has_dates")
+        .update({ has_dates: false });
+    }
+
+    if (
+      (await knex.schema.hasTable("park_operations")) &&
+      (await knex.schema.hasColumn("park_operations", "has_dates"))
+    ) {
+      await knex("park_operations")
+        .whereNull("has_dates")
+        .update({ has_dates: false });
+    }
+  },
+};


### PR DESCRIPTION
### Jira Ticket:
CMS-1630

### Description:
- Issue: Although `hasDates` is configured with `"default": false` in Strapi, the boolean field appears unselected in the Strapi admin UI
- The default does not backfill existing records with null values, so I added a migration to update existing rows accordingly