### PR TITLE
CMS-1540: Crunchy-Postgres prod resource tuning

### DIFF
--- a/infrastructure/helm/crunchy-postgres/MIGRATION.md
+++ b/infrastructure/helm/crunchy-postgres/MIGRATION.md
@@ -40,13 +40,18 @@
    ```
 
 1. Copy the backup onto the crunchy primary with `oc cp`
-   - I usually put it in `/tmp`
-   - It will get removed in a few minutes so work fast
 
-   e.g.
+   Run this in the leader pod
 
    ```
-   oc cp ./strapi-backup.sql crunchy-postgres-alpha-ha-jrs7-0:/tmp/strapi-backup.sql
+   mkdir -p /pgdata/tmp_backup
+   chmod 700 /pgdata/tmp_backup
+   ```
+
+   Run this from your mac terminal
+
+   ```
+   oc cp ./strapi-backup.sql crunchy-postgres-alpha-ha-jrs7-0:/pgdata/tmp_backup/strapi-backup.sql
    ```
 
 1. Restore the DB
@@ -59,7 +64,7 @@
    ```
    \q
 
-   psql -h crunchy-postgres-primary -U crunchy-postgres -d cms < /tmp/strapi-backup.sql
+   psql -h crunchy-postgres-primary -U crunchy-postgres -d cms < /pgdata/tmp_backup/strapi-backup.sql
    ```
 
    alpha environments:
@@ -68,7 +73,9 @@
    ```
    \q
 
-   psql -h crunchy-postgres-alpha-primary -U crunchy-postgres-alpha -d cms < /tmp/strapi-backup.sql
+   psql -h crunchy-postgres-alpha-primary -U crunchy-postgres-alpha -d cms < /pgdata/tmp_backup/strapi-backup.sql
    ```
+
+   **You can delete the backup when you're done.**
 
 1. Run the `upgrade` command in the `deployment` helm chart for the environment being migrated

--- a/infrastructure/helm/crunchy-postgres/values-prod.yaml
+++ b/infrastructure/helm/crunchy-postgres/values-prod.yaml
@@ -3,9 +3,9 @@ fullnameOverride: crunchy-postgres
 postgresVersion: 17
 
 instances:
-  replicas: 2
+  replicas: 3
   dataVolumeClaimSpec:
-    storage: 2Gi
+    storage: 6Gi
   requests:
     cpu: 100m
 
@@ -13,7 +13,7 @@ pgBackRest:
   retention: "15" # Ideally a larger number such as 30 backups/days
   repos:
     volume:
-      storage: 2Gi
+      storage: 6Gi
   s3:
     enabled: true
     bucket: "parks-cms-prod"

--- a/infrastructure/helm/deployment/values.yaml
+++ b/infrastructure/helm/deployment/values.yaml
@@ -116,14 +116,14 @@ redis:
 etl:
   componentName: etl
 
-  # Enabled by default.  Overriden for aplha-dev
+  # Enabled by default.  Overridden for alpha-dev
   enabled: true
   disableBcwfsCron: true
   disableParkNamesCron: false
   enableBcwfsStandalonePropagation: false
 
-  # Run the cron job every hour at 15 minutes past the hour
-  schedule: "15 * * * *"
+  # Run the cron job every hour at 1 minute past the hour
+  schedule: "1 * * * *"
 
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 2


### PR DESCRIPTION
### Jira Ticket:
CMS-1540

### Description:
Final adjustments to crunchy postgres config made during prod deplyoment

- Increased PVC sizes from 2gb to 6gb to match what we had with Patroni (this is bigger than we ever needed but also easy to justify because we had 6gb before)
- Increased the number of replicas from 2 to 3 to match the Patroni config
- Changed the ETL cron job time from 15 minutes after each hour to 1 minute after each hour.  This was done based on a recent conversation on MS Teams (fire bans always start or end at noon precisely) -- 1 minute just gives a tiny buffer for varying clock speeds on different machines. This isn't related to CrunchyDB at all, but I included it because I was editing the Helm files already.
- Updated migration documentation to use the `/pgdata` folder instead of the `/tmp` folder.  `/tmp` is an "emptyDir" volume and putting too much data in it causes the pod to restart within about 1 minute.   

** The Confluence page documenting how to back-up and restore databases has also been updated to use `/pgdata` for both `bcparks-staff-portal` and `bcparks.ca`. Some steps may need refinement the first time these instruction are used. 
