### PR TITLE
NOBUG: Update unpublishedByName when advisory gets expired

### DIFF
--- a/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
+++ b/src/cms/src/api/public-advisory-audit/content-types/public-advisory-audit/schema.json
@@ -88,9 +88,6 @@
     "expiryDate": {
       "type": "datetime"
     },
-    "removalDate": {
-      "type": "datetime"
-    },
     "updatedDate": {
       "type": "datetime"
     },

--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -77,7 +77,6 @@ module.exports = ({ strapi }) => ({
                 advisoryStatus: {
                   id: advisoryStatusMap["UNP"].id,
                 },
-                removalDate: new Date(),
                 modifiedByName: "system",
                 modifiedDate: new Date(),
                 unpublishedByName: "system",
@@ -130,7 +129,6 @@ module.exports = ({ strapi }) => ({
               },
               modifiedByName: "system",
               modifiedDate: new Date(),
-              removalDate: null,
             },
           })
           .then(async (advisory) => {

--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -27,7 +27,7 @@ module.exports = ({ strapi }) => ({
       // delete advisories - public advisory table
       for (const advisory of advisoryToUnpublish) {
         strapi.log.info(
-          `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`,
+          `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`
         );
         await strapi
           .documents("api::public-advisory.public-advisory")
@@ -43,13 +43,13 @@ module.exports = ({ strapi }) => ({
               "Expired advisory removed",
               "An expired advisory was removed",
               advisory.advisoryNumber,
-              "public-advisory-audit::services::scheduling::expire()",
+              "public-advisory-audit::services::scheduling::expire()"
             );
           })
           .catch((error) => {
             strapi.log.error(
               `error updating public-advisory #${advisory.advisoryNumber}`,
-              error,
+              error
             );
           });
       }
@@ -66,7 +66,7 @@ module.exports = ({ strapi }) => ({
           });
         if (advisoryAudit.length) {
           strapi.log.info(
-            `setting public-advisory-audit to unpublished [advisoryNumber:${advisory.advisoryNumber}]`,
+            `setting public-advisory-audit to unpublished [advisoryNumber:${advisory.advisoryNumber}]`
           );
           await strapi
             .documents("api::public-advisory-audit.public-advisory-audit")
@@ -80,12 +80,14 @@ module.exports = ({ strapi }) => ({
                 removalDate: new Date(),
                 modifiedByName: "system",
                 modifiedDate: new Date(),
+                unpublishedByName: "system",
+                unpublishedDate: new Date(),
               },
             })
             .catch((error) => {
               strapi.log.error(
                 `error updating public-advisory-audit #${advisory.advisoryNumber}`,
-                error,
+                error
               );
             });
         }
@@ -115,7 +117,7 @@ module.exports = ({ strapi }) => ({
       // publish advisories - audit table
       for (const advisory of scheduledAdvisoryToPublishAudit) {
         strapi.log.info(
-          `publishing scheduled public-advisory-audit [advisoryNumber:${advisory.advisoryNumber}]`,
+          `publishing scheduled public-advisory-audit [advisoryNumber:${advisory.advisoryNumber}]`
         );
         await strapi
           .documents("api::public-advisory-audit.public-advisory-audit")
@@ -137,13 +139,13 @@ module.exports = ({ strapi }) => ({
               "Scheduled advisory posted",
               "A scheduled advisory was posted",
               advisory.advisoryNumber,
-              "public-advisory-audit::services::scheduling::publish()",
+              "public-advisory-audit::services::scheduling::publish()"
             );
           })
           .catch((error) => {
             strapi.log.error(
               `error updating public-advisory-audit #${advisory.advisoryNumber}`,
-              error,
+              error
             );
           });
       }
@@ -169,13 +171,13 @@ module.exports = ({ strapi }) => ({
       });
     for (const advisory of expiringSoon) {
       strapi.log.info(
-        `advisory expiring soon [advisoryNumber:${advisory.advisoryNumber}]`,
+        `advisory expiring soon [advisoryNumber:${advisory.advisoryNumber}]`
       );
       await queueAdvisoryEmail(
         "Advisory expiring soon",
         "This advisory will be expiring in one week",
         advisory.advisoryNumber,
-        "public-advisory::services::scheduling::expiringSoon()",
+        "public-advisory::services::scheduling::expiringSoon()"
       );
     }
     return expiringSoon.length;
@@ -193,14 +195,14 @@ module.exports = ({ strapi }) => ({
         const today = new Date();
         const reminderDate = new Date(
           today.setTime(
-            today.getTime() + reminder.daysBefore * 24 * 60 * 60 * 1000,
-          ),
+            today.getTime() + reminder.daysBefore * 24 * 60 * 60 * 1000
+          )
         );
         const rangeStart = new Date(
-          reminderDate.setTime(reminderDate.getTime() - 60 * 1000),
+          reminderDate.setTime(reminderDate.getTime() - 60 * 1000)
         ).toISOString();
         const rangeEnd = new Date(
-          reminderDate.setTime(reminderDate.getTime() + 120 * 1000),
+          reminderDate.setTime(reminderDate.getTime() + 120 * 1000)
         ).toISOString();
         const publishingSoon = await strapi
           .documents("api::public-advisory-audit.public-advisory-audit")
@@ -224,13 +226,13 @@ module.exports = ({ strapi }) => ({
           });
         for (const advisory of publishingSoon) {
           strapi.log.info(
-            `advisory going live soon [advisoryNumber:${advisory.advisoryNumber}]`,
+            `advisory going live soon [advisoryNumber:${advisory.advisoryNumber}]`
           );
           await queueAdvisoryEmail(
             "Advisory going live soon",
             reminder.message,
             advisory.advisoryNumber,
-            "public-advisory-audit::services::scheduling::publishingSoon()",
+            "public-advisory-audit::services::scheduling::publishingSoon()"
           );
         }
         totalPublishingSoon += publishingSoon.length;

--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -27,7 +27,7 @@ module.exports = ({ strapi }) => ({
       // delete advisories - public advisory table
       for (const advisory of advisoryToUnpublish) {
         strapi.log.info(
-          `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`
+          `unpublishing public-advisory [advisoryNumber:${advisory.advisoryNumber}]`,
         );
         await strapi
           .documents("api::public-advisory.public-advisory")
@@ -43,13 +43,13 @@ module.exports = ({ strapi }) => ({
               "Expired advisory removed",
               "An expired advisory was removed",
               advisory.advisoryNumber,
-              "public-advisory-audit::services::scheduling::expire()"
+              "public-advisory-audit::services::scheduling::expire()",
             );
           })
           .catch((error) => {
             strapi.log.error(
               `error updating public-advisory #${advisory.advisoryNumber}`,
-              error
+              error,
             );
           });
       }
@@ -66,7 +66,7 @@ module.exports = ({ strapi }) => ({
           });
         if (advisoryAudit.length) {
           strapi.log.info(
-            `setting public-advisory-audit to unpublished [advisoryNumber:${advisory.advisoryNumber}]`
+            `setting public-advisory-audit to unpublished [advisoryNumber:${advisory.advisoryNumber}]`,
           );
           await strapi
             .documents("api::public-advisory-audit.public-advisory-audit")
@@ -87,7 +87,7 @@ module.exports = ({ strapi }) => ({
             .catch((error) => {
               strapi.log.error(
                 `error updating public-advisory-audit #${advisory.advisoryNumber}`,
-                error
+                error,
               );
             });
         }
@@ -117,7 +117,7 @@ module.exports = ({ strapi }) => ({
       // publish advisories - audit table
       for (const advisory of scheduledAdvisoryToPublishAudit) {
         strapi.log.info(
-          `publishing scheduled public-advisory-audit [advisoryNumber:${advisory.advisoryNumber}]`
+          `publishing scheduled public-advisory-audit [advisoryNumber:${advisory.advisoryNumber}]`,
         );
         await strapi
           .documents("api::public-advisory-audit.public-advisory-audit")
@@ -139,13 +139,13 @@ module.exports = ({ strapi }) => ({
               "Scheduled advisory posted",
               "A scheduled advisory was posted",
               advisory.advisoryNumber,
-              "public-advisory-audit::services::scheduling::publish()"
+              "public-advisory-audit::services::scheduling::publish()",
             );
           })
           .catch((error) => {
             strapi.log.error(
               `error updating public-advisory-audit #${advisory.advisoryNumber}`,
-              error
+              error,
             );
           });
       }
@@ -171,13 +171,13 @@ module.exports = ({ strapi }) => ({
       });
     for (const advisory of expiringSoon) {
       strapi.log.info(
-        `advisory expiring soon [advisoryNumber:${advisory.advisoryNumber}]`
+        `advisory expiring soon [advisoryNumber:${advisory.advisoryNumber}]`,
       );
       await queueAdvisoryEmail(
         "Advisory expiring soon",
         "This advisory will be expiring in one week",
         advisory.advisoryNumber,
-        "public-advisory::services::scheduling::expiringSoon()"
+        "public-advisory::services::scheduling::expiringSoon()",
       );
     }
     return expiringSoon.length;
@@ -195,14 +195,14 @@ module.exports = ({ strapi }) => ({
         const today = new Date();
         const reminderDate = new Date(
           today.setTime(
-            today.getTime() + reminder.daysBefore * 24 * 60 * 60 * 1000
-          )
+            today.getTime() + reminder.daysBefore * 24 * 60 * 60 * 1000,
+          ),
         );
         const rangeStart = new Date(
-          reminderDate.setTime(reminderDate.getTime() - 60 * 1000)
+          reminderDate.setTime(reminderDate.getTime() - 60 * 1000),
         ).toISOString();
         const rangeEnd = new Date(
-          reminderDate.setTime(reminderDate.getTime() + 120 * 1000)
+          reminderDate.setTime(reminderDate.getTime() + 120 * 1000),
         ).toISOString();
         const publishingSoon = await strapi
           .documents("api::public-advisory-audit.public-advisory-audit")
@@ -226,13 +226,13 @@ module.exports = ({ strapi }) => ({
           });
         for (const advisory of publishingSoon) {
           strapi.log.info(
-            `advisory going live soon [advisoryNumber:${advisory.advisoryNumber}]`
+            `advisory going live soon [advisoryNumber:${advisory.advisoryNumber}]`,
           );
           await queueAdvisoryEmail(
             "Advisory going live soon",
             reminder.message,
             advisory.advisoryNumber,
-            "public-advisory-audit::services::scheduling::publishingSoon()"
+            "public-advisory-audit::services::scheduling::publishingSoon()",
           );
         }
         totalPublishingSoon += publishingSoon.length;


### PR DESCRIPTION
### Jira Ticket:
None

### Description:
- Updated `unpublishedByName: "system"` and `unpublishedDate` when an advisory gets unpublished automatically because of `expiryDate`
- Removed `removalDate`
