### PR TITLE
CMS-1737: Add sort order to advisory status

### DIFF
--- a/src/cms/database/migrations/2026.05.13T00.00.010-populate-advisory-status-precedence.js
+++ b/src/cms/database/migrations/2026.05.13T00.00.010-populate-advisory-status-precedence.js
@@ -1,0 +1,28 @@
+"use strict";
+
+module.exports = {
+  async up(knex) {
+    if (!(await knex.schema.hasTable("advisory_statuses"))) {
+      return;
+    }
+
+    if (!(await knex.schema.hasColumn("advisory_statuses", "precedence"))) {
+      await knex.schema.table("advisory_statuses", (table) => {
+        table.integer("precedence");
+      });
+    }
+
+    await knex.raw(`
+      UPDATE advisory_statuses
+      SET precedence = CASE advisory_status
+        WHEN 'Draft' THEN 0
+        WHEN 'HQ review' THEN 1
+        WHEN 'Scheduled' THEN 2
+        WHEN 'Published' THEN 3
+        WHEN 'Unpublished' THEN 4
+        ELSE precedence
+      END
+      WHERE advisory_status IN ('Draft', 'HQ review', 'Scheduled', 'Published', 'Unpublished');
+    `);
+  },
+};

--- a/src/cms/database/migrations/2026.05.13T00.00.010-populate-advisory-status-sort-order.js
+++ b/src/cms/database/migrations/2026.05.13T00.00.010-populate-advisory-status-sort-order.js
@@ -6,21 +6,21 @@ module.exports = {
       return;
     }
 
-    if (!(await knex.schema.hasColumn("advisory_statuses", "precedence"))) {
+    if (!(await knex.schema.hasColumn("advisory_statuses", "sortOrder"))) {
       await knex.schema.table("advisory_statuses", (table) => {
-        table.integer("precedence");
+        table.integer("sortOrder");
       });
     }
 
     await knex.raw(`
       UPDATE advisory_statuses
-      SET precedence = CASE advisory_status
+      SET sortOrder = CASE advisory_status
         WHEN 'Draft' THEN 0
         WHEN 'HQ review' THEN 1
         WHEN 'Scheduled' THEN 2
         WHEN 'Published' THEN 3
         WHEN 'Unpublished' THEN 4
-        ELSE precedence
+        ELSE sortOrder
       END
       WHERE advisory_status IN ('Draft', 'HQ review', 'Scheduled', 'Published', 'Unpublished');
     `);

--- a/src/cms/database/migrations/2026.05.13T00.00.010-populate-advisory-status-sort-order.js
+++ b/src/cms/database/migrations/2026.05.13T00.00.010-populate-advisory-status-sort-order.js
@@ -6,21 +6,21 @@ module.exports = {
       return;
     }
 
-    if (!(await knex.schema.hasColumn("advisory_statuses", "sortOrder"))) {
+    if (!(await knex.schema.hasColumn("advisory_statuses", "sort_order"))) {
       await knex.schema.table("advisory_statuses", (table) => {
-        table.integer("sortOrder");
+        table.integer("sort_order");
       });
     }
 
     await knex.raw(`
       UPDATE advisory_statuses
-      SET sortOrder = CASE advisory_status
+      SET sort_order = CASE advisory_status
         WHEN 'Draft' THEN 0
         WHEN 'HQ review' THEN 1
         WHEN 'Scheduled' THEN 2
         WHEN 'Published' THEN 3
         WHEN 'Unpublished' THEN 4
-        ELSE sortOrder
+        ELSE sort_order
       END
       WHERE advisory_status IN ('Draft', 'HQ review', 'Scheduled', 'Published', 'Unpublished');
     `);

--- a/src/cms/src/api/advisory-status/content-types/advisory-status/schema.json
+++ b/src/cms/src/api/advisory-status/content-types/advisory-status/schema.json
@@ -19,10 +19,10 @@
     "code": {
       "type": "string"
     },
-    "precedence": {
+    "sortOrder": {
       "type": "integer",
       "unique": true,
-      "required": false
+      "required": true
     }
   }
 }

--- a/src/cms/src/api/advisory-status/content-types/advisory-status/schema.json
+++ b/src/cms/src/api/advisory-status/content-types/advisory-status/schema.json
@@ -18,6 +18,11 @@
     },
     "code": {
       "type": "string"
+    },
+    "precedence": {
+      "type": "integer",
+      "unique": true,
+      "required": false
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-1737

### Description:
- The new sorting for advisory status in the advisory table required a defined sort order
  - Added `precedence` field to advisory status
  - Added a migration script to populate `precedence` in order of order Draft > HQ review > Scheduled > Published > Unpublished