### PR TITLE
CMS-1427: Suppress warning message when there are zero draft parks

### DIFF
--- a/src/scheduler/elasticsearch/scripts/indexParks.js
+++ b/src/scheduler/elasticsearch/scripts/indexParks.js
@@ -197,11 +197,13 @@ const getBatch = async function (queuedTasks, options) {
       (p) => !publishedParkDocIds.includes(p.documentId),
     );
 
-    getLogger().warn(
-      `Adding ${extraDrafts.length} draft protected areas to the list (to be removed from index).`,
-    );
-
-    parkList.push(...extraDrafts);
+    // add any draft parks that aren't in the published parks to the list of parks to be indexed
+    if (extraDrafts.length > 0) {
+      getLogger().warn(
+        `Adding ${extraDrafts.length} draft protected areas to the list (to be removed from index).`,
+      );
+      parkList.push(...extraDrafts);
+    }
   }
 
   return parkList;


### PR DESCRIPTION
### Jira Ticket:
CMS-1427

### Description:
This change suppresses the warning message "Adding 0 draft protected areas to the list (to be removed from index)." from Elasticsearch indexing in the scheduler.

