### PR TITLE
CMS-1792: Change api page size max limit

### DIFF
--- a/src/cms/config/api.js
+++ b/src/cms/config/api.js
@@ -4,6 +4,6 @@
 module.exports = {
   rest: {
     defaultLimit: 100,
-    maxLimit: 2000,
+    maxLimit: 4000,
   },
 };


### PR DESCRIPTION
### Jira Ticket:
CMS-1792

### Description:
- Increased the Strapi API maximum page size limit from 2,000 to 4,000
- When a user selected "All" rows per page in the frontend, only 2,000 advisories were returned, causing some advisories to be hidden unless the user performed a search
- There are currently 3,070 records in `public-advisory-audit` with `isLatestRevision="true"`, so the maximum limit has been increased to 4,000 to accommodate all current records