### PR TITLE
CMS-1829: Update Redis TTL to seconds instead of milliseconds

### DIFF
--- a/infrastructure/helm/deployment/values-prod.yaml
+++ b/infrastructure/helm/deployment/values-prod.yaml
@@ -26,7 +26,7 @@ cms:
   env:
     environment: prod
     externalUrl: https://cms.bcparks.ca
-    cacheTtl: "600000"
+    cacheTtl: "600"
 
   hpa:
     minReplicas: 2

--- a/infrastructure/helm/deployment/values.yaml
+++ b/infrastructure/helm/deployment/values.yaml
@@ -48,7 +48,7 @@ cms:
     smtpReplyTo: noreply@gov.bc.ca
     cacheEnabled: true
     cacheType: redis
-    cacheTtl: "60000"
+    cacheTtl: "600"
     enableGraphQLPlayground: true
     indexName: bcparks-protected-areas
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1829

### Description:
The documentation for "@strapi-community/plugin-rest-cache" is wrong.
https://github.com/strapi-community/plugin-rest-cache/issues/124

Also changing the value for non-production environments from 1 minute to 10 minutes to match production. 
