### PR TITLE
CMS-1717: Process all "elastic batch-queue parks" tasks together

### DIFF
--- a/src/scheduler/doot/scripts/publish.js
+++ b/src/scheduler/doot/scripts/publish.js
@@ -10,12 +10,14 @@ const { dootSplitMessage } = require("./splitMessage");
 exports.dootPublish = async function () {
   let queue;
   const logger = getLogger();
+  let processedTasks;
 
   // When we create/update date ranges from DOOT data, we will only delete existing
   // date ranges of these types to avoid removing date ranges managed manually in Strapi.
   const DOOT_MANAGED_DATE_TYPE_IDS = [1, 2, 3, 4, 6, 7, 8]; // Gate, Tier 1, Tier 2, Winter fee, Operation, Reservation, Backcountry registration
 
   do {
+    processedTasks = [];
     // get items from the queue with the action 'doot publish'
     try {
       queue = await readQueue("doot publish");
@@ -261,11 +263,12 @@ exports.dootPublish = async function () {
       if (!errorProcessingMessage) {
         try {
           await removeFromQueue([message.documentId]);
+          processedTasks.push(message.documentId);
         } catch (error) {
           logger.error(`dootPublish() failed while removing message from queue: ${error}`);
           continue;
         }
       }
     }
-  } while (queue.length > 0);
+  } while (processedTasks.length > 0);
 };

