### PR TITLE
CMS-1786: Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -18,13 +18,13 @@ jobs:
       BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-22
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -61,7 +61,7 @@ jobs:
       IMAGE_NAME: public-builder-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: |
@@ -69,7 +69,7 @@ jobs:
           echo "REGISTRY_IMAGE=${{ secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY }}/${{ secrets.OPENSHIFT_GOLD_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -91,7 +91,7 @@ jobs:
       IMAGE_NAME: maintenance-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: |
@@ -99,7 +99,7 @@ jobs:
           echo "REGISTRY_IMAGE=${{ secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY }}/${{ secrets.OPENSHIFT_GOLD_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -122,13 +122,13 @@ jobs:
       BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-22
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -164,13 +164,13 @@ jobs:
       BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-22
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -205,7 +205,7 @@ jobs:
     needs: [build-cms]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
@@ -225,7 +225,7 @@ jobs:
           oc -n ${{ secrets.OPENSHIFT_GOLD_LICENSE_PLATE }}-dev rollout restart deployment ${{ github.ref_name }}-scheduler
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-alpha-test.yaml
+++ b/.github/workflows/deploy-alpha-test.yaml
@@ -32,7 +32,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag scheduler-alpha:latest scheduler-alpha:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 
@@ -50,7 +50,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag scheduler-main:${{ github.event.inputs.releaseTag }} scheduler-main:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 
@@ -47,7 +47,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag scheduler-main:${{ github.event.inputs.releaseTag }} scheduler-main:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -12,10 +12,10 @@ jobs:
   test-strapi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
 
@@ -36,10 +36,10 @@ jobs:
   test-gatsby:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
 

--- a/.github/workflows/publish-gatsby.yaml
+++ b/.github/workflows/publish-gatsby.yaml
@@ -94,21 +94,21 @@ jobs:
               fi
           fi
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
           password: ${{secrets.OPENSHIFT_GOLD_SA_PASSWORD}}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
 
       - run: mkdir -p gatsby/public && mkdir gatsby/.cache
 
       - name: Cache Gatsby Cache Folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: gatsby-cache-folder
         with:
           path: gatsby/.cache
@@ -116,7 +116,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cache-gatsby-${{ env.BRANCH }}-${{ env.ENV_SUFFIX }}
       - name: Cache Gatsby Public Folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: gatsby-public-folder
         with:
           path: gatsby/public


### PR DESCRIPTION
### Jira Ticket:
CMS-1786

### Description:
 This change updates GitHub actions to the latest major versions in anticipation of actions being forced onto Node 24 on June 2, 2026.

This will be cherry-picked to the main branch after it is tested on alpha and we ensure the publish-gatsby.yaml workflow still works. 
