### PR TITLE
CMS-1746: Fix typo causing errors in advisory scheduling

### DIFF
--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -25,7 +25,7 @@ module.exports = ({ strapi }) => ({
         });
 
       // delete advisories - public advisory table
-      advisoryToUnpublish.forEach(async (advisory) => {
+      for (const advisory of advisoryToUnpublish) {
         strapi.log.info(
           `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`,
         );
@@ -52,10 +52,10 @@ module.exports = ({ strapi }) => ({
               error,
             );
           });
-      });
+      }
 
       // unpublish advisories - audit table
-      advisoryToUnpublish.forEach(async (advisory) => {
+      for (const advisory of advisoryToUnpublish) {
         const advisoryAudit = await strapi
           .documents("api::public-advisory-audit.public-advisory-audit")
           .findMany({
@@ -89,7 +89,7 @@ module.exports = ({ strapi }) => ({
               );
             });
         }
-      });
+      }
     }
     return expiredAdvisoryCount;
   },
@@ -113,7 +113,7 @@ module.exports = ({ strapi }) => ({
       let publishedAdvisoryCount = 0;
 
       // publish advisories - audit table
-      scheduledAdvisoryToPublishAudit.forEach(async (advisory) => {
+      for (const advisory of scheduledAdvisoryToPublishAudit) {
         strapi.log.info(
           `publishing scheduled public-advisory-audit [advisoryNumber:${advisory.advisoryNumber}]`,
         );
@@ -146,7 +146,7 @@ module.exports = ({ strapi }) => ({
               error,
             );
           });
-      });
+      }
 
       return publishedAdvisoryCount;
     }
@@ -184,7 +184,7 @@ module.exports = ({ strapi }) => ({
             ],
           },
         });
-      expiringSoon.forEach(async (advisory) => {
+      for (const advisory of expiringSoon) {
         strapi.log.info(
           `advisory expiring soon [advisoryNumber:${advisory.advisoryNumber}]`,
         );
@@ -194,7 +194,7 @@ module.exports = ({ strapi }) => ({
           advisory.advisoryNumber,
           "public-advisory-audit::services::scheduling::expiringSoon()",
         );
-      });
+      }
       return expiringSoon.length;
     }
     return 0;
@@ -240,7 +240,7 @@ module.exports = ({ strapi }) => ({
               ],
             },
           });
-        publishingSoon.forEach(async (advisory) => {
+        for (const advisory of publishingSoon) {
           strapi.log.info(
             `advisory going live soon [advisoryNumber:${advisory.advisoryNumber}]`,
           );
@@ -250,7 +250,7 @@ module.exports = ({ strapi }) => ({
             advisory.advisoryNumber,
             "public-advisory-audit::services::scheduling::publishingSoon()",
           );
-        });
+        }
         totalPublishingSoon += publishingSoon.length;
       }
       return totalPublishingSoon;
@@ -267,9 +267,9 @@ module.exports = ({ strapi }) => ({
         populate: "*",
       });
     const advisoryStatusMap = {};
-    advisoryStatus.forEach((a) => {
+    for (const a of advisoryStatus) {
       advisoryStatusMap[a.code] = a;
-    });
+    }
     return advisoryStatusMap;
   },
 });

--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -148,7 +148,7 @@ module.exports = ({ strapi }) => ({
           });
       });
 
-      return publishedAdviosryCount;
+      return publishedAdvisoryCount;
     }
   },
 

--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -95,6 +95,8 @@ module.exports = ({ strapi }) => ({
   },
 
   publish: async (advisoryStatusMap) => {
+    let publishedAdvisoryCount = 0;
+
     if (Object.keys(advisoryStatusMap).length > 0) {
       // fetch advisories to publish - audit table
       const scheduledAdvisoryToPublishAudit = await strapi
@@ -109,8 +111,6 @@ module.exports = ({ strapi }) => ({
           },
           populate: "*",
         });
-
-      let publishedAdvisoryCount = 0;
 
       // publish advisories - audit table
       for (const advisory of scheduledAdvisoryToPublishAudit) {
@@ -147,9 +147,8 @@ module.exports = ({ strapi }) => ({
             );
           });
       }
-
-      return publishedAdvisoryCount;
     }
+    return publishedAdvisoryCount;
   },
 
   expiringSoon: async (advisoryStatusMap) => {
@@ -201,8 +200,9 @@ module.exports = ({ strapi }) => ({
   },
 
   publishingSoon: async (advisoryStatusMap) => {
+    let totalPublishingSoon = 0;
+
     if (Object.keys(advisoryStatusMap).length > 0) {
-      let totalPublishingSoon = 0;
       const reminders = [
         { daysBefore: 5, message: "This advisory will go live in 5 days" },
         { daysBefore: 2, message: "This advisory will go live in 2 days" },
@@ -253,9 +253,8 @@ module.exports = ({ strapi }) => ({
         }
         totalPublishingSoon += publishingSoon.length;
       }
-      return totalPublishingSoon;
     }
-    return 0;
+    return totalPublishingSoon;
   },
 
   getAdvisoryStatusMap: async () => {


### PR DESCRIPTION
### Jira Ticket:
CMS-1746

### Description:
This fixes an error that was appearing in the openshift logs for Strapi.
```
[2026-05-07 20:21:00.510] error: publishedAdviosryCount is not defined
ReferenceError: publishedAdviosryCount is not defined
at Object.publish (/opt/app-root/src/src/api/public-advisory/services/scheduling.js:151:7)
at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
at async Object.triggerScheduled (/opt/app-root/src/src/api/public-advisory/controllers/public-advisory.js:198:30)
at async returnBodyMiddleware (/opt/app-root/src/node_modules/@strapi/core/dist/services/server/compose-endpoint.js:46:20)
at async policiesMiddleware (/opt/app-root/src/node_modules/@strapi/core/dist/services/server/policy.js:21:9)
at async /opt/app-root/src/node_modules/@strapi/core/dist/services/server/compose-endpoint.js:27:20
at async /opt/app-root/src/src/middlewares/draft-read-blocker.js:19:16
at async /opt/app-root/src/node_modules/@strapi/core/dist/middlewares/body.js:45:17
at async cors (/opt/app-root/src/node_modules/@koa/cors/index.js:106:16)
at async /opt/app-root/src/node_modules/@strapi/core/dist/middlewares/powered-by.js:12:9
```

As part of the fix, `forEach` loops were also converted to `for...of` loops because CoPilot pointed out that the existing behaviour wasn't really asynchronous.

Also functions were not always returning a number. That has also been fixed.