--- a/src/scheduler/elasticsearch/scripts/batchQueueParks.js
+++ b/src/scheduler/elasticsearch/scripts/batchQueueParks.js
@@ -12,57 +12,63 @@ exports.batchQueueParks = async function () {
   let queue;
 
   // get items from the queue with the action 'elastic batch-queue parks'
-  try {
-    queue = await readQueue("elastic batch-queue parks");
-  } catch (error) {
-    logger.error(
-      `batchQueueParks() failed while retrieving 'elastic batch-queue parks' tasks: ${error}`,
-    );
-    return;
-  }
-
-  for (const task of queue) {
-    const query = qs.stringify(
-      {
-        filters: {
-          documentId: { $in: task.jsonData.parkDocumentIds },
-        },
-        fields: ["orcs"],
-      },
-      { encodeValuesOnly: true },
-    );
-
-    let parks;
+  do {
     try {
-      parks = await cmsAxios.get(`/api/protected-areas?${query}`);
+      queue = await readQueue("elastic batch-queue parks");
     } catch (error) {
-      logger.error(`batchQueueParks() failed while retrieving parks: ${error}`);
+      logger.error(
+        `batchQueueParks() failed while retrieving 'elastic batch-queue parks' tasks: ${error}`,
+      );
       return;
     }
 
-    let isError = false;
-    for (const park of parks?.data?.data || []) {
+    for (const task of queue) {
+      const query = qs.stringify(
+        {
+          filters: {
+            documentId: { $in: task.jsonData.parkDocumentIds },
+          },
+          fields: ["orcs"],
+        },
+        { encodeValuesOnly: true },
+      );
+
+      let parks;
       try {
-        if (!(await existsInQueue("elastic index park", park.orcs))) {
-          const addedToQueue = await addToQueue({
-            data: { action: "elastic index park", numericData: park.orcs },
-          });
-          if (!addedToQueue) {
-            isError = true;
-          }
-        }
+        parks = await cmsAxios.get(`/api/protected-areas?${query}`);
       } catch (error) {
-        isError = true;
-        logger.error(`batchQueueParks() failed while adding park ${park.orcs} to queue: ${error}`);
-      }
-    }
-    if (!isError) {
-      try {
-        await removeFromQueue([task.documentId]);
-      } catch (error) {
-        logger.error(`batchQueueParks() failed while removing batch-queue task from queue: ${error}`);
+        logger.error(`batchQueueParks() failed while retrieving parks: ${error}`);
         return;
       }
+
+      let isError = false;
+      for (const park of parks?.data?.data || []) {
+        try {
+          if (!(await existsInQueue("elastic index park", park.orcs))) {
+            const addedToQueue = await addToQueue({
+              data: { action: "elastic index park", numericData: park.orcs },
+            });
+            if (!addedToQueue) {
+              isError = true;
+            }
+          }
+        } catch (error) {
+          isError = true;
+          logger.error(
+            `batchQueueParks() failed while adding park ${park.orcs} to queue: ${error}`,
+          );
+        }
+      }
+      if (!isError) {
+        try {
+          await removeFromQueue([task.documentId]);
+        } catch (error) {
+          logger.error(
+            `batchQueueParks() failed while removing batch-queue task from queue: ${error}`,
+          );
+          return;
+        }
+      }
     }
-  }
+  } while (queue.length > 0);
 };

--- a/src/scheduler/elasticsearch/scripts/batchQueueParks.js
+++ b/src/scheduler/elasticsearch/scripts/batchQueueParks.js
@@ -25,30 +25,40 @@ exports.batchQueueParks = async function () {
     }
 
     for (const task of queue) {
-      const query = qs.stringify(
-        {
-          filters: {
-            documentId: { $in: task.jsonData.parkDocumentIds },
-          },
-          fields: ["orcs"],
-        },
-        { encodeValuesOnly: true },
-      );
+      const parkDocumentIds = task.jsonData?.parkDocumentIds || [];
 
-      let parks;
-      try {
-        parks = await cmsAxios.get(`/api/protected-areas?${query}`);
-      } catch (error) {
-        logger.error(`batchQueueParks() failed while retrieving parks: ${error}`);
-        return;
+      // Convert documentIds to orcs in batches of 50 to avoid URL length issues
+      const batchSize = 50;
+      const orcsValues = [];
+
+      for (let i = 0; i < parkDocumentIds.length; i += batchSize) {
+        const batchIds = parkDocumentIds.slice(i, i + batchSize);
+        const query = qs.stringify(
+          {
+            filters: {
+              documentId: { $in: batchIds },
+            },
+            fields: ["orcs"],
+          },
+          { encodeValuesOnly: true },
+        );
+
+        let parks;
+        try {
+          parks = await cmsAxios.get(`/api/protected-areas?${query}`);
+          orcsValues.push(...parks.data.data.map((park) => park.orcs));
+        } catch (error) {
+          logger.error(`batchQueueParks() failed while retrieving parks: ${error}`);
+          return;
+        }
       }
 
       let isError = false;
-      for (const park of parks?.data?.data || []) {
+      for (const orcs of orcsValues) {
         try {
-          if (!(await existsInQueue("elastic index park", park.orcs))) {
+          if (!(await existsInQueue("elastic index park", orcs))) {
             const addedToQueue = await addToQueue({
-              data: { action: "elastic index park", numericData: park.orcs },
+              data: { action: "elastic index park", numericData: orcs },
             });
             if (!addedToQueue) {
               isError = true;
@@ -56,9 +66,7 @@ exports.batchQueueParks = async function () {
           }
         } catch (error) {
           isError = true;
-          logger.error(
-            `batchQueueParks() failed while adding park ${park.orcs} to queue: ${error}`,
-          );
+          logger.error(`batchQueueParks() failed while adding park ${orcs} to queue: ${error}`);
         }
       }
       if (!isError) {

--- a/src/scheduler/elasticsearch/scripts/batchQueueParks.js
+++ b/src/scheduler/elasticsearch/scripts/batchQueueParks.js
@@ -12,7 +12,9 @@ exports.batchQueueParks = async function () {
   let queue;
 
   // get items from the queue with the action 'elastic batch-queue parks'
+  let processedTasks;
   do {
+    processedTasks = [];
     try {
       queue = await readQueue("elastic batch-queue parks");
     } catch (error) {
@@ -62,6 +64,7 @@ exports.batchQueueParks = async function () {
       if (!isError) {
         try {
           await removeFromQueue([task.documentId]);
+          processedTasks.push(task.documentId);
         } catch (error) {
           logger.error(
             `batchQueueParks() failed while removing batch-queue task from queue: ${error}`,
@@ -70,5 +73,5 @@ exports.batchQueueParks = async function () {
         }
       }
     }
-  } while (queue.length > 0);
+  } while (processedTasks.length > 0);
 };


### PR DESCRIPTION
### Jira Ticket:
CMS-1717

### Description:
`readQueue` returns a maximum of 20 records per call. Without a loop, `batchQueueParks` only converted 20 `elastic batch-queue parks` tasks into `elastic index park` tasks per scheduler run.

A full-year DOOT publish produces 1,500–2,000 tasks. At 20 tasks per 1-minute scheduler cycle, the queue could take up to 100 minutes to fully drain before Elasticsearch re-indexing could complete.

**Fix:** Wrap the queue read and processing in a `do/while (queue.length > 0)` loop, consistent with `elasticsearch/scripts/indexParks.js` and `doot/scripts/publish.js`.

Also updated fetching logic so it fetches protected areas in documentId batches of 50 to avoid oversized requests that can cause HTTP 431 errors.

> **Note:** This has not been confirmed as the root cause of reported publishing slowness, but it is a clear bottleneck that would cause significant lag in search result updates after a large publish.
