### PR TITLE
CMS-1753: Update draftReadBlocker for compatibility with Strapi 5.45.0

### DIFF
--- a/src/cms/src/extensions/users-permissions/strategies/keycloak-users-permissions.js
+++ b/src/cms/src/extensions/users-permissions/strategies/keycloak-users-permissions.js
@@ -2,10 +2,10 @@
 
 const { map } = require("lodash/fp");
 const { UnauthorizedError } = require("@strapi/utils").errors;
+
 const AUTH_URL =
   process.env.STRAPI_SSO_AUTH_URL || "https://dev.loginproxy.gov.bc.ca/auth";
-
-const KEYCLOAK_AUTH_ROLES = ["submitter", "approver"];
+const KEYCLOAK_AUTH_ROLES = ["advisory-user"];
 
 const getService = (name) => {
   return strapi.plugin("users-permissions").service(name);

--- a/src/cms/src/middlewares/draft-read-blocker.js
+++ b/src/cms/src/middlewares/draft-read-blocker.js
@@ -34,14 +34,13 @@ module.exports = () => {
       }
     }
 
-    // Call next() to ensure ctx.request.body & ctx.state.auth are populated
+    // Call next() to ensure ctx.request.body & ctx.state are populated
     await next();
 
     // Allow draft access for authenticated users
-    const isUser = !!ctx.state?.user;
-    const isApiToken = ctx.state?.auth?.strategy?.name === "api-token";
+    const isAuthenticated = !!ctx.state?.isAuthenticated;
 
-    if (isUser || isApiToken) {
+    if (isAuthenticated) {
       return;
     }
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1753

### Description:
Fixes a regression from the Strapi upgrade where API token requests were blocked due to unreliable strategy checks.
Simplifies draft access control by using `ctx.state.isAuthenticated` instead of checking specifically for API tokens and ensuring only authenticated requests can access drafts.
Also fixes a bug in keycloak-users-permissions where deprecated Keycloak client roles were still being checked.
