### PR TITLE
CMS-1807: Trigger revision when other user edits non-published advisory

### DIFF
--- a/src/cms/src/middlewares/helpers/advisoryData.js
+++ b/src/cms/src/middlewares/helpers/advisoryData.js
@@ -120,10 +120,14 @@ function isAdvisoryEqual(newData, oldData) {
     fireCentres: [],
     fireZones: [],
     naturalResourceDistricts: [],
+    recreationDistricts: [],
+    recreationResources: [],
     isAdvisoryDateDisplayed: null,
     isEffectiveDateDisplayed: null,
     isEndDateDisplayed: null,
     isUpdatedDateDisplayed: null,
+    isReservationsAffected: null,
+    isUrgentAfterHours: null,
     modifiedByName: null,
   };
 

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -128,8 +128,11 @@ module.exports = () => {
 
     if (isAdvisoryEqual(updatedPublicAdvisory, oldPublicAdvisory)) return;
 
-    // revision flow 1: all changes involving published advisories
-    if (newAdvisoryStatusCode === "PUB" || oldAdvisoryStatus === "PUB") {
+    // revision flow 1: published by system
+    if (
+      newAdvisoryStatusCode === "PUB" &&
+      updatedPublicAdvisory.publishedByName === "system"
+    ) {
       await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
       updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(
         oldPublicAdvisory.advisoryNumber,
@@ -137,7 +140,16 @@ module.exports = () => {
       return;
     }
 
-    // revision flow 2: non-published advisory modified by a different user
+    // revision flow 2: changes to published advisories
+    if (oldAdvisoryStatus === "PUB") {
+      await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
+      updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(
+        oldPublicAdvisory.advisoryNumber,
+      );
+      return;
+    }
+
+    // revision flow 3: non-published advisory modified by a different user
     if (
       oldPublicAdvisory.modifiedByName !==
         updatedPublicAdvisory.modifiedByName &&

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -126,27 +126,10 @@ module.exports = () => {
       updatedPublicAdvisory.advisoryStatus,
     );
 
-    // When changing a published advisory into draft/review status, create an archived copy
-    // of the current live revision first, then let the live record continue as the next revision.
-    if (
-      oldAdvisoryStatus === "PUB" &&
-      ["DFT", "HQR"].includes(newAdvisoryStatusCode)
-    ) {
-      // Create an archived copy of the current live revision, and update
-      // that live record with the next revision number.
-      await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
-      updatedPublicAdvisory.advisoryNumber = oldPublicAdvisory.advisoryNumber;
-      updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(
-        oldPublicAdvisory.advisoryNumber,
-      );
-      updatedPublicAdvisory.isLatestRevision = true;
-      return;
-    }
-
     if (isAdvisoryEqual(updatedPublicAdvisory, oldPublicAdvisory)) return;
 
-    // flow 5: system updates
-    if (updatedPublicAdvisory.modifiedByName === "system") {
+    // revision flow 1: all changes involving published advisories
+    if (newAdvisoryStatusCode === "PUB" || oldAdvisoryStatus === "PUB") {
       await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
       updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(
         oldPublicAdvisory.advisoryNumber,
@@ -154,20 +137,13 @@ module.exports = () => {
       return;
     }
 
-    // flow 4: update unpublished (set by system)
+    // revision flow 2: non-published advisory modified by a different user
     if (
-      oldAdvisoryStatus === "UNP" &&
-      oldPublicAdvisory.modifiedByName === "system"
+      oldPublicAdvisory.modifiedByName !==
+        updatedPublicAdvisory.modifiedByName &&
+      ["DFT", "HQR", "SCH"].includes(newAdvisoryStatusCode) &&
+      ["DFT", "HQR", "SCH"].includes(oldAdvisoryStatus)
     ) {
-      await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
-      updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(
-        oldPublicAdvisory.advisoryNumber,
-      );
-      return;
-    }
-
-    // flow 3: update published advisory
-    if (oldAdvisoryStatus === "PUB") {
       await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
       updatedPublicAdvisory.revisionNumber = await getNextRevisionNumber(
         oldPublicAdvisory.advisoryNumber,


### PR DESCRIPTION
### Jira Ticket:
CMS-1807

### Description:
Added a new condition to trigger a revision when a different user edits an advisory in the draft (DFT), HQ review (HQR) or scheduled (SCH) status.  

Simplified other revision creation scenarios to avoid repetition. 
