### PR TITLE
CMS-1731: Add unpublished fields to public advisory audit

### DIFF
--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
@@ -183,6 +183,12 @@
     "reviewedAt": {
       "type": "datetime"
     },
+    "unpublishedByName": {
+      "type": "string"
+    },
+    "unpublishedAt": {
+      "type": "datetime"
+    },
     "createdByRole": {
       "type": "string"
     },


### PR DESCRIPTION
### Jira Ticket:
CMS-1731

### Description:
- In the Advisory Review tab, advisories that have been moved to the unpublished state will be displayed in the following cases:
  - They are automatically unpublished when they expire based on the expiry date.
  - They are manually unpublished when someone clicks the “Unpublish” action.
- For the second case, the system currently does not track who unpublished an advisory or when it was intentionally unpublished. To address this, I added these fields to the public advisory audit table to track manual unpublish actions.
