### PR TITLE
NOBUG: Fix migrations broken by recent schema updates

### DIFF
--- a/src/cms/database/migrations/2026.03.21T00.00.004a-populate-closed-rst-resources.js
+++ b/src/cms/database/migrations/2026.03.21T00.00.004a-populate-closed-rst-resources.js
@@ -229,12 +229,27 @@ function titleCase(str) {
 module.exports = {
   async up(knex) {
     if (await knex.schema.hasTable("recreation_resources")) {
-      await knex.raw(
-        "DELETE FROM public_advisory_audits WHERE submitted_by = 'Imported'",
-      );
-      await knex.raw(
-        "DELETE FROM public_advisories WHERE submitted_by = 'Imported'",
-      );
+      if (
+        await knex.schema.hasColumn(
+          "public_advisory_audits",
+          "submitted_by_name",
+        )
+      ) {
+        await knex.raw(
+          "DELETE FROM public_advisory_audits WHERE submitted_by_name = 'Imported'",
+        );
+
+        await loadData();
+      }
+
+      if (
+        await knex.schema.hasColumn("public_advisories", "submitted_by_name")
+      ) {
+        await knex.raw(
+          "DELETE FROM public_advisories WHERE submitted_by_name = 'Imported'",
+        );
+      }
+
       await loadData();
     }
   },

--- a/src/cms/database/migrations/2026.05.20T00.00.012-import-standard-messages.js
+++ b/src/cms/database/migrations/2026.05.20T00.00.012-import-standard-messages.js
@@ -110,6 +110,8 @@ const messages = [
 module.exports = {
   async up(knex) {
     if (await knex.schema.hasTable("standard_messages")) {
+      await knex.raw("DELETE FROM standard_messages where precedence >= 19"); // delete existing messages to prevent duplicates on re-run
+
       // create a map of event type names (eventType field) to documentIds
       const eventTypes = await knex("event_types").select(
         "document_id",
@@ -140,6 +142,7 @@ module.exports = {
               precedence,
               description,
               eventType: eventTypeDocId,
+              isActive: true,
             },
           });
       }

--- a/src/cms/database/migrations/2026.05.20T00.00.012-import-standard-messages.js
+++ b/src/cms/database/migrations/2026.05.20T00.00.012-import-standard-messages.js
@@ -110,7 +110,16 @@ const messages = [
 module.exports = {
   async up(knex) {
     if (await knex.schema.hasTable("standard_messages")) {
-      await knex.raw("DELETE FROM standard_messages where precedence >= 19"); // delete existing messages to prevent duplicates on re-run
+      // If precedence 30 already exists, this migration has already imported all rows.
+      const precedence30Exists = await knex("standard_messages")
+        .where({ precedence: 30 })
+        .first();
+      if (precedence30Exists) {
+        strapi.log.info(
+          "Standard messages already imported (precedence 30 exists). Skipping migration.",
+        );
+        return;
+      }
 
       // create a map of event type names (eventType field) to documentIds
       const eventTypes = await knex("event_types").select(


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
This PR fixes two migrations that caused issues when restoring my local dev database with a fresh copy of production. 

|migration|reason|
|--|--|
|`2026.03.21T00.00.004a-populate-closed-rst-resources.js`|`submitted_by` was renamed to `submitted_by_name`|
|`2026.05.20T00.00.012-import-standard-messages.js`|migration was not re-runnable due to a unique constraint and was not setting new records to active|

