### PR TITLE
CMS-1762: Update slug character validator regex

### DIFF
--- a/src/cms/src/helpers/validator.js
+++ b/src/cms/src/helpers/validator.js
@@ -42,7 +42,7 @@ module.exports = {
   },
   // checks for valid characters and consecutive forward slashes
   slugCharacterValidator: function (slug) {
-    const regex = new RegExp("^(?:[a-z0-9]+(?:[-/][a-z0-9]+)*)?$");
+    const regex = new RegExp("^(?:/?[a-z0-9]+(?:[-/][a-z0-9]+)*)?$");
     if (!regex.test(slug)) {
       throw new ApplicationError(
         "Please enter lower case letters, numbers, hyphens, or slashes for slugs. No spaces.",


### PR DESCRIPTION
### Jira Ticket:
CMS-1762

### Description:
- It failed because `slugCharacterValidator` requires the first character to be `[a-z0-9]` but the slugs in the page collection have a leading `/`
- Updated it to accept the first char may be `/` and `[a-z0-9]`
