### PR TITLE
CMS-1807: Track unpublishing metadata on previous version

### DIFF
--- a/src/cms/database/migrations/2026.06.15T00.00.017-unpublished-backfill.js
+++ b/src/cms/database/migrations/2026.06.15T00.00.017-unpublished-backfill.js
@@ -1,0 +1,66 @@
+"use strict";
+
+/*
+Backfill audit metadata for unpublished advisories.
+
+For advisories whose latest revision is UNP, copy audit metadata from that latest
+UNP revision to the previous revision (revision_number - 1), but only when the
+previous revision is PUB.
+
+Source values on the UNP revision:
+- published_by_name (fallback: modified_by_name)
+- published_date    (fallback: modified_date)
+
+Reason:
+Unpublish audit metadata is now stored on the previous published revision, which
+is the record that actually transitioned from published to unpublished.
+*/
+
+module.exports = {
+  async up(knex) {
+    // check if the advisories table exists and if it contains an "is_published" column
+    if (
+      (await knex.schema.hasTable("public_advisory_audits")) &&
+      (await knex.schema.hasColumn(
+        "public_advisory_audits",
+        "unpublished_date",
+      ))
+    ) {
+      await knex.raw(`
+WITH latest_unpublished AS (
+    SELECT
+        paa.advisory_number,
+        MAX(paa.revision_number) AS revision_number
+    FROM public_advisory_audits paa
+    JOIN public_advisory_audits_advisory_status_lnk paaasl
+        ON paaasl.public_advisory_audit_id = paa.id
+    JOIN advisory_statuses t
+        ON t.id = paaasl.advisory_status_id
+    WHERE
+        paa.is_latest_revision = true
+        AND t.code = 'UNP'
+    GROUP BY paa.advisory_number
+    HAVING MAX(paa.revision_number) > 1
+) UPDATE public_advisory_audits prev
+SET
+    published_by_name = COALESCE(curr.published_by_name, curr.modified_by_name),
+    published_date    = COALESCE(curr.published_date, curr.modified_date)
+FROM latest_unpublished lu
+JOIN public_advisory_audits curr
+    ON curr.advisory_number = lu.advisory_number
+   AND curr.revision_number = lu.revision_number
+WHERE
+    prev.advisory_number = lu.advisory_number
+    AND prev.revision_number = lu.revision_number - 1
+    AND (
+        SELECT s.code
+        FROM public_advisory_audits_advisory_status_lnk lnk
+        JOIN advisory_statuses s
+            ON s.id = lnk.advisory_status_id
+        WHERE lnk.public_advisory_audit_id = prev.id
+        LIMIT 1
+    ) = 'PUB';
+      `);
+    }
+  },
+};

--- a/src/cms/database/migrations/2026.06.15T00.00.017-unpublished-backfill.js
+++ b/src/cms/database/migrations/2026.06.15T00.00.017-unpublished-backfill.js
@@ -18,7 +18,7 @@ is the record that actually transitioned from published to unpublished.
 
 module.exports = {
   async up(knex) {
-    // check if the advisories table exists and if it contains an "is_published" column
+    // check if the advisories table exists and if it contains an "unpublished_date" column
     if (
       (await knex.schema.hasTable("public_advisory_audits")) &&
       (await knex.schema.hasColumn(

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -115,12 +115,6 @@ module.exports = () => {
 
     if (!oldPublicAdvisory) return;
 
-    // save the status of the old advisory so we can get it back in afterUpdate()
-    if (!ctx.state) {
-      ctx.state = {};
-    }
-    ctx.state.oldStatus = oldPublicAdvisory.advisoryStatus?.code;
-
     const oldAdvisoryStatus = oldPublicAdvisory.advisoryStatus
       ? oldPublicAdvisory.advisoryStatus.code
       : "DFT";
@@ -129,6 +123,20 @@ module.exports = () => {
     const newAdvisoryStatusCode = await getAdvisoryStatusCode(
       updatedPublicAdvisory.advisoryStatus,
     );
+
+    // save the status of the old advisory so we can get it back in afterUpdate()
+    if (!ctx.state) {
+      ctx.state = {};
+    }
+    ctx.state.oldStatus = oldAdvisoryStatus;
+
+    // Copy unpublish metadata to the previous revision because it is the version
+    // actually being unpublished; the audit fields become immutable on the previous version.
+    if (newAdvisoryStatusCode === "UNP" && oldAdvisoryStatus === "PUB") {
+      oldPublicAdvisory.unpublishedByName =
+        updatedPublicAdvisory.unpublishedByName;
+      oldPublicAdvisory.unpublishedDate = updatedPublicAdvisory.unpublishedDate;
+    }
 
     if (isAdvisoryEqual(updatedPublicAdvisory, oldPublicAdvisory)) return;
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1807

### Description:
This change duplicates the tracking of the `unpublishedDate` and `unpublishedByName` fields on the latest revision to the previous revision. 

The previous revision is the version actually being unpublished and the audit fields become immutable on the previous version.

The other half of this change is in https://github.com/bcgov/bcparks-staff-portal/pull/621
