### PR TITLE
CMS-1714: Use prod Keycloak for dev Strapi (SP training backend)

### DIFF
--- a/infrastructure/helm/deployment/values-dev.yaml
+++ b/infrastructure/helm/deployment/values-dev.yaml
@@ -1,5 +1,5 @@
 cluster:
-  ssoAuthUrl: https://dev.loginproxy.gov.bc.ca/auth
+  ssoAuthUrl: https://loginproxy.gov.bc.ca/auth
   publicUrl: https://dev.bcparks.ca
   staffPortalUrl: https://dev-staff.bcparks.ca
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1714

### Description:
The Staff Portal frontend depends on Strapi but training does not have a dedicated Strapi environment. Training previously used alpha-test-cms, which relies on test Keycloak, causing 401 errors.
This PR prepares dev-cms to act as the Strapi backend for training by aligning it with prod Keycloak. A separate PR in the Staff Portal repo will switch Training to use dev-cms.

**Notes**

- Merging this PR does not update OpenShift config — it only commits the change to source control
- Prod Keycloak does not require a new redirect for DEV — already covered by the existing Training redirect
- Depends on https://github.com/bcgov/bcparks-staff-portal/pull/565 (merge order doesn't matter)
