### PR TITLE
CMS-1698: Add name field to park operation

### DIFF
--- a/src/cms/database/migrations/2026.05.06T00.00.009-populate-park-operation-name.js
+++ b/src/cms/database/migrations/2026.05.06T00.00.009-populate-park-operation-name.js
@@ -1,0 +1,53 @@
+"use strict";
+
+/*
+  This migration adds and backfills park operation names based on related entities.
+  Priority is protected area name, then site name.
+*/
+
+module.exports = {
+  async up(knex) {
+    if (await knex.schema.hasTable("park_operations")) {
+      if (!(await knex.schema.hasColumn("park_operations", "name"))) {
+        await knex.schema.table("park_operations", (table) => {
+          table.string("name");
+        });
+      }
+
+      await knex.raw(`
+        WITH name_build AS (
+          SELECT
+            po.id,
+            COALESCE(s.orcs_site_number::text, '') || ': ' ||
+            COALESCE(s.site_name, '') AS new_name
+          FROM public.park_operations AS po
+          LEFT JOIN public.park_operations_site_lnk AS posl ON posl.park_operation_id = po.id
+          LEFT JOIN public.sites AS s ON s.id = posl.site_id
+          WHERE s.orcs_site_number IS NOT NULL
+        )
+        UPDATE public.park_operations AS po
+        SET name = nb.new_name
+        FROM name_build AS nb
+        WHERE nb.id = po.id
+          AND (po.name IS NULL OR po.name = '');
+      `);
+
+      await knex.raw(`
+        WITH name_build AS (
+          SELECT
+            po.id,
+            COALESCE(p.orcs::text, '') || ': ' ||
+            COALESCE(p.protected_area_name, '') AS new_name
+          FROM public.park_operations AS po
+          LEFT JOIN public.park_operations_protected_area_lnk AS popol ON popol.park_operation_id = po.id
+          LEFT JOIN public.protected_areas AS p ON p.id = popol.protected_area_id
+          WHERE p.orcs IS NOT NULL
+        )
+        UPDATE public.park_operations AS po
+        SET name = nb.new_name
+        FROM name_build AS nb
+        WHERE nb.id = po.id;
+      `);
+    }
+  },
+};

--- a/src/cms/database/migrations/2026.05.06T00.00.009-populate-park-operation-name.js
+++ b/src/cms/database/migrations/2026.05.06T00.00.009-populate-park-operation-name.js
@@ -18,6 +18,23 @@ module.exports = {
         WITH name_build AS (
           SELECT
             po.id,
+            COALESCE(p.orcs::text, '') || ': ' ||
+            COALESCE(p.protected_area_name, '') AS new_name
+          FROM public.park_operations AS po
+          LEFT JOIN public.park_operations_protected_area_lnk AS popol ON popol.park_operation_id = po.id
+          LEFT JOIN public.protected_areas AS p ON p.id = popol.protected_area_id
+          WHERE p.orcs IS NOT NULL
+        )
+        UPDATE public.park_operations AS po
+        SET name = nb.new_name
+        FROM name_build AS nb
+        WHERE nb.id = po.id;
+      `);
+
+      await knex.raw(`
+        WITH name_build AS (
+          SELECT
+            po.id,
             COALESCE(s.orcs_site_number::text, '') || ': ' ||
             COALESCE(s.site_name, '') AS new_name
           FROM public.park_operations AS po
@@ -30,23 +47,6 @@ module.exports = {
         FROM name_build AS nb
         WHERE nb.id = po.id
           AND (po.name IS NULL OR po.name = '');
-      `);
-
-      await knex.raw(`
-        WITH name_build AS (
-          SELECT
-            po.id,
-            COALESCE(p.orcs::text, '') || ': ' ||
-            COALESCE(p.protected_area_name, '') AS new_name
-          FROM public.park_operations AS po
-          LEFT JOIN public.park_operations_protected_area_lnk AS popol ON popol.park_operation_id = po.id
-          LEFT JOIN public.protected_areas AS p ON p.id = popol.protected_area_id
-          WHERE p.orcs IS NOT NULL
-        )
-        UPDATE public.park_operations AS po
-        SET name = nb.new_name
-        FROM name_build AS nb
-        WHERE nb.id = po.id;
       `);
     }
   },

--- a/src/cms/src/api/park-operation/content-types/park-operation/schema.json
+++ b/src/cms/src/api/park-operation/content-types/park-operation/schema.json
@@ -12,6 +12,9 @@
     "draftAndPublish": true
   },
   "attributes": {
+    "name": {
+      "type": "string"
+    },
     "orcsSiteNumber": {
       "type": "string"
     },

--- a/src/cms/src/middlewares/name-generator.js
+++ b/src/cms/src/middlewares/name-generator.js
@@ -75,6 +75,10 @@ const collections = [
     uid: "api::park-gate.park-gate",
     suffixGenerator: relationNameLabel,
   },
+  {
+    uid: "api::park-operation.park-operation",
+    suffixGenerator: relationNameLabel,
+  },
 ];
 const collectionTypes = collections.map((c) => c.uid);
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1698

### Description:
- Added a name field to `parkOperation`
- Added a script to generate a name in `parkOperation`
  - If `parkOperation` has a relation with `protectedArea`, it'll generate a name `protectedArea.orcs: protectedAreaName` e.g. 6648: Adams Lake Marine Park
  - If `parkOperation` has a relation with `site`, it'll generate a name `site.orcsSiteNumber: site.siteName`
