### PR TITLE
CMS-1733: Update Strapi audit columns

### DIFF
--- a/src/cms/database/migrations/2026.04.08T00.00.005-populate-rst-closures.js
+++ b/src/cms/database/migrations/2026.04.08T00.00.005-populate-rst-closures.js
@@ -1811,7 +1811,7 @@ module.exports = {
       (await knex.schema.hasTable("public_advisory_audits")) &&
       (await knex.schema.hasColumn(
         "public_advisory_audits",
-        "modifiedByName",
+        "modified_by_name",
       )) &&
       (await knex.schema.hasTable("recreation_resources"))
     ) {

--- a/src/cms/database/migrations/2026.04.08T00.00.005-populate-rst-closures.js
+++ b/src/cms/database/migrations/2026.04.08T00.00.005-populate-rst-closures.js
@@ -1809,6 +1809,10 @@ module.exports = {
     if (
       process.env.STRAPI_ADMIN_ENVIRONMENT !== "prod" &&
       (await knex.schema.hasTable("public_advisory_audits")) &&
+      (await knex.schema.hasColumn(
+        "public_advisory_audits",
+        "modifiedByName",
+      )) &&
       (await knex.schema.hasTable("recreation_resources"))
     ) {
       // use strapi.documents to get all the recreation resources and create a map of recResourceId to documentId
@@ -1904,8 +1908,8 @@ module.exports = {
           title: closure.headline,
           description: closure.closure_description,
           accessStatus: fullClosureAccessStatus?.documentId,
-          submittedBy: "Imported",
-          modifiedBy: "Imported",
+          submittedByName: "Imported",
+          modifiedByName: "Imported",
           advisoryDate: new Date(),
           effectiveDate: new Date(),
           createdDate: new Date(),

--- a/src/cms/database/migrations/2026.05.27T00.00.013-rename-audit-columns.js
+++ b/src/cms/database/migrations/2026.05.27T00.00.013-rename-audit-columns.js
@@ -1,0 +1,41 @@
+"use strict";
+
+/**
+ * Column naming conventions enforced in this migration:
+ *
+ * 1. Non-Strapi user name fields must end with `Name` — e.g. `submittedBy` → `submittedByName`,
+ *    `modifiedBy` → `modifiedByName`
+ * 2. Non-Strapi date fields must end with `Date` — e.g. `reviewedAt` → `reviewedDate`,
+ *    `unpublishedAt` → `unpublishedDate`. Fields ending with `At` are reserved for Strapi
+ *    system timestamps (`createdAt`, `updatedAt`, `publishedAt`)
+ */
+
+module.exports = {
+  async up(knex) {
+    if (await knex.schema.hasColumn("public_advisory_audits", "submitted_by")) {
+      await knex.schema.table("public_advisory_audits", (table) => {
+        table.renameColumn("submitted_by", "submitted_by_name");
+      });
+    }
+
+    if (await knex.schema.hasColumn("public_advisory_audits", "modified_by")) {
+      await knex.schema.table("public_advisory_audits", (table) => {
+        table.renameColumn("modified_by", "modified_by_name");
+      });
+    }
+
+    if (await knex.schema.hasColumn("public_advisory_audits", "reviewed_at")) {
+      await knex.schema.table("public_advisory_audits", (table) => {
+        table.renameColumn("reviewed_at", "reviewed_date");
+      });
+    }
+
+    if (
+      await knex.schema.hasColumn("public_advisory_audits", "unpublished_at")
+    ) {
+      await knex.schema.table("public_advisory_audits", (table) => {
+        table.renameColumn("unpublished_at", "unpublished_date");
+      });
+    }
+  },
+};

--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
@@ -70,7 +70,7 @@
       "type": "boolean",
       "default": null
     },
-    "submittedBy": {
+    "submittedByName": {
       "type": "string"
     },
     "createdDate": {
@@ -97,7 +97,7 @@
     "modifiedDate": {
       "type": "datetime"
     },
-    "modifiedBy": {
+    "modifiedByName": {
       "type": "string"
     },
     "modifiedByRole": {
@@ -180,13 +180,13 @@
     "reviewedByName": {
       "type": "string"
     },
-    "reviewedAt": {
+    "reviewedDate": {
       "type": "datetime"
     },
     "unpublishedByName": {
       "type": "string"
     },
-    "unpublishedAt": {
+    "unpublishedDate": {
       "type": "datetime"
     },
     "createdByRole": {

--- a/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
+++ b/src/cms/src/api/public-advisory/content-types/public-advisory/schema.json
@@ -68,9 +68,6 @@
       "type": "boolean",
       "default": null
     },
-    "submittedBy": {
-      "type": "string"
-    },
     "createdDate": {
       "type": "datetime"
     },
@@ -84,9 +81,6 @@
       "type": "datetime"
     },
     "expiryDate": {
-      "type": "datetime"
-    },
-    "removalDate": {
       "type": "datetime"
     },
     "updatedDate": {

--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -78,7 +78,7 @@ module.exports = ({ strapi }) => ({
                   id: advisoryStatusMap["UNP"].id,
                 },
                 removalDate: new Date(),
-                modifiedBy: "system",
+                modifiedByName: "system",
                 modifiedDate: new Date(),
               },
             })
@@ -126,7 +126,7 @@ module.exports = ({ strapi }) => ({
               advisoryStatus: {
                 id: advisoryStatusMap["PUB"].id,
               },
-              modifiedBy: "system",
+              modifiedByName: "system",
               modifiedDate: new Date(),
               removalDate: null,
             },

--- a/src/cms/src/middlewares/helpers/advisoryData.js
+++ b/src/cms/src/middlewares/helpers/advisoryData.js
@@ -124,7 +124,7 @@ function isAdvisoryEqual(newData, oldData) {
     isEffectiveDateDisplayed: null,
     isEndDateDisplayed: null,
     isUpdatedDateDisplayed: null,
-    modifiedBy: null,
+    modifiedByName: null,
   };
 
   for (const key of Object.keys(fieldsToCompare)) {

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -146,7 +146,7 @@ module.exports = () => {
     if (isAdvisoryEqual(updatedPublicAdvisory, oldPublicAdvisory)) return;
 
     // flow 5: system updates
-    if (updatedPublicAdvisory.modifiedBy === "system") {
+    if (updatedPublicAdvisory.modifiedByName === "system") {
       await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
       updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(
         oldPublicAdvisory.advisoryNumber,
@@ -157,7 +157,7 @@ module.exports = () => {
     // flow 4: update unpublished (set by system)
     if (
       oldAdvisoryStatus === "UNP" &&
-      oldPublicAdvisory.modifiedBy === "system"
+      oldPublicAdvisory.modifiedByName === "system"
     ) {
       await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
       updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(


### PR DESCRIPTION
### Jira Ticket:
CMS-1733

### Description:
This change updates the audit columns in the `public-advisory-audits` collection to standardize naming conventions and ensure that only necessary fields are included in the public projection collection `public-advisories`. 

**Column naming conventions being enforced in this PR**
 
1. Non-Strapi user name fields must end with `Name` — e.g. `submittedBy` → `submittedByName`, `modifiedBy` → `modifiedByName`
2. Non-Strapi date fields must end with `Date` — e.g. `reviewedAt` → `reviewedDate`, `unpublishedAt` → `unpublishedDate`. Fields ending with `At` are reserved for Strapi  system timestamps (`createdAt`, `updatedAt`, `publishedAt`)

Old Name | New Name
-- | --
submittedBy | submittedByName
modifiedBy | modifiedByName
reviewedAt | reviewedDate
unpublishedAt | unpublishedDate


**Public-advisories dropped columns**

Column | Reason
-- | --
submittedBy | Reveals staff names, does not need to be public
removalDate | Only applicable once advisores are unpublished by the scheduler, so never applicable in published advisories



