### PR TITLE
CMS-1613: Add Feature "datesCanSpan2Years" field

### DIFF
--- a/src/cms/database/migrations/2026.05.29T00.00.011-populate-feature-dates-can-span-2years.js
+++ b/src/cms/database/migrations/2026.05.29T00.00.011-populate-feature-dates-can-span-2years.js
@@ -1,0 +1,39 @@
+"use strict";
+
+// feature_id values for park features that can have dates spanning 2 years
+const featureIds = [
+  "41_271", // Cultus Lake / Maple Bay Cabins / All cabins
+  "41_876", // Cultus Lake / Maple Bay day-use area / Picnic area
+  "7_360", // Garibaldi / Red Heather campground / All sites
+  "7_449", // Garibaldi / Taylor Meadows campground / All sites
+  "33_57", // EC Manning / Cambie Creek groupsite / All sites
+  "33_248", // EC Manning / (no area) / Lightning Lake day-use area
+  "5_313", // Mount Assiniboine / Og Lake Campground / All sites
+  "5_263", // Mount Assiniboine / Magog Lake Campground / All sites
+  "5_792", // Mount Assiniboine / Porcupine Campground / All sites
+  "314_476", // Porteau Cove / Porteau Cove walk-in sites / All sites
+  "314_914", // Porteau Cove / Porteau Cove Campground vehicle accessible sites / All sites
+  "409_185", // Ts'ilos Park / Gwe Da Ts'ih Campground / All sites
+];
+
+module.exports = {
+  async up(knex) {
+    // Skip if the table collection table doesn't exist
+    if (!(await knex.schema.hasTable("park_features"))) return;
+
+    // Add the new column if it doesn't exist
+    // Strapi maps datesCanSpan2years to dates_can_span_2_years
+    if (
+      !(await knex.schema.hasColumn("park_features", "dates_can_span_2_years"))
+    ) {
+      await knex.schema.table("park_features", (table) => {
+        table.boolean("dates_can_span_2_years").notNullable().defaultTo(false);
+      });
+    }
+
+    // Update the specified features to have their datesCanSpan2years value set to true
+    await knex("park_features")
+      .whereIn("feature_id", featureIds)
+      .update({ dates_can_span_2_years: true });
+  },
+};

--- a/src/cms/database/migrations/2026.05.29T00.00.011-populate-feature-dates-can-span-2years.js
+++ b/src/cms/database/migrations/2026.05.29T00.00.011-populate-feature-dates-can-span-2years.js
@@ -22,7 +22,7 @@ module.exports = {
     if (!(await knex.schema.hasTable("park_features"))) return;
 
     // Add the new column if it doesn't exist
-    // Strapi maps datesCanSpan2years to dates_can_span_2_years
+    // Strapi maps datesCanSpan2Years to dates_can_span_2_years
     if (
       !(await knex.schema.hasColumn("park_features", "dates_can_span_2_years"))
     ) {
@@ -31,7 +31,7 @@ module.exports = {
       });
     }
 
-    // Update the specified features to have their datesCanSpan2years value set to true
+    // Update the specified features to have their datesCanSpan2Years value set to true
     await knex("park_features")
       .whereIn("feature_id", featureIds)
       .update({ dates_can_span_2_years: true });

--- a/src/cms/database/migrations/2026.05.29T00.00.011-populate-feature-dates-can-span-2years.js
+++ b/src/cms/database/migrations/2026.05.29T00.00.011-populate-feature-dates-can-span-2years.js
@@ -18,7 +18,7 @@ const featureIds = [
 
 module.exports = {
   async up(knex) {
-    // Skip if the table collection table doesn't exist
+    // Skip if the collection table doesn't exist
     if (!(await knex.schema.hasTable("park_features"))) return;
 
     // Add the new column if it doesn't exist

--- a/src/cms/src/api/park-feature/content-types/park-feature/schema.json
+++ b/src/cms/src/api/park-feature/content-types/park-feature/schema.json
@@ -248,6 +248,11 @@
       "target": "api::park-gate.park-gate",
       "mappedBy": "parkFeature"
     },
+    "datesCanSpan2years": {
+      "type": "boolean",
+      "required": true,
+      "default": false
+    },
     "hasDates": {
       "type": "boolean",
       "default": false

--- a/src/cms/src/api/park-feature/content-types/park-feature/schema.json
+++ b/src/cms/src/api/park-feature/content-types/park-feature/schema.json
@@ -248,7 +248,7 @@
       "target": "api::park-gate.park-gate",
       "mappedBy": "parkFeature"
     },
-    "datesCanSpan2years": {
+    "datesCanSpan2Years": {
       "type": "boolean",
       "required": true,
       "default": false


### PR DESCRIPTION
### Jira Ticket:
CMS-1613

### Description:

Part 1 of the multi-part task to allow certain features to bypass some validation rules. This adds a boolean flag field "Dates can span 2 years" to Strapi. The next steps are:
- Add that field to the DOOT db
- Sync that field from Strapi via sync scripts
- Update the validation to check that field and bypass the rules as needed.

I tagged this with 3.1.0 for now but we can change it. It just needs to go to production before the associated DOOT update does.

Instead of the "two start" migration pattern we were using in the past, this creates the new fields in the migration so it only needs to run once. 👍 