### PR TITLE
CMS-1813: Strip querystring from YouTube url before calling noembed.com

### DIFF
--- a/src/gatsby/src/utils/usePreRenderVideo.js
+++ b/src/gatsby/src/utils/usePreRenderVideo.js
@@ -38,7 +38,7 @@ export const usePreRenderVideo = (content = "") => {
       const urlSegments = iframeSrc?.split("/");
       const rawSegment = urlSegments?.at(-1);
       // Strip query params to get a clean video ID
-      const videoId = rawSegment?.split("?")[0]
+      const videoId = rawSegment?.split("?")[0];
 
       if (videoId) {
         // Fetch video title from noembed API (YouTube metadata service)

--- a/src/gatsby/src/utils/usePreRenderVideo.js
+++ b/src/gatsby/src/utils/usePreRenderVideo.js
@@ -36,7 +36,9 @@ export const usePreRenderVideo = (content = "") => {
 
       // Extract YouTube video ID from URL (last segment after splitting by "/")
       const urlSegments = iframeSrc?.split("/");
-      const videoId = urlSegments?.at(-1);
+      const rawSegment = urlSegments?.at(-1);
+      // Strip query params to get a clean video ID
+      const videoId = rawSegment?.split("?")[0]
 
       if (videoId) {
         // Fetch video title from noembed API (YouTube metadata service)


### PR DESCRIPTION
### Jira Ticket:
CMS-1813

### Description:
This change fixes an issue with the Berg Lake Trail video where the YouTube URL had a start time querystring and it was breaking the lookup on noembed.com. 

e.g. `https://www.youtube.com/embed/-_YsZHp4IAk?start=165` => `https://noembed.com/embed?dataType=json&url=https://www.youtube.com/watch?v=-_YsZHp4IAk`

I discovered while working on this that cheerio is actually supposed to be a server-side nodeJs library and we're using it on client side in a `useEffect()`. That might explain why it was trying to bundle nodeJs libraries into our webpack bundle. 