### PR TITLE
CMS-1733: Add createdByEmail and contibutor role to public-advisory-audits

### DIFF
--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
@@ -177,6 +177,9 @@
     "createdByName": {
       "type": "string"
     },
+    "createdByEmail": {
+      "type": "string"
+    },
     "reviewedByName": {
       "type": "string"
     },

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -204,7 +204,8 @@ module.exports = () => {
     if (
       newAdvisoryStatus === "PUB" &&
       oldAdvisoryStatus !== "PUB" &&
-      publicAdvisoryAudit.modifiedByRole === "submitter" &&
+      (publicAdvisoryAudit.modifiedByRole === "submitter" ||
+        publicAdvisoryAudit.modifiedByRole === "contributor") && // TODO: determine after-hours rules for contributors
       publicAdvisoryAudit.isUrgentAfterHours
     ) {
       await queueAdvisoryEmail(


### PR DESCRIPTION
### Jira Ticket:
CMS-1733

### Description:

- Added new createdByEmail field to the Strapi public-advisory-audits collection
- Expanded email notifiatitions for after hours advisories to include the "contributor" role (waiting for clarifiation from UX about expected behaviour)
