### PR TITLE
CMS-1795: Update email triggers and subjects

### DIFF
--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -6,82 +6,196 @@
 
 const { queueAdvisoryEmail } = require("../../../helpers/taskQueue.js");
 
-module.exports = ({ strapi }) => ({
-  expire: async (advisoryStatusMap) => {
-    let expiredAdvisoryCount = 0;
+/**
+ * Adds the advisory headline to the email subject.
+ * @param {string} subject the base subject for the email
+ * @param {object} advisoryData the advisory data
+ * @param {string} advisoryData.title the title of the advisory
+ * @return {string} subject with headline appended if it exists
+ */
+function addHeadlineToSubject(subject, advisoryData) {
+  if (advisoryData.title) {
+    return `${subject}: ${advisoryData.title}`;
+  }
 
-    if (Object.keys(advisoryStatusMap).length > 0) {
-      // fetch advisories to unpublish - public advisory table
-      const advisoryToUnpublish = await strapi
-        .documents("api::public-advisory.public-advisory")
-        .findMany({
-          filters: {
-            expiryDate: {
-              $lte: new Date().toISOString(),
-            },
-            advisoryStatus: advisoryStatusMap["PUB"].id,
-          },
-          populate: "*",
-        });
+  // Return the original subject if no headline exists
+  return subject;
+}
 
-      // delete advisories - public advisory table
-      for (const advisory of advisoryToUnpublish) {
-        strapi.log.info(
-          `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`,
-        );
-        await strapi
+module.exports = ({ strapi }) => {
+  /**
+   * Gets the original creator email for an advisory.
+   * Returns the createdByEmail value from the first corresponding revision in public-advisory-audit.
+   * @param {number} advisoryNumber the advisory number to look up
+   * @returns {Promise<string|undefined>} creator email, if found
+   */
+  async function getCreatorEmail(advisoryNumber) {
+    // Find the original advisory revision to get the submitter email.
+    const advisoryAudit = await strapi
+      .documents("api::public-advisory-audit.public-advisory-audit")
+      .findFirst({
+        filters: {
+          advisoryNumber,
+          revisionNumber: 1,
+        },
+        fields: ["createdByEmail"],
+      });
+
+    return advisoryAudit?.createdByEmail;
+  }
+
+  return {
+    expire: async (advisoryStatusMap) => {
+      let expiredAdvisoryCount = 0;
+
+      if (Object.keys(advisoryStatusMap).length > 0) {
+        // fetch advisories to unpublish - public advisory table
+        const advisoryToUnpublish = await strapi
           .documents("api::public-advisory.public-advisory")
-          .update({
-            documentId: advisory.documentId,
-            data: {
-              publishedAt: null,
+          .findMany({
+            filters: {
+              expiryDate: {
+                $lte: new Date().toISOString(),
+              },
+              advisoryStatus: advisoryStatusMap["PUB"].id,
             },
-          })
-          .then(async (advisory) => {
-            expiredAdvisoryCount++;
-            await queueAdvisoryEmail(
-              "Expired advisory removed",
-              "An expired advisory was removed",
-              advisory.advisoryNumber,
-              "public-advisory-audit::services::scheduling::expire()",
-            );
-          })
-          .catch((error) => {
-            strapi.log.error(
-              `error updating public-advisory #${advisory.advisoryNumber}`,
-              error,
-            );
+            populate: "*",
           });
-      }
 
-      // unpublish advisories - audit table
-      for (const advisory of advisoryToUnpublish) {
-        const advisoryAudit = await strapi
+        // delete advisories - public advisory table
+        for (const advisory of advisoryToUnpublish) {
+          strapi.log.info(
+            `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`,
+          );
+          await strapi
+            .documents("api::public-advisory.public-advisory")
+            .update({
+              documentId: advisory.documentId,
+              data: {
+                publishedAt: null,
+              },
+            })
+            .then(async (advisory) => {
+              expiredAdvisoryCount++;
+
+              const subject = addHeadlineToSubject(
+                "Expired advisory / closure was removed",
+                advisory,
+              );
+
+              // Find the creator email from the original advisory-audit record
+              const creatorEmail = await getCreatorEmail(
+                advisory.advisoryNumber,
+              );
+
+              await queueAdvisoryEmail(
+                subject,
+                "An expired advisory was removed",
+                advisory.advisoryNumber,
+                "public-advisory-audit::services::scheduling::expire()",
+                creatorEmail ? [creatorEmail] : [],
+              );
+            })
+            .catch((error) => {
+              strapi.log.error(
+                `error updating public-advisory #${advisory.advisoryNumber}`,
+                error,
+              );
+            });
+        }
+
+        // unpublish advisories - audit table
+        for (const advisory of advisoryToUnpublish) {
+          const advisoryAudit = await strapi
+            .documents("api::public-advisory-audit.public-advisory-audit")
+            .findMany({
+              filters: {
+                advisoryNumber: advisory.advisoryNumber,
+                isLatestRevision: true,
+              },
+            });
+          if (advisoryAudit.length) {
+            strapi.log.info(
+              `setting public-advisory-audit to unpublished [advisoryNumber:${advisory.advisoryNumber}]`,
+            );
+            await strapi
+              .documents("api::public-advisory-audit.public-advisory-audit")
+              .update({
+                documentId: advisoryAudit[0].documentId,
+                data: {
+                  publishedAt: new Date(),
+                  advisoryStatus: {
+                    id: advisoryStatusMap["UNP"].id,
+                  },
+                  modifiedByName: "system",
+                  modifiedDate: new Date(),
+                  unpublishedByName: "system",
+                  unpublishedDate: new Date(),
+                },
+              })
+              .catch((error) => {
+                strapi.log.error(
+                  `error updating public-advisory-audit #${advisory.advisoryNumber}`,
+                  error,
+                );
+              });
+          }
+        }
+      }
+      return expiredAdvisoryCount;
+    },
+
+    publish: async (advisoryStatusMap) => {
+      let publishedAdvisoryCount = 0;
+
+      if (Object.keys(advisoryStatusMap).length > 0) {
+        // fetch advisories to publish - audit table
+        const scheduledAdvisoryToPublishAudit = await strapi
           .documents("api::public-advisory-audit.public-advisory-audit")
           .findMany({
             filters: {
-              advisoryNumber: advisory.advisoryNumber,
               isLatestRevision: true,
+              advisoryDate: {
+                $lte: new Date().toISOString(),
+              },
+              advisoryStatus: advisoryStatusMap["SCH"].id,
             },
+            populate: "*",
           });
-        if (advisoryAudit.length) {
+
+        // publish advisories - audit table
+        for (const advisory of scheduledAdvisoryToPublishAudit) {
           strapi.log.info(
-            `setting public-advisory-audit to unpublished [advisoryNumber:${advisory.advisoryNumber}]`,
+            `publishing scheduled public-advisory-audit [advisoryNumber:${advisory.advisoryNumber}]`,
           );
           await strapi
             .documents("api::public-advisory-audit.public-advisory-audit")
             .update({
-              documentId: advisoryAudit[0].documentId,
+              documentId: advisory.documentId,
               data: {
-                publishedAt: new Date(),
+                publishedAt: advisory.advisoryDate,
                 advisoryStatus: {
-                  id: advisoryStatusMap["UNP"].id,
+                  id: advisoryStatusMap["PUB"].id,
                 },
                 modifiedByName: "system",
                 modifiedDate: new Date(),
-                unpublishedByName: "system",
-                unpublishedDate: new Date(),
               },
+            })
+            .then(async (advisory) => {
+              publishedAdvisoryCount++;
+
+              const subject = addHeadlineToSubject(
+                "Scheduled advisory / closure posted",
+                advisory,
+              );
+
+              await queueAdvisoryEmail(
+                subject,
+                "A scheduled advisory was posted",
+                advisory.advisoryNumber,
+                "public-advisory-audit::services::scheduling::publish()",
+                advisory.createdByEmail ? [advisory.createdByEmail] : [],
+              );
             })
             .catch((error) => {
               strapi.log.error(
@@ -91,166 +205,127 @@ module.exports = ({ strapi }) => ({
             });
         }
       }
-    }
-    return expiredAdvisoryCount;
-  },
+      return publishedAdvisoryCount;
+    },
 
-  publish: async (advisoryStatusMap) => {
-    let publishedAdvisoryCount = 0;
+    expiringSoon: async (advisoryStatusMap) => {
+      // Use a 3-minute window 7 days before expiry to avoid missing advisories when
+      // cron timing drifts. Duplicate emails are throttled in scheduler email logic
+      // (THROTTLE_MINUTES), so overlap won't send multiple emails.
+      const today = new Date();
+      const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+      const rangeStart = new Date(nextWeek.getTime() - 60 * 1000).toISOString();
+      const rangeEnd = new Date(nextWeek.getTime() + 120 * 1000).toISOString();
 
-    if (Object.keys(advisoryStatusMap).length > 0) {
-      // fetch advisories to publish - audit table
-      const scheduledAdvisoryToPublishAudit = await strapi
-        .documents("api::public-advisory-audit.public-advisory-audit")
+      const expiringSoon = await strapi
+        .documents("api::public-advisory.public-advisory")
         .findMany({
           filters: {
-            isLatestRevision: true,
-            advisoryDate: {
-              $lte: new Date().toISOString(),
-            },
-            advisoryStatus: advisoryStatusMap["SCH"].id,
+            expiryDate: { $gte: rangeStart, $lte: rangeEnd },
           },
-          populate: "*",
         });
 
-      // publish advisories - audit table
-      for (const advisory of scheduledAdvisoryToPublishAudit) {
+      for (const advisory of expiringSoon) {
         strapi.log.info(
-          `publishing scheduled public-advisory-audit [advisoryNumber:${advisory.advisoryNumber}]`,
+          `advisory expiring soon [advisoryNumber:${advisory.advisoryNumber}]`,
         );
-        await strapi
-          .documents("api::public-advisory-audit.public-advisory-audit")
-          .update({
-            documentId: advisory.documentId,
-            data: {
-              publishedAt: advisory.advisoryDate,
-              advisoryStatus: {
-                id: advisoryStatusMap["PUB"].id,
+
+        const subject = addHeadlineToSubject(
+          "Advisory / closure expiring soon",
+          advisory,
+        );
+
+        // Find the creator email from the original advisory-audit record
+        const creatorEmail = await getCreatorEmail(advisory.advisoryNumber);
+
+        await queueAdvisoryEmail(
+          subject,
+          "This advisory will be expiring in one week",
+          advisory.advisoryNumber,
+          "public-advisory::services::scheduling::expiringSoon()",
+          creatorEmail ? [creatorEmail] : [],
+        );
+      }
+      return expiringSoon.length;
+    },
+
+    publishingSoon: async (advisoryStatusMap) => {
+      let totalPublishingSoon = 0;
+
+      if (Object.keys(advisoryStatusMap).length > 0) {
+        const reminders = [
+          { daysBefore: 7, message: "This advisory will go live in 7 days" },
+        ];
+        for (const reminder of reminders) {
+          const today = new Date();
+          const reminderDate = new Date(
+            today.setTime(
+              today.getTime() + reminder.daysBefore * 24 * 60 * 60 * 1000,
+            ),
+          );
+          const rangeStart = new Date(
+            reminderDate.setTime(reminderDate.getTime() - 60 * 1000),
+          ).toISOString();
+          const rangeEnd = new Date(
+            reminderDate.setTime(reminderDate.getTime() + 120 * 1000),
+          ).toISOString();
+          const publishingSoon = await strapi
+            .documents("api::public-advisory-audit.public-advisory-audit")
+            .findMany({
+              filters: {
+                $and: [
+                  {
+                    isLatestRevision: true,
+                  },
+                  {
+                    advisoryDate: { $gte: rangeStart },
+                  },
+                  {
+                    advisoryDate: { $lte: rangeEnd },
+                  },
+                  {
+                    advisoryStatus: advisoryStatusMap["SCH"].id,
+                  },
+                ],
               },
-              modifiedByName: "system",
-              modifiedDate: new Date(),
-            },
-          })
-          .then(async (advisory) => {
-            publishedAdvisoryCount++;
+            });
+          for (const advisory of publishingSoon) {
+            strapi.log.info(
+              `advisory going live soon [advisoryNumber:${advisory.advisoryNumber}]`,
+            );
+
+            const subject = addHeadlineToSubject(
+              "Advisory / closure going live soon",
+              advisory,
+            );
+
             await queueAdvisoryEmail(
-              "Scheduled advisory posted",
-              "A scheduled advisory was posted",
+              subject,
+              reminder.message,
               advisory.advisoryNumber,
-              "public-advisory-audit::services::scheduling::publish()",
+              "public-advisory-audit::services::scheduling::publishingSoon()",
+              advisory.createdByEmail ? [advisory.createdByEmail] : [],
             );
-          })
-          .catch((error) => {
-            strapi.log.error(
-              `error updating public-advisory-audit #${advisory.advisoryNumber}`,
-              error,
-            );
-          });
-      }
-    }
-    return publishedAdvisoryCount;
-  },
-
-  expiringSoon: async (advisoryStatusMap) => {
-    // Use a 3-minute window 7 days before expiry to avoid missing advisories when
-    // cron timing drifts. Duplicate emails are throttled in scheduler email logic
-    // (THROTTLE_MINUTES), so overlap won't send multiple emails.
-    const today = new Date();
-    const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
-    const rangeStart = new Date(nextWeek.getTime() - 60 * 1000).toISOString();
-    const rangeEnd = new Date(nextWeek.getTime() + 120 * 1000).toISOString();
-
-    const expiringSoon = await strapi
-      .documents("api::public-advisory.public-advisory")
-      .findMany({
-        filters: {
-          expiryDate: { $gte: rangeStart, $lte: rangeEnd },
-        },
-      });
-    for (const advisory of expiringSoon) {
-      strapi.log.info(
-        `advisory expiring soon [advisoryNumber:${advisory.advisoryNumber}]`,
-      );
-      await queueAdvisoryEmail(
-        "Advisory expiring soon",
-        "This advisory will be expiring in one week",
-        advisory.advisoryNumber,
-        "public-advisory::services::scheduling::expiringSoon()",
-      );
-    }
-    return expiringSoon.length;
-  },
-
-  publishingSoon: async (advisoryStatusMap) => {
-    let totalPublishingSoon = 0;
-
-    if (Object.keys(advisoryStatusMap).length > 0) {
-      const reminders = [
-        { daysBefore: 5, message: "This advisory will go live in 5 days" },
-        { daysBefore: 2, message: "This advisory will go live in 2 days" },
-      ];
-      for (const reminder of reminders) {
-        const today = new Date();
-        const reminderDate = new Date(
-          today.setTime(
-            today.getTime() + reminder.daysBefore * 24 * 60 * 60 * 1000,
-          ),
-        );
-        const rangeStart = new Date(
-          reminderDate.setTime(reminderDate.getTime() - 60 * 1000),
-        ).toISOString();
-        const rangeEnd = new Date(
-          reminderDate.setTime(reminderDate.getTime() + 120 * 1000),
-        ).toISOString();
-        const publishingSoon = await strapi
-          .documents("api::public-advisory-audit.public-advisory-audit")
-          .findMany({
-            filters: {
-              $and: [
-                {
-                  isLatestRevision: true,
-                },
-                {
-                  advisoryDate: { $gte: rangeStart },
-                },
-                {
-                  advisoryDate: { $lte: rangeEnd },
-                },
-                {
-                  advisoryStatus: advisoryStatusMap["SCH"].id,
-                },
-              ],
-            },
-          });
-        for (const advisory of publishingSoon) {
-          strapi.log.info(
-            `advisory going live soon [advisoryNumber:${advisory.advisoryNumber}]`,
-          );
-          await queueAdvisoryEmail(
-            "Advisory going live soon",
-            reminder.message,
-            advisory.advisoryNumber,
-            "public-advisory-audit::services::scheduling::publishingSoon()",
-          );
+          }
+          totalPublishingSoon += publishingSoon.length;
         }
-        totalPublishingSoon += publishingSoon.length;
       }
-    }
-    return totalPublishingSoon;
-  },
+      return totalPublishingSoon;
+    },
 
-  getAdvisoryStatusMap: async () => {
-    // fetch advisory statuses
-    const advisoryStatus = await strapi
-      .documents("api::advisory-status.advisory-status")
-      .findMany({
-        limit: -1,
-        populate: "*",
-      });
-    const advisoryStatusMap = {};
-    for (const a of advisoryStatus) {
-      advisoryStatusMap[a.code] = a;
-    }
-    return advisoryStatusMap;
-  },
-});
+    getAdvisoryStatusMap: async () => {
+      // fetch advisory statuses
+      const advisoryStatus = await strapi
+        .documents("api::advisory-status.advisory-status")
+        .findMany({
+          limit: -1,
+          populate: "*",
+        });
+      const advisoryStatusMap = {};
+      for (const a of advisoryStatus) {
+        advisoryStatusMap[a.code] = a;
+      }
+      return advisoryStatusMap;
+    },
+  };
+};

--- a/src/cms/src/helpers/taskQueue.js
+++ b/src/cms/src/helpers/taskQueue.js
@@ -84,6 +84,7 @@ module.exports = {
     title,
     advisoryNumber,
     triggerInfo,
+    additionalRecipients = [],
   ) {
     if (!subject || !title || !advisoryNumber) {
       return;
@@ -111,6 +112,7 @@ module.exports = {
               title: title,
               advisoryNumber: advisoryNumber,
               triggeredBy: triggerInfo,
+              additionalRecipients: additionalRecipients,
             },
           },
         });

--- a/src/scheduler/email-alerts/scripts/mailer.js
+++ b/src/scheduler/email-alerts/scripts/mailer.js
@@ -1,6 +1,20 @@
 const nodemailer = require("nodemailer");
 
-exports.send = async function (subject, body, summary, fromName) {
+/**
+ * Sends an email to the provided list of recipients.
+ * @param {string} subject email subject
+ * @param {string} body rendered HTML body
+ * @param {string} summary plain-text summary/body
+ * @param {string} fromName display name for sender
+ * @param {string[]} recipients full list of recipients
+ */
+exports.send = async function (
+  subject,
+  body,
+  summary,
+  fromName,
+  recipients,
+) {
   const transporter = nodemailer.createTransport({
     host: process.env.EMAIL_SERVER,
     port: process.env.EMAIL_PORT,
@@ -13,7 +27,7 @@ exports.send = async function (subject, body, summary, fromName) {
 
   await transporter.sendMail({
     from: `${fromName} <${process.env.EMAIL_SENDER}>`,
-    to: process.env.EMAIL_RECIPIENT,
+    to: recipients,
     subject: subject,
     text: summary,
     html: body,

--- a/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
+++ b/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
@@ -114,7 +114,7 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
 
       if (scriptKeySpecified("emailsend") || noCommandLineArgs()) {
         if (process.env.EMAIL_ENABLED.toLowerCase() !== "false") {
-          const subject = `${emailData.subject}: ${emailData.data.title}`;
+          const subject = emailData.subject;
           const summary = emailData.data.description.replace(
             /(<([^>]+)>)/gi,
             "",
@@ -123,7 +123,15 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
             process.env.BCPARKS_ENVIRONMENT.toLowerCase() === "prod"
               ? "Staff Web Portal"
               : process.env.BCPARKS_ENVIRONMENT.toUpperCase();
-          await send(subject, htmlMessageBody, summary, fromName);
+
+          // Build recipients list for this email
+          const recipients = [
+            // Split EMAIL_RECIPIENT because it can be a comma-separated list
+            ...(process.env.EMAIL_RECIPIENT || "").split(",").filter(Boolean),
+            ...(emailInfo.additionalRecipients ?? []),
+          ].filter(Boolean);
+
+          await send(subject, htmlMessageBody, summary, fromName, recipients);
         }
       }
     }

--- a/src/scheduler/email-alerts/scripts/sendParkNamesEmails.js
+++ b/src/scheduler/email-alerts/scripts/sendParkNamesEmails.js
@@ -45,11 +45,17 @@ exports.sendParkNamesEmails = async function () {
       if (process.env.EMAIL_ENABLED.toLowerCase() !== "false") {
         const subject = `A Protected Area Name Was Changed`;
         const summary = `${jsonData.oldName} was changed to ${jsonData.newName}`;
+        // Split EMAIL_RECIPIENT because it can be a comma-separated list
+        const recipients = (process.env.EMAIL_RECIPIENT || "")
+          .split(",")
+          .filter(Boolean);
         const fromName =
           process.env.BCPARKS_ENVIRONMENT.toLowerCase() === "prod"
             ? "Staff Web Portal"
             : process.env.BCPARKS_ENVIRONMENT.toUpperCase();
-        await send(subject, htmlMessageBody, summary, fromName);
+        await send(subject, htmlMessageBody, summary, fromName, [
+          ...recipients,
+        ]);
       }
     }
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1795

### Description:

Changes to the email scheduler service, in preparation for updating some emails and adding a couple of new ones in future tickets.

- Selectively add the advisory headline to the email subject instead of automatically doing it every time (some upcoming emails won't include the headline)
- Updated several email subjects to include mention of closures
- Added "additional recipients" support to add more "to" email addresses for some messages. This is used to include the original poster on several of the emails.

Updated email trigger conditions:
"Expiring soon" - sends out 1 week before expiry date (previously was 2 and 5 days before)

# For discussion
The task also mentions a few things we might want to change or implement as part of this ticket (or its related tickets)

> Need to ensure the dev and test environments do not spam Parks staff with emails.
> Perhaps via whitelists.
> Do not include emails in public API (should only be in public-advisory-audit).
