### PR TITLE
CMS-1733: Add publishedByName and publishedDate to public-advisory-audit

### DIFF
--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
@@ -186,6 +186,12 @@
     "reviewedDate": {
       "type": "datetime"
     },
+    "publishedByName": {
+      "type": "string"
+    },
+    "publishedDate": {
+      "type": "datetime"
+    },
     "unpublishedByName": {
       "type": "string"
     },


### PR DESCRIPTION
### Jira Ticket:
CMS-1733

### Description:
This change adds two additional fields to the public-advisory-audit collection in Strapi

- publishedByName
- publishedDate

Strapi already has a system-level publishedAt field but these fields are managed by the ACT application and they are intended to mirror other audit fields being managed by the application in ACT.  

The addition of these two extra fields will allow us to keep track of who published the advisory, when it was published, and if the advisory has ever been published.  
