### PR TITLE
CMS-1797: Add "Review posting" email and triggers

### DIFF
--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -80,7 +80,7 @@ module.exports = () => {
       );
     } else if (newAdvisoryStatus === "SCH" || newAdvisoryStatus === "PUB") {
       // Regular posting notification:
-      // If the status changed from some other status to SCH or PUB
+      // If the advisory is created directly with status SCH or PUB
       await queueAdvisoryEmail(
         `Review posting: ${urgency} urgency advisory / closure`,
         "An advisory / closure is ready for review:",

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -64,22 +64,12 @@ module.exports = () => {
       );
     }
 
-    // If the status is SCH or PUB, send "Review posting" email
-    if (newAdvisoryStatus === "SCH" || newAdvisoryStatus === "PUB") {
-      await queueAdvisoryEmail(
-        `Review posting: ${urgency} urgency advisory / closure`,
-        "An advisory / closure is ready for review:",
-        newPublicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterCreate()",
-        [],
-        [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
-      );
-    }
-
     if (
       newAdvisoryStatus === "PUB" &&
       newPublicAdvisoryAudit.isUrgentAfterHours
     ) {
+      // After-hours posting notification
+      // If users with after-hours posting permission posted this with an urgent/after-hours flag
       await queueAdvisoryEmail(
         "After-hours advisory / closure was posted",
         "An after-hours advisory / closure was posted:",
@@ -87,6 +77,17 @@ module.exports = () => {
         "public-advisory-audit::lifecycles::afterCreate()",
         [],
         [METADATA_FIELDS.POSTING_DATE],
+      );
+    } else if (newAdvisoryStatus === "SCH" || newAdvisoryStatus === "PUB") {
+      // Regular posting notification:
+      // If the status changed from some other status to SCH or PUB
+      await queueAdvisoryEmail(
+        `Review posting: ${urgency} urgency advisory / closure`,
+        "An advisory / closure is ready for review:",
+        newPublicAdvisoryAudit.advisoryNumber,
+        "public-advisory-audit::lifecycles::afterCreate()",
+        [],
+        [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
       );
     }
 
@@ -216,21 +217,6 @@ module.exports = () => {
       );
     }
 
-    // If the status changed from some other status to SCH or PUB, send "Review posting" email
-    if (
-      (newAdvisoryStatus === "SCH" && oldAdvisoryStatus !== "SCH") ||
-      (newAdvisoryStatus === "PUB" && oldAdvisoryStatus !== "PUB")
-    ) {
-      await queueAdvisoryEmail(
-        `Review posting: ${urgency} urgency advisory / closure`,
-        "An advisory / closure is ready for review:",
-        publicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterUpdate()",
-        [],
-        [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
-      );
-    }
-
     if (
       newAdvisoryStatus === "PUB" &&
       oldAdvisoryStatus !== "PUB" &&
@@ -238,6 +224,8 @@ module.exports = () => {
         publicAdvisoryAudit.modifiedByRole === "contributor") && // TODO: determine after-hours rules for contributors
       publicAdvisoryAudit.isUrgentAfterHours
     ) {
+      // After-hours posting notification
+      // If users with after-hours posting permission posted this with an urgent/after-hours flag
       await queueAdvisoryEmail(
         "After-hours advisory / closure was posted",
         "An after-hours advisory / closure was posted:",
@@ -245,6 +233,20 @@ module.exports = () => {
         "public-advisory-audit::lifecycles::afterUpdate()",
         [],
         [METADATA_FIELDS.POSTING_DATE],
+      );
+    } else if (
+      (newAdvisoryStatus === "SCH" && oldAdvisoryStatus !== "SCH") ||
+      (newAdvisoryStatus === "PUB" && oldAdvisoryStatus !== "PUB")
+    ) {
+      // Regular posting notification:
+      // If the status changed from some other status to SCH or PUB
+      await queueAdvisoryEmail(
+        `Review posting: ${urgency} urgency advisory / closure`,
+        "An advisory / closure is ready for review:",
+        publicAdvisoryAudit.advisoryNumber,
+        "public-advisory-audit::lifecycles::afterUpdate()",
+        [],
+        [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
       );
     }
 

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -52,12 +52,23 @@ module.exports = () => {
 
     const urgency =
       newPublicAdvisoryAudit.urgency?.urgency?.toLowerCase() ?? "";
-    const subject = `Review draft: ${urgency} urgency advisory / closure`;
 
     if (newAdvisoryStatus === "HQR") {
       await queueAdvisoryEmail(
-        subject,
+        `Review draft: ${urgency} urgency advisory / closure`,
         "A draft advisory / closure is ready for review:",
+        newPublicAdvisoryAudit.advisoryNumber,
+        "public-advisory-audit::lifecycles::afterCreate()",
+        [],
+        [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
+      );
+    }
+
+    // If the status is SCH or PUB, send "Review posting" email
+    if (newAdvisoryStatus === "SCH" || newAdvisoryStatus === "PUB") {
+      await queueAdvisoryEmail(
+        `Review posting: ${urgency} urgency advisory / closure`,
+        "An advisory / closure is ready for review:",
         newPublicAdvisoryAudit.advisoryNumber,
         "public-advisory-audit::lifecycles::afterCreate()",
         [],
@@ -193,12 +204,26 @@ module.exports = () => {
     const newAdvisoryStatus = publicAdvisoryAudit.advisoryStatus?.code;
 
     const urgency = publicAdvisoryAudit.urgency?.urgency?.toLowerCase() ?? "";
-    const subject = `Review draft: ${urgency} urgency advisory / closure`;
 
     if (newAdvisoryStatus === "HQR" && oldAdvisoryStatus !== "HQR") {
       await queueAdvisoryEmail(
-        subject,
+        `Review draft: ${urgency} urgency advisory / closure`,
         "A draft advisory / closure is ready for review:",
+        publicAdvisoryAudit.advisoryNumber,
+        "public-advisory-audit::lifecycles::afterUpdate()",
+        [],
+        [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
+      );
+    }
+
+    // If the status changed from some other status to SCH or PUB, send "Review posting" email
+    if (
+      (newAdvisoryStatus === "SCH" && oldAdvisoryStatus !== "SCH") ||
+      (newAdvisoryStatus === "PUB" && oldAdvisoryStatus !== "PUB")
+    ) {
+      await queueAdvisoryEmail(
+        `Review posting: ${urgency} urgency advisory / closure`,
+        "An advisory / closure is ready for review:",
         publicAdvisoryAudit.advisoryNumber,
         "public-advisory-audit::lifecycles::afterUpdate()",
         [],


### PR DESCRIPTION
### Jira Ticket:
CMS-1797

### Description:
Similar to #1871 , this adds a new ACT notification email: "Review advisory after it's created". It's like the existing "Review draft before it's posted" but it triggers on a different status.

- When a new advisory is created directly with the PUB or SCH status (By someone with permission to do that), or
- When an advisory changes from some other status to the PUB or SCH.