### PR TITLE
CMS-1827: Create public-advisory-audits/scheduled-and-published endpoint

### DIFF
--- a/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
+++ b/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
@@ -35,7 +35,7 @@ module.exports = createCoreController(
       const { filters, sort, populate, fields, pagination } = ctx.query;
 
       // Get all the published public advisories from the projection table.
-      // We need to do it this way because it's possible for the lastest revision
+      // We need to do it this way because it's possible for the latest revision
       // of a public advisory audit to be newer than the published revision.
       const published = await strapi
         .documents("api::public-advisory.public-advisory")
@@ -73,6 +73,11 @@ module.exports = createCoreController(
           }
         : publishedOrScheduledFilter;
 
+      // use a very large pageSize to force the configured rest.maxLimit cap.
+      const paginationOption = !pagination
+        ? { pagination: { pageSize: Number.MAX_SAFE_INTEGER } }
+        : { pagination };
+
       // query the audit table with the merged filters and all other query params
       const { results, pagination: paginationResult } = await strapi
         .service("api::public-advisory-audit.public-advisory-audit")
@@ -80,7 +85,7 @@ module.exports = createCoreController(
           filters: mergedFilters,
           sort,
           populate,
-          pagination,
+          ...paginationOption,
           fields,
           status: "published",
         });

--- a/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
+++ b/src/cms/src/api/public-advisory-audit/controllers/public-advisory-audit.js
@@ -3,7 +3,6 @@
  * public-advisory-audit controller
  */
 
-const { sanitize } = require("@strapi/utils");
 const { createCoreController } = require("@strapi/strapi").factories;
 
 module.exports = createCoreController(
@@ -27,6 +26,70 @@ module.exports = createCoreController(
       }
 
       return this.sanitizeOutput(entities, ctx);
+    },
+    /**
+     * Retrieves all public advisory audits that are either scheduled or published.
+     * This is used for synchronization with RST RecSpace.
+     **/
+    async scheduledAndPublished(ctx) {
+      const { filters, sort, populate, fields, pagination } = ctx.query;
+
+      // Get all the published public advisories from the projection table.
+      // We need to do it this way because it's possible for the lastest revision
+      // of a public advisory audit to be newer than the published revision.
+      const published = await strapi
+        .documents("api::public-advisory.public-advisory")
+        .findMany({
+          fields: ["advisoryNumber", "revisionNumber"],
+        });
+
+      // build filters to join with the audit table
+      const publishedPairFilters = published
+        .filter(
+          ({ advisoryNumber, revisionNumber }) =>
+            advisoryNumber && revisionNumber,
+        )
+        .map((record) => ({
+          advisoryNumber: record.advisoryNumber,
+          revisionNumber: record.revisionNumber,
+        }));
+
+      // filter for records matching the join map and
+      // all scheduled records that are the latest revision
+      const publishedOrScheduledFilter = {
+        $or: [
+          ...publishedPairFilters,
+          {
+            advisoryStatus: { code: "SCH" },
+            isLatestRevision: true,
+          },
+        ],
+      };
+
+      // add additional filters from the querystring if they exist
+      const mergedFilters = filters
+        ? {
+            $and: [publishedOrScheduledFilter, filters],
+          }
+        : publishedOrScheduledFilter;
+
+      // query the audit table with the merged filters and all other query params
+      const { results, pagination: paginationResult } = await strapi
+        .service("api::public-advisory-audit.public-advisory-audit")
+        .find({
+          filters: mergedFilters,
+          sort,
+          populate,
+          pagination,
+          fields,
+          status: "published",
+        });
+
+      const sanitizedEntities = await this.sanitizeOutput(results, ctx);
+
+      return this.transformResponse(sanitizedEntities, {
+        pagination: paginationResult,
+      });
     },
   }),
 );

--- a/src/cms/src/api/public-advisory-audit/routes/custom.js
+++ b/src/cms/src/api/public-advisory-audit/routes/custom.js
@@ -5,5 +5,10 @@ module.exports = {
       path: "/public-advisory-audits/history/:advisoryNumber",
       handler: "public-advisory-audit.history",
     },
+    {
+      method: "GET",
+      path: "/public-advisory-audits/scheduled-and-published",
+      handler: "public-advisory-audit.scheduledAndPublished",
+    },
   ],
 };


### PR DESCRIPTION
### Jira Ticket:
CMS-1827

### Description:

Added a scheduledAndPublished action to the public-advisory-audit controller. It returns all published audit rows matched by advisoryNumber/revisionNumber pair against the live advisories table, plus any SCH rows where isLatestRevision is true. Caller-supplied querystring filters are merged with a logical AND, and standard Strapi query params (fields, populate, sort, pagination) are fully supported.

RecSpace and Team Orca need a reliable way to pull currently published and scheduled advisory revisions from the audit table. The pair-match approach is necessary because the latest audit revision may be newer than the published one.

Replicating this logic via the standard Strapi REST API would require multiple round trips — first to fetch the live published advisories, then to query the audit table per pair — along with client-side merging and deduplication. The custom endpoint handles all of this server-side in a single call.

e.g. http://localhost:1337/api/public-advisory-audits/scheduled-and-published?populate[0]=accessStatus&populate[1]=eventType&populate[2]=advisoryStatus&populate[3]=recreationResources&populate[4]=urgency&filters[recreationResources][id][$notNull]=true

Note: By default the new endpoint will be private. It will need to be made accessible to the authenticated role via a post deployment task. 