### PR TITLE
CMS-1763: Remove Draft/Publish mutations from advisory scheduling

### DIFF
--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -39,25 +39,33 @@ module.exports = ({ strapi }) => ({
           strapi.log.info(
             `setting public-advisory-audit to unpublished [advisoryNumber:${advisory.advisoryNumber}]`,
           );
-          await strapi
-            .documents("api::public-advisory-audit.public-advisory-audit")
-            .update({
-              documentId: advisoryAudit[0].documentId,
-              data: {
-                advisoryStatus: {
-                  id: advisoryStatusMap["UNP"].id,
+          try {
+            await strapi
+              .documents("api::public-advisory-audit.public-advisory-audit")
+              .update({
+                documentId: advisoryAudit[0].documentId,
+                data: {
+                  advisoryStatus: {
+                    id: advisoryStatusMap["UNP"].id,
+                  },
+                  removalDate: new Date(),
+                  modifiedBy: "system",
+                  modifiedDate: new Date(),
                 },
-                removalDate: new Date(),
-                modifiedBy: "system",
-                modifiedDate: new Date(),
-              },
-            })
-            .catch((error) => {
-              strapi.log.error(
-                `error updating public-advisory-audit #${advisory.advisoryNumber}`,
-                error,
-              );
-            });
+              });
+            expiredAdvisoryCount++;
+            await queueAdvisoryEmail(
+              "Expired advisory removed",
+              "An expired advisory was removed",
+              advisory.advisoryNumber,
+              "public-advisory::services::scheduling::expire()",
+            );
+          } catch (error) {
+            strapi.log.error(
+              `error updating public-advisory-audit #${advisory.advisoryNumber}`,
+              error,
+            );
+          }
         }
       }
     }

--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -24,37 +24,8 @@ module.exports = ({ strapi }) => ({
           populate: "*",
         });
 
-      // delete advisories - public advisory table
-      for (const advisory of advisoryToUnpublish) {
-        strapi.log.info(
-          `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`,
-        );
-        await strapi
-          .documents("api::public-advisory.public-advisory")
-          .update({
-            documentId: advisory.documentId,
-            data: {
-              publishedAt: null,
-            },
-          })
-          .then(async (advisory) => {
-            expiredAdvisoryCount++;
-            await queueAdvisoryEmail(
-              "Expired advisory removed",
-              "An expired advisory was removed",
-              advisory.advisoryNumber,
-              "public-advisory-audit::services::scheduling::expire()",
-            );
-          })
-          .catch((error) => {
-            strapi.log.error(
-              `error updating public-advisory #${advisory.advisoryNumber}`,
-              error,
-            );
-          });
-      }
-
       // unpublish advisories - audit table
+      // middleware will remove the records from public-advisories once the audit record is unpublished
       for (const advisory of advisoryToUnpublish) {
         const advisoryAudit = await strapi
           .documents("api::public-advisory-audit.public-advisory-audit")
@@ -73,7 +44,6 @@ module.exports = ({ strapi }) => ({
             .update({
               documentId: advisoryAudit[0].documentId,
               data: {
-                publishedAt: new Date(),
                 advisoryStatus: {
                   id: advisoryStatusMap["UNP"].id,
                 },
@@ -122,7 +92,6 @@ module.exports = ({ strapi }) => ({
           .update({
             documentId: advisory.documentId,
             data: {
-              publishedAt: advisory.advisoryDate,
               advisoryStatus: {
                 id: advisoryStatusMap["PUB"].id,
               },


### PR DESCRIPTION
### Jira Ticket:
CMS-1763

### Description:
This change removes some mutations to the Strapi publishedAt field for public advisory audits.  Public advisory collections no longer have draft and publish mode enabled and this field should be handled by Strapi.  