### PR TITLE
CMS-1722: Add eventTypeSubCategory and remove eventType groupLabel

### DIFF
--- a/src/cms/database/migrations/2026.05.20T00.00.012-import-standard-messages.js
+++ b/src/cms/database/migrations/2026.05.20T00.00.012-import-standard-messages.js
@@ -110,6 +110,13 @@ const messages = [
 module.exports = {
   async up(knex) {
     if (await knex.schema.hasTable("standard_messages")) {
+      // add a group_label (string) column if it doesn't exist
+      if (!(await knex.schema.hasColumn("standard_messages", "group_label"))) {
+        await knex.schema.table("standard_messages", (table) => {
+          table.string("group_label");
+        });
+      }
+
       // If precedence 30 already exists, this migration has already imported all rows.
       const precedence30Exists = await knex("standard_messages")
         .where({ precedence: 30 })
@@ -149,6 +156,7 @@ module.exports = {
               scope,
               title,
               precedence,
+              groupLabel: "Access",
               description,
               eventType: eventTypeDocId,
               isActive: true,

--- a/src/cms/database/migrations/2026.06.08T00.00.015-event-types.js
+++ b/src/cms/database/migrations/2026.06.08T00.00.015-event-types.js
@@ -714,37 +714,42 @@ exports.up = async function (knex) {
 
   // create the link table if it doesn't exist yet
   if (
-    !(await knex.schema.hasTable("event_types_event_type_sub_categories_lnk"))
+    !(await knex.schema.hasTable("event_type_sub_categories_event_types_lnk"))
   ) {
     await knex.schema.createTable(
-      "event_types_event_type_sub_categories_lnk",
+      "event_type_sub_categories_event_types_lnk",
       (table) => {
         table.increments("id").primary();
-        table
-          .integer("event_type_id")
-          .references("id")
-          .inTable("event_types")
-          .onDelete("CASCADE");
         table
           .integer("event_type_sub_category_id")
           .references("id")
           .inTable("event_type_sub_categories")
           .onDelete("CASCADE");
+        table
+          .integer("event_type_id")
+          .references("id")
+          .inTable("event_types")
+          .onDelete("CASCADE");
+        table.double("event_type_ord");
         table.double("event_type_sub_category_ord");
-        table.unique(["event_type_id", "event_type_sub_category_id"], {
-          indexName: "event_types_event_type_sub_categories_lnk_uq",
+        table.unique(["event_type_sub_category_id", "event_type_id"], {
+          indexName: "event_type_sub_categories_event_types_lnk_uq",
         });
         table.index(
-          ["event_type_id"],
-          "event_types_event_type_sub_categories_lnk_fk",
+          ["event_type_sub_category_id"],
+          "event_type_sub_categories_event_types_lnk_fk",
         );
         table.index(
-          ["event_type_sub_category_id"],
-          "event_types_event_type_sub_categories_lnk_ifk",
+          ["event_type_id"],
+          "event_type_sub_categories_event_types_lnk_ifk",
+        );
+        table.index(
+          ["event_type_ord"],
+          "event_type_sub_categories_event_types_lnk_ofk",
         );
         table.index(
           ["event_type_sub_category_ord"],
-          "event_types_event_type_sub_categories_lnk_ofk",
+          "event_type_sub_categories_event_types_lnk_oifk",
         );
       },
     );

--- a/src/cms/database/migrations/2026.06.08T00.00.015-event-types.js
+++ b/src/cms/database/migrations/2026.06.08T00.00.015-event-types.js
@@ -5,903 +5,648 @@ This migration adds new event types to the event_types table and populates
 new fields on existing records.
 */
 
-const existingItems = [
+const data = [
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Access restricted",
+    eventType: "Access restricted",
     description:
       "Access to a specific park, area, trail, or facility is limited (e.g., permits, escorts, time windows) for safety, cultural, wildlife, or operational reasons.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Anchorage",
+    eventType: "Anchorage",
     description:
       "Guidance or restrictions on where and how vessels may anchor or use mooring buoys within marine park areas.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Area closures",
-    event_type: "Area closure",
+    eventType: "Area closure",
     description:
       "A defined area, site, or trail is closed—temporarily or until further notice—due to hazards, protection needs, or operations.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Avalanche",
+    eventType: "Avalanche",
     description:
       "Advisory that avalanche hazards exist and visitors must check forecasts and use appropriate winter backcountry caution.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Avalanche hazard",
+    eventType: "Avalanche hazard",
     description:
       "Advisory that avalanche hazards exist and visitors must check forecasts and use appropriate winter backcountry caution.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Facilities",
-    event_type: "Boat launch",
+    eventType: "Boat launch",
     description:
       "Status changes, restrictions, or closures affecting boat launch facilities and associated access/parking.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Human health",
-    event_type: "Boil water advisory",
+    eventType: "Boil water advisory",
     description:
       "Drinking water must be boiled, filtered, or treated before use due to water‑quality concerns.",
     scope: "BCP",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Boundary adjustment",
+    eventType: "Boundary adjustment",
     description:
       "Notification of changes to a park/protected area boundary or alignment.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Bridge outage",
+    eventType: "Bridge outage",
     description:
       "A bridge is unsafe, damaged, or removed, altering route access until repairs or replacement occur.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Campfires",
+    eventType: "Campfires",
     description:
       "Restrictions or prohibitions on campfires/open burning, typically during elevated wildfire risk.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Park management",
-    event_type: "Campground capacity",
+    eventType: "Campground capacity",
     description:
       "Information on seasonal capacity, availability, or operating status of campgrounds (e.g., winter operations, early openings).",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Area closures",
-    event_type: "Campground closure",
+    eventType: "Campground closure",
     description:
       "Full or partial campground closures due to hazards, maintenance, damage, seasonality, or project work.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Campground expansion",
+    eventType: "Campground expansion",
     description:
       "Announcements of new campsites or expansions to increase capacity and improve facilities.",
     scope: "BCP",
   },
   {
-    category: "Access and facilities",
-    group_label: "Facilities",
-    event_type: "Campground infrastructure",
+    eventType: "Campground infrastructure",
     description:
       "Construction or upgrades to campground infrastructure (e.g., service centers, utilities) that affect use.",
     scope: "BCP",
   },
   {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Campground maintenance",
+    eventType: "Campground maintenance",
     description:
       "Routine or scheduled maintenance in campgrounds that may cause noise, delays, or temporary facility outages.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Camping",
+    eventType: "Camping",
     description:
       "General rules, availability, and limitations for camping (frontcountry/backcountry), including what is or isn’t permitted.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Construction",
+    eventType: "Construction",
     description:
       "Project work (trail, road, facility) that may cause detours, reduced access, noise, or temporary closures.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Community",
-    event_type: "Cultural",
+    eventType: "Cultural",
     description:
       "Notices tied to Indigenous cultural values/management, including closures or protocols to protect cultural heritage.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Day-use passes",
+    eventType: "Day-use passes",
     description:
       "Requirement to obtain a (free) day‑use pass to manage visitor volumes for specific dates/areas.",
     scope: "BCP",
   },
   {
-    category: "Access and facilities",
-    group_label: "Facilities",
-    event_type: "Dock closure",
+    eventType: "Dock closure",
     description:
       "A dock is closed or limited for safety, damage, or maintenance reasons, affecting boating access.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Human health",
-    event_type: "Drinking water",
+    eventType: "Drinking water",
     description:
       "Potable water availability has changed (e.g., taps off, bring your own) due to outages or system issues.",
     scope: "BCP",
   },
   {
-    category: "Ecological",
-    group_label: "Environment and wildlife",
-    event_type: "Ecosystem protection",
+    eventType: "Ecosystem protection",
     description:
       "Visitor rules and advisories to protect sensitive habitats/species or water quality (e.g., leash pets, no discharge).",
     scope: "BCP",
   },
   {
-    category: "Ecological",
-    group_label: "Environment and wildlife",
-    event_type: "Ecosystem restoration project",
+    eventType: "Ecosystem restoration project",
     description:
       "Active habitat restoration works (e.g., wetland/forest treatments) with related temporary restrictions.",
     scope: "BCP",
   },
   {
-    category: "People",
-    group_label: "Community",
-    event_type: "Event",
+    eventType: "Event",
     description:
       "Information about park‑led programs, celebrations, or community events held in or about the park.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Facilities",
-    event_type: "Facilities unavailable",
+    eventType: "Facilities unavailable",
     description:
       "Amenities (e.g., water if available, washrooms, sani‑stations, pumps) are temporarily unavailable due to outages or repairs.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Facilities",
-    event_type: "Facility closure",
+    eventType: "Facility closure",
     description:
       "A specific facility (e.g., hut, cabin, building, washroom) is closed until further notice.",
     scope: "BCP",
   },
   {
-    category: "Access and facilities",
-    group_label: "Facilities",
-    event_type: "Facility out of service",
+    eventType: "Facility out of service",
     description:
       "A particular piece of infrastructure is not operational (e.g., water system, toilet, cable car) pending repair.",
     scope: "BCP",
   },
   {
-    category: "Access and facilities",
-    group_label: "Facilities",
-    event_type: "Facility reopening",
+    eventType: "Facility reopening",
     description:
       "Announcement that a previously closed area or facility has reopened to visitors.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Community",
-    event_type: "Feedback",
+    eventType: "Feedback",
     description:
       "Request for visitor input (surveys, comment forms) to inform park operations or planning.",
     scope: "BCP",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Flood",
+    eventType: "Flood",
     description:
       "Active or forecast flooding affecting safety, access, or operations within the park.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Flood damage",
+    eventType: "Flood damage",
     description:
       "Flood‑related damage (e.g., washed‑out bridges/roads) causing closures, detours, or hazards.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Freshet",
+    eventType: "Freshet",
     description:
       "Seasonal high‑water conditions (spring runoff) requiring caution and occasionally limiting access.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Freshet",
+    eventType: "Freshet",
     description:
       "Seasonal high‑water conditions (spring runoff) requiring caution and occasionally limiting access.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Area closures",
-    event_type: "Gate closure",
+    eventType: "Gate closure",
     description:
       "Vehicle gates are closed (often seasonally), restricting motorized access; foot access may remain.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Group camping",
+    eventType: "Group camping",
     description:
       "Details on group site availability, reservations, and related rules.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Hazard conditions",
+    eventType: "Hazard conditions",
     description:
       "General advisories about significant hazards (water, terrain, industrial activity) requiring heightened caution.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Hazard facility",
+    eventType: "Hazard facility",
     description:
       "A specific facility poses a temporary hazard to users (e.g., obstructions or unsafe operating conditions).",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Hazard trees",
+    eventType: "Hazard trees",
     description:
       "Danger from unstable/damaged trees prompting closures, decommissioning, or caution.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Horseback riding",
+    eventType: "Horseback riding",
     description:
       "Guidance or restrictions for equestrian use of park trails/facilities (inferred where descriptions were absent).",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Hours of operation",
+    eventType: "Hours of operation",
     description:
       "Park/day‑use hours and curfews, including overnight parking/use prohibitions.",
     scope: "BCP",
   },
   {
-    category: "Ecological",
-    group_label: "Weather and seasonal",
-    event_type: "Icy conditions",
+    eventType: "Icy conditions",
     description:
       "Ice or frost present on surfaces, creating slippery and potentially hazardous travel conditions.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Landslide",
+    eventType: "Landslide",
     description:
       "Landslide activity leading to closures, detours, or travel advisories.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Motorized boats prohibited",
+    eventType: "Motorized boats prohibited",
     description:
       "Notice that motorized vessels are not permitted in a park/waterbody to protect values or comply with regulation.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Camping prohibited",
+    eventType: "Camping prohibited",
     description:
       "Reminder that camping and/or campfires are not permitted at any time in the specified park/area.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Public behaviour",
-    event_type: "Noise",
+    eventType: "Noise",
     description:
       "Alerts about potential noise (e.g., trains, industrial operations, helicopters) that may disturb visitors and posted quiet hours.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Off-road vehicles",
+    eventType: "Off-road vehicles",
     description:
       "Rules on ORV registration, permitted routes, and enforcement of off‑road restrictions.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Human health",
-    event_type: "Pandemic",
+    eventType: "Pandemic",
     description:
       "COVID‑19 related closures/partial closures, local access restrictions, and public‑health protocols.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Park access",
+    eventType: "Park access",
     description:
       "Access conditions to a park (e.g., road deactivation, 4x4 only, seasonal limitations, ferry schedules).",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Area closures",
-    event_type: "Park closure",
+    eventType: "Park closure",
     description:
       "Full park closure under regulation for safety, wildfire, flood, cultural, or community reasons.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Park maintenance",
+    eventType: "Park maintenance",
     description:
       "Park‑wide maintenance activities that may reduce services or cause short closures.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Park management",
-    event_type: "Park management",
+    eventType: "Park management",
     description:
       "Governance/management updates (e.g., co‑management with First Nations, title areas, policies).",
     scope: "BCP",
   },
   {
-    category: "People",
-    group_label: "Park management",
-    event_type: "Park name",
+    eventType: "Park name",
     description:
       "Announcement of an official renaming to reflect Indigenous names or correct nomenclature.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Park management",
-    event_type: "Park policy",
+    eventType: "Park policy",
     description:
       "Policy reminders (e.g., alcohol/smoking rules, commercial use requirements) applicable in the park.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Parking",
+    eventType: "Parking",
     description:
       "Parking rules, capacity/overflow information, and towing enforcement for illegal parking.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Parking lot access",
+    eventType: "Parking lot access",
     description:
       "Status or restrictions for specific parking lots/access roads (e.g., closures, seasonal limits).",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Public behaviour",
-    event_type: "Pets",
+    eventType: "Pets",
     description:
       "Pet policies and seasonal restrictions (e.g., leash rules, beach closures, wildlife protection).",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Environment and wildlife",
-    event_type: "Prescribed burn",
+    eventType: "Prescribed burn",
     description:
       "Planned burning for ecosystem restoration or fuel reduction, often with smoke advisories.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Area closures",
-    event_type: "Private land / off-limits",
+    eventType: "Private land / off-limits",
     description:
       "Reminder that certain routes/areas cross private land and are not open to public access.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Community",
-    event_type: "Public consultation",
+    eventType: "Public consultation",
     description:
       "Invitations to provide input on plans/strategies or share comments to improve management.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Park management",
-    event_type: "Regulations",
+    eventType: "Regulations",
     description:
       "Special regulations in specific areas or seasons (e.g., guided‑only access, closures).",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Park management",
-    event_type: "Reservations",
+    eventType: "Reservations",
     description:
       "Information about reservation systems, booking windows, and newly reservable facilities.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Road closure",
+    eventType: "Road closure",
     description:
       "Road or bridge closures affecting resource access due to construction, washouts, landslides, or safety.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Road conditions",
+    eventType: "Road conditions",
     description:
       "Current conditions on park/forest service roads (e.g., deactivated, 4x4 only, rough).",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Road construction",
+    eventType: "Road construction",
     description:
       "Road building or upgrades with traffic control, delays, and temporary restrictions.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Road hazards",
+    eventType: "Road hazards",
     description:
       "Specific road hazards (washouts, narrow grades, rockfall) requiring extra caution.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Road hazards",
-    description:
-      "Specific road hazards (washouts, narrow grades, rockfall) requiring extra caution.",
-    scope: "Both",
-  },
-  {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Road inaccessible",
+    eventType: "Road inaccessible",
     description:
       "A segment is impassable or deactivated with no vehicle access.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Rockfall hazard",
+    eventType: "Rockfall hazard",
     description:
       "Rockfall risk leading to closures or travel restrictions in affected zones.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Area closures",
-    event_type: "Scheduled closure",
+    eventType: "Scheduled closure",
     description:
       "Announced, time‑bounded closures for operations or partner‑led restrictions.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Shellfish",
+    eventType: "Shellfish",
     description:
       "Public‑health advisory to check federal shellfish‑harvest closures before collecting/consuming.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Human health",
-    event_type: "Shellfish",
-    description:
-      "Public‑health advisory to check federal shellfish‑harvest closures before collecting/consuming.",
-    scope: "Both",
-  },
-  {
-    category: "People",
-    group_label: "Activities",
-    event_type: "Snowmobiles",
+    eventType: "Snowmobiles",
     description:
       "Where/when snowmobiling is permitted and the associated safety/avalanche requirements.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Weather and seasonal",
-    event_type: "Spring conditions",
+    eventType: "Spring conditions",
     description:
       "Variable spring trail/snow conditions that require preparation and caution.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Weather and seasonal",
-    event_type: "Storm damage",
+    eventType: "Storm damage",
     description:
       "Storm‑related blowdown/washouts that affect trails, access, or facilities.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Public behaviour",
-    event_type: "Thieves",
+    eventType: "Thieves",
     description:
       "Crime‑prevention reminders to secure vehicles/belongings and report incidents.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Area closures",
-    event_type: "Trail closure",
+    eventType: "Trail closure",
     description:
       "Full or partial trail closures for hazards, construction, wildlife, or protection needs.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Trail conditions",
+    eventType: "Trail conditions",
     description:
       "Current trail conditions and seasonal hazards affecting safe travel.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Trail construction",
+    eventType: "Trail construction",
     description:
       "New builds or rehabilitation projects with detours and short‑term closures.",
     scope: "Both",
   },
   {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Trail maintenance",
+    eventType: "Trail maintenance",
     description:
       "Routine maintenance activities that may temporarily limit access.",
     scope: "Both",
   },
   {
-    category: "People",
-    group_label: "Community",
-    event_type: "Volunteer",
+    eventType: "Volunteer",
     description: "Opportunities for volunteer hosts/stewards and how to apply.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Human health",
-    event_type: "Water quality",
+    eventType: "Water quality",
     description:
       "Public‑health notices for cyanobacteria/blue‑green algae and other water‑quality issues.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Weather and seasonal",
-    event_type: "Weather",
+    eventType: "Weather",
     description:
       "Seasonal and weather‑driven condition updates and where to check forecasts.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Wildfire",
+    eventType: "Wildfire",
     description:
       "Active wildfire information (including evacuation alerts/orders) and related closures.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Wildfire damage",
+    eventType: "Wildfire damage",
     description:
       "Hazards and closures due to areas burned by wildfire (e.g., danger trees, unstable slopes).",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Wildfire fuel management",
+    eventType: "Wildfire fuel management",
     description:
       "Fuel‑reduction treatments/prescribed activities to lower fire risk in and around parks.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Wildfire nearby",
+    eventType: "Wildfire nearby",
     description:
       "Nearby wildfires producing smoke/evacuation advisories that may impact park use.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Wildfire risk",
+    eventType: "Wildfire risk",
     description:
       "Proactive restrictions and public‑safety notices during high fire danger (e.g., fire bans).",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Wildfire tree assessment",
+    eventType: "Wildfire tree assessment",
     description:
       "Danger‑tree or post‑fire tree assessments and the associated public hazards.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Environment and wildlife",
-    event_type: "Wildlife",
+    eventType: "Wildlife",
     description:
       "Wildlife‑safety advisories and attractant management (e.g., bears, wolves, cougars, seals).",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Environment and wildlife",
-    event_type: "Wildlife protection",
+    eventType: "Wildlife protection",
     description:
       "Measures to protect specific species/habitats with visitor rules (e.g., closures, leash areas).",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Weather and seasonal",
-    event_type: "Windstorm damage",
+    eventType: "Windstorm damage",
     description: "Access closures and hazards following severe wind events.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Weather and seasonal",
-    event_type: "Winter conditions",
+    eventType: "Winter conditions",
     description:
       "Winter access and snow/ice hazards, including chain requirements and avalanche cautions.",
     scope: "Both",
   },
   {
-    category: "Public safety",
-    group_label: "Public safety",
-    event_type: "Public safety",
+    eventType: "Public safety",
     description:
       "Safety bulletins about hazards (e.g., UXO, mine traffic, theft) and required precautions.",
     scope: "Both",
   },
-];
-
-const newItems = [
   {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Blowdown",
-    description: "Trees down or overhead danger or wind event",
-    scope: "RST",
-  },
-  {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Catastrophic event",
-    description: "Entire site has been destroyed or greater portion unsafe",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Closure area restriction",
-    description:
-      "Restriction due to emergency services restricting tourist travel",
-    scope: "RST",
-  },
-  {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Damaged unsafe infrastructure",
-    description: "Damaged unsafe infrastructure",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Environment and wildlife",
-    event_type: "Environmental related",
-    description:
-      "Due to larger ecological perspective, by other agencies or RSTBC",
-    scope: "RST",
-  },
-  {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Fire rehabilitation",
-    description: "Fire Rehabilitation",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Fire suppression activity",
-    description: "Fire Suppression Activity",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Environment and wildlife",
-    event_type: "Forest health",
-    description: "Insect or other infestation",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Human health",
-    event_type: "Human health",
-    description: "Any issue specific to human health",
-    scope: "Both",
-  },
-  {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Industrial activity",
-    description:
-      "Industrial activities causing dangerous conditions for public access",
-    scope: "Both",
-  },
-  {
-    category: "People",
-    group_label: "Public behaviour",
-    event_type: "Investigation",
-    description: "Closed due to legal C&E or Police investigations",
-    scope: "RST",
-  },
-  {
-    category: "Access and facilities",
-    group_label: "Construction/maintenance",
-    event_type: "Maintenance",
-    description: "Repair or enhancement to site or trail",
-    scope: "RST",
-  },
-  {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Park re-opening",
-    description:
-      "Notice that a park/area has reopened for day‑use or camping after a closure.",
-    scope: "Both",
-  },
-  {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Road washout",
-    description: "Road Washout",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Weather and seasonal",
-    event_type: "Seasonal",
-    description: "Operating season ended",
-    scope: "Both",
-  },
-  {
-    category: "Access and facilities",
-    group_label: "Access",
-    event_type: "Trail access",
-    description: "Trail is impacted",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Tsunami",
+    eventType: "Tsunami",
     description:
       "A tsunami hazard requiring evacuation, restricted access, or heightened safety measures.",
     scope: "Both",
   },
   {
-    category: "Ecological",
-    group_label: "Wildfire",
-    event_type: "Wildfire closure year",
+    eventType: "Park re-opening",
+    description:
+      "Notice that a park/area has reopened for day‑use or camping after a closure.",
+    scope: "Both",
+  },
+  {
+    eventType: "Blowdown",
+    description: "Trees down or overhead danger or wind event",
+    scope: "RST",
+  },
+  {
+    eventType: "Catastrophic event",
+    description: "Entire site has been destroyed or greater portion unsafe",
+    scope: "Both",
+  },
+  {
+    eventType: "Closure area restriction",
+    description:
+      "Restriction due to emergency services restricting tourist travel",
+    scope: "RST",
+  },
+  {
+    eventType: "Damaged unsafe infrastructure",
+    description: "Damaged unsafe infrastructure",
+    scope: "Both",
+  },
+  {
+    eventType: "Environmental related",
+    description:
+      "Due to larger ecological perspective, by other agencies or RSTBC",
+    scope: "RST",
+  },
+  {
+    eventType: "Fire rehabilitation",
+    description: "Fire Rehabilitation",
+    scope: "Both",
+  },
+  {
+    eventType: "Fire suppression activity",
+    description: "Fire Suppression Activity",
+    scope: "Both",
+  },
+  {
+    eventType: "Forest health",
+    description: "Insect or other infestation",
+    scope: "Both",
+  },
+  {
+    eventType: "Human health",
+    description: "Any issue specific to human health",
+    scope: "Both",
+  },
+  {
+    eventType: "Industrial activity",
+    description:
+      "Industrial activities causing dangerous conditions for public access",
+    scope: "Both",
+  },
+  {
+    eventType: "Investigation",
+    description: "Closed due to legal C&E or Police investigations",
+    scope: "RST",
+  },
+  {
+    eventType: "Maintenance",
+    description: "Repair or enhancement to site or trail",
+    scope: "RST",
+  },
+  {
+    eventType: "Road washout",
+    description: "Road Washout",
+    scope: "Both",
+  },
+  {
+    eventType: "Seasonal",
+    description: "Operating season ended",
+    scope: "Both",
+  },
+  {
+    eventType: "Trail access",
+    description: "Trail is impacted",
+    scope: "Both",
+  },
+  {
+    eventType: "Wildfire closure year",
     description: "For planning purposes and forest recovery",
     scope: "RST",
   },
   {
-    category: "Ecological",
-    group_label: "Natural disasters and emergencies",
-    event_type: "Freshet",
-    description:
-      "Seasonal high‑water conditions (spring runoff) requiring caution and occasionally limiting access.",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Hazards",
-    event_type: "Road hazards",
-    description:
-      "Specific road hazards (washouts, narrow grades, rockfall) requiring extra caution.",
-    scope: "Both",
-  },
-  {
-    category: "Ecological",
-    group_label: "Human health",
-    event_type: "Shellfish",
+    eventType: "Shellfish",
     description:
       "Public‑health advisory to check federal shellfish‑harvest closures before collecting/consuming.",
     scope: "Both",
@@ -920,64 +665,113 @@ exports.up = async function (knex) {
     });
   }
 
-  if (!(await knex.schema.hasColumn("event_types", "group_label"))) {
-    await knex.schema.table("event_types", (table) => {
-      table.string("group_label");
+  // rename items prior to import
+  await knex.raw(
+    `update event_types set event_type = 'Park re-opening' where event_type = 'Park opening'`,
+  );
+
+  // this one is already right on prod but wrong on some dev/staging environments
+  await knex.raw(
+    `update event_types set event_type = 'Camping prohibited' where event_type = 'No camping'`,
+  );
+
+  // create event_type_sub_categories if it doesn't exist yet
+  // (required before using the Strapi documents API for event-type, which JOINs this table)
+  if (!(await knex.schema.hasTable("event_type_sub_categories"))) {
+    await knex.schema.createTable("event_type_sub_categories", (table) => {
+      table.increments("id").primary();
+      table.string("document_id", 255);
+      table.string("sub_category", 255);
+      table.string("category", 255);
+      table.timestamp("created_at", { precision: 6 });
+      table.timestamp("updated_at", { precision: 6 });
+      table.timestamp("published_at", { precision: 6 });
+      table
+        .integer("created_by_id")
+        .references("id")
+        .inTable("admin_users")
+        .onDelete("SET NULL");
+      table
+        .integer("updated_by_id")
+        .references("id")
+        .inTable("admin_users")
+        .onDelete("SET NULL");
+      table.string("locale", 255);
+      table.index(
+        ["document_id", "locale", "published_at"],
+        "event_type_sub_categories_documents_idx",
+      );
+      table.index(
+        ["created_by_id"],
+        "event_type_sub_categories_created_by_id_fk",
+      );
+      table.index(
+        ["updated_by_id"],
+        "event_type_sub_categories_updated_by_id_fk",
+      );
     });
   }
 
-  const makeKey = (event_type, group_label) =>
-    `${event_type}::${group_label ?? ""}`;
+  // create the link table if it doesn't exist yet
+  if (
+    !(await knex.schema.hasTable("event_types_event_type_sub_categories_lnk"))
+  ) {
+    await knex.schema.createTable(
+      "event_types_event_type_sub_categories_lnk",
+      (table) => {
+        table.increments("id").primary();
+        table
+          .integer("event_type_id")
+          .references("id")
+          .inTable("event_types")
+          .onDelete("CASCADE");
+        table
+          .integer("event_type_sub_category_id")
+          .references("id")
+          .inTable("event_type_sub_categories")
+          .onDelete("CASCADE");
+        table.double("event_type_sub_category_ord");
+        table.unique(["event_type_id", "event_type_sub_category_id"], {
+          indexName: "event_types_event_type_sub_categories_lnk_uq",
+        });
+        table.index(
+          ["event_type_id"],
+          "event_types_event_type_sub_categories_lnk_fk",
+        );
+        table.index(
+          ["event_type_sub_category_id"],
+          "event_types_event_type_sub_categories_lnk_ifk",
+        );
+        table.index(
+          ["event_type_sub_category_ord"],
+          "event_types_event_type_sub_categories_lnk_ofk",
+        );
+      },
+    );
+  }
 
-  const existingEventTypes = await knex("event_types")
-    .whereIn(
-      "event_type",
-      newItems.map((item) => item.event_type),
-    )
-    .select("event_type", "group_label");
+  // do an upsert based on eventType using the Strapi documents API
+  const eventTypeDocuments = strapi.documents("api::event-type.event-type");
 
-  const existingEventTypeSet = new Set(
-    existingEventTypes.map((item) =>
-      makeKey(item.event_type, item.group_label),
-    ),
-  );
+  const existingEventTypes = await eventTypeDocuments.findMany({
+    fields: ["documentId", "eventType"],
+  });
+  const eventTypeMap = {};
+  for (const et of existingEventTypes) {
+    eventTypeMap[et.eventType] = et;
+  }
 
-  const itemsToInsert = newItems.filter(
-    (item) =>
-      !existingEventTypeSet.has(makeKey(item.event_type, item.group_label)),
-  );
-
-  if (itemsToInsert.length > 0) {
-    const eventTypeDocuments = strapi.documents("api::event-type.event-type");
-
-    for (const row of itemsToInsert) {
+  for (const { eventType, description, scope } of data) {
+    const existing = eventTypeMap[eventType];
+    if (existing) {
+      await eventTypeDocuments.update({
+        documentId: existing.documentId,
+        data: { eventType, description, scope },
+      });
+    } else {
       await eventTypeDocuments.create({
-        data: {
-          groupLabel: row.group_label,
-          description: row.description,
-          scope: row.scope,
-          eventType: row.event_type,
-        },
+        data: { eventType, description, scope },
       });
     }
-  }
-
-  // update existing items
-  for (const item of existingItems) {
-    const targetRow = await knex("event_types")
-      .where({ event_type: item.event_type })
-      .orderBy("id", "asc")
-      .first("id");
-
-    if (!targetRow) {
-      continue;
-    }
-
-    await knex("event_types").where({ id: targetRow.id }).update({
-      group_label: item.group_label,
-      description: item.description,
-      scope: item.scope,
-      updated_at: knex.fn.now(),
-    });
   }
 };

--- a/src/cms/database/migrations/2026.06.24T00.00.019-event-type-reimport.js
+++ b/src/cms/database/migrations/2026.06.24T00.00.019-event-type-reimport.js
@@ -40,7 +40,6 @@ const eventTypes = [
   {
     subCategory: "Natural disasters and emergencies",
     eventType: "Avalanche hazard",
-  }
   },
   {
     subCategory: "Hazards",
@@ -91,7 +90,7 @@ const eventTypes = [
     eventType: "Camping",
   },
   {
-    subCategory: "Natural disasters and emergenices",
+    subCategory: "Natural disasters and emergencies",
     eventType: "Catastrophic event",
   },
   {
@@ -185,7 +184,6 @@ const eventTypes = [
   {
     subCategory: "Natural disasters and emergencies",
     eventType: "Freshet",
-  }
   },
   {
     subCategory: "Area closures",
@@ -232,7 +230,7 @@ const eventTypes = [
     eventType: "Investigation",
   },
   {
-    subCategory: "Natural disasters and emergenices",
+    subCategory: "Natural disasters and emergencies",
     eventType: "Landslide",
   },
   {
@@ -352,7 +350,7 @@ const eventTypes = [
     eventType: "Road washout",
   },
   {
-    subCategory: "Natural disasters and emergenices",
+    subCategory: "Natural disasters and emergencies",
     eventType: "Rockfall hazard",
   },
   {
@@ -408,7 +406,7 @@ const eventTypes = [
     eventType: "Trail maintenance",
   },
   {
-    subCategory: "Natural disasters and emergenices",
+    subCategory: "Natural disasters and emergencies",
     eventType: "Tsunami",
   },
   {
@@ -532,37 +530,42 @@ module.exports = {
 
     // create the link table if it doesn't exist yet
     if (
-      !(await knex.schema.hasTable("event_types_event_type_sub_categories_lnk"))
+      !(await knex.schema.hasTable("event_type_sub_categories_event_types_lnk"))
     ) {
       await knex.schema.createTable(
-        "event_types_event_type_sub_categories_lnk",
+        "event_type_sub_categories_event_types_lnk",
         (table) => {
           table.increments("id").primary();
-          table
-            .integer("event_type_id")
-            .references("id")
-            .inTable("event_types")
-            .onDelete("CASCADE");
           table
             .integer("event_type_sub_category_id")
             .references("id")
             .inTable("event_type_sub_categories")
             .onDelete("CASCADE");
+          table
+            .integer("event_type_id")
+            .references("id")
+            .inTable("event_types")
+            .onDelete("CASCADE");
+          table.double("event_type_ord");
           table.double("event_type_sub_category_ord");
-          table.unique(["event_type_id", "event_type_sub_category_id"], {
-            indexName: "event_types_event_type_sub_categories_lnk_uq",
+          table.unique(["event_type_sub_category_id", "event_type_id"], {
+            indexName: "event_type_sub_categories_event_types_lnk_uq",
           });
           table.index(
-            ["event_type_id"],
-            "event_types_event_type_sub_categories_lnk_fk",
+            ["event_type_sub_category_id"],
+            "event_type_sub_categories_event_types_lnk_fk",
           );
           table.index(
-            ["event_type_sub_category_id"],
-            "event_types_event_type_sub_categories_lnk_ifk",
+            ["event_type_id"],
+            "event_type_sub_categories_event_types_lnk_ifk",
+          );
+          table.index(
+            ["event_type_ord"],
+            "event_type_sub_categories_event_types_lnk_ofk",
           );
           table.index(
             ["event_type_sub_category_ord"],
-            "event_types_event_type_sub_categories_lnk_ofk",
+            "event_type_sub_categories_event_types_lnk_oifk",
           );
         },
       );

--- a/src/cms/database/migrations/2026.06.24T00.00.019-event-type-reimport.js
+++ b/src/cms/database/migrations/2026.06.24T00.00.019-event-type-reimport.js
@@ -323,10 +323,6 @@ const eventTypes = [
   },
   {
     subCategory: "Access",
-    eventType: "Road closure",
-  },
-  {
-    subCategory: "Access",
     eventType: "Road conditions",
   },
   {

--- a/src/cms/database/migrations/2026.06.24T00.00.019-event-type-reimport.js
+++ b/src/cms/database/migrations/2026.06.24T00.00.019-event-type-reimport.js
@@ -1,0 +1,659 @@
+"use strict";
+
+const subCategories = [
+  { category: "Access and facilities", subCategory: "Access" },
+  { category: "Access and facilities", subCategory: "Area closures" },
+  { category: "Access and facilities", subCategory: "Facilities" },
+  {
+    category: "Access and facilities",
+    subCategory: "Construction/maintenance",
+  },
+  { category: "Ecological", subCategory: "Natural disasters and emergencies" },
+  { category: "Ecological", subCategory: "Hazards" },
+  { category: "Ecological", subCategory: "Human health" },
+  { category: "Ecological", subCategory: "Wildfire" },
+  { category: "Ecological", subCategory: "Environment and wildlife" },
+  { category: "Ecological", subCategory: "Weather and seasonal" },
+  { category: "People", subCategory: "Activities" },
+  { category: "People", subCategory: "Park management" },
+  { category: "People", subCategory: "Community" },
+  { category: "People", subCategory: "Public behaviour" },
+];
+
+const eventTypes = [
+  {
+    subCategory: "Access",
+    eventType: "Access restricted",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Anchorage",
+  },
+  {
+    subCategory: "Area closures",
+    eventType: "Area closure",
+  },
+  {
+    subCategory: "Natural disasters and emergencies",
+    eventType: "Avalanche",
+  },
+  {
+    subCategory: "Natural disasters and emergencies",
+    eventType: "Avalanche hazard",
+  }
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Blowdown",
+  },
+  {
+    subCategory: "Facilities",
+    eventType: "Boat launch",
+  },
+  {
+    subCategory: "Human health",
+    eventType: "Boil water advisory",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Boundary adjustment",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Bridge outage",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Campfires",
+  },
+  {
+    subCategory: "Park management",
+    eventType: "Campground capacity",
+  },
+  {
+    subCategory: "Area closures",
+    eventType: "Campground closure",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Campground expansion",
+  },
+  {
+    subCategory: "Facilities",
+    eventType: "Campground infrastructure",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Campground maintenance",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Camping",
+  },
+  {
+    subCategory: "Natural disasters and emergenices",
+    eventType: "Catastrophic event",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Closure area restriction",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Construction",
+  },
+  {
+    subCategory: "Community",
+    eventType: "Cultural",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Damaged unsafe infrastructure",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Day-use passes",
+  },
+  {
+    subCategory: "Facilities",
+    eventType: "Dock closure",
+  },
+  {
+    subCategory: "Human health",
+    eventType: "Drinking water",
+  },
+  {
+    subCategory: "Environment and wildlife",
+    eventType: "Ecosystem protection",
+  },
+  {
+    subCategory: "Environment and wildlife",
+    eventType: "Ecosystem restoration project",
+  },
+  {
+    subCategory: "Environment and wildlife",
+    eventType: "Environmental related",
+  },
+  {
+    subCategory: "Community",
+    eventType: "Event",
+  },
+  {
+    subCategory: "Facilities",
+    eventType: "Facilities unavailable",
+  },
+  {
+    subCategory: "Facilities",
+    eventType: "Facility closure",
+  },
+  {
+    subCategory: "Facilities",
+    eventType: "Facility out of service",
+  },
+  {
+    subCategory: "Facilities",
+    eventType: "Facility reopening",
+  },
+  {
+    subCategory: "Community",
+    eventType: "Feedback",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Fire rehabilitation",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Fire suppression activity",
+  },
+  {
+    subCategory: "Natural disasters and emergencies",
+    eventType: "Flood",
+  },
+  {
+    subCategory: "Natural disasters and emergencies",
+    eventType: "Flood damage",
+  },
+  {
+    subCategory: "Environment and wildlife",
+    eventType: "Forest health",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Freshet",
+  },
+  {
+    subCategory: "Natural disasters and emergencies",
+    eventType: "Freshet",
+  }
+  },
+  {
+    subCategory: "Area closures",
+    eventType: "Gate closure",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Group camping",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Hazard conditions",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Hazard facility",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Hazard trees",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Horseback riding",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Hours of operation",
+  },
+  {
+    subCategory: "Human health",
+    eventType: "Human health",
+  },
+  {
+    subCategory: "Weather and seasonal",
+    eventType: "Icy conditions",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Industrial activity",
+  },
+  {
+    subCategory: "Public behaviour",
+    eventType: "Investigation",
+  },
+  {
+    subCategory: "Natural disasters and emergenices",
+    eventType: "Landslide",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Maintenance",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Motorized boats prohibited",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Camping prohibited",
+  },
+  {
+    subCategory: "Public behaviour",
+    eventType: "Noise",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Off-road vehicles",
+  },
+  {
+    subCategory: "Human health",
+    eventType: "Pandemic",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Park access",
+  },
+  {
+    subCategory: "Area closures",
+    eventType: "Park closure",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Park maintenance",
+  },
+  {
+    subCategory: "Park management",
+    eventType: "Park management",
+  },
+  {
+    subCategory: "Park management",
+    eventType: "Park name",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Park re-opening",
+  },
+  {
+    subCategory: "Park management",
+    eventType: "Park policy",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Parking",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Parking lot access",
+  },
+  {
+    subCategory: "Public behaviour",
+    eventType: "Pets",
+  },
+  {
+    subCategory: "Environment and wildlife",
+    eventType: "Prescribed burn",
+  },
+  {
+    subCategory: "Area closures",
+    eventType: "Private land / off-limits",
+  },
+  {
+    subCategory: "Community",
+    eventType: "Public consultation",
+  },
+  {
+    subCategory: "Park management",
+    eventType: "Regulations",
+  },
+  {
+    subCategory: "Park management",
+    eventType: "Reservations",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Road closure",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Road closure",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Road conditions",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Road construction",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Road hazards",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Road hazards",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Road inaccessible",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Road washout",
+  },
+  {
+    subCategory: "Natural disasters and emergenices",
+    eventType: "Rockfall hazard",
+  },
+  {
+    subCategory: "Area closures",
+    eventType: "Scheduled closure",
+  },
+  {
+    subCategory: "Weather and seasonal",
+    eventType: "Seasonal",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Shellfish",
+  },
+  {
+    subCategory: "Human health",
+    eventType: "Shellfish",
+  },
+  {
+    subCategory: "Activities",
+    eventType: "Snowmobiles",
+  },
+  {
+    subCategory: "Weather and seasonal",
+    eventType: "Spring conditions",
+  },
+  {
+    subCategory: "Weather and seasonal",
+    eventType: "Storm damage",
+  },
+  {
+    subCategory: "Public behaviour",
+    eventType: "Thieves",
+  },
+  {
+    subCategory: "Access",
+    eventType: "Trail access",
+  },
+  {
+    subCategory: "Area closures",
+    eventType: "Trail closure",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Trail conditions",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Trail construction",
+  },
+  {
+    subCategory: "Construction/maintenance",
+    eventType: "Trail maintenance",
+  },
+  {
+    subCategory: "Natural disasters and emergenices",
+    eventType: "Tsunami",
+  },
+  {
+    subCategory: "Community",
+    eventType: "Volunteer",
+  },
+  {
+    subCategory: "Human health",
+    eventType: "Water quality",
+  },
+  {
+    subCategory: "Weather and seasonal",
+    eventType: "Weather",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Wildfire",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Wildfire closure year",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Wildfire damage",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Wildfire fuel management",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Wildfire nearby",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Wildfire risk",
+  },
+  {
+    subCategory: "Wildfire",
+    eventType: "Wildfire tree assessment",
+  },
+  {
+    subCategory: "Environment and wildlife",
+    eventType: "Wildlife",
+  },
+  {
+    subCategory: "Environment and wildlife",
+    eventType: "Wildlife protection",
+  },
+  {
+    subCategory: "Weather and seasonal",
+    eventType: "Windstorm damage",
+  },
+  {
+    subCategory: "Weather and seasonal",
+    eventType: "Winter conditions",
+  },
+  {
+    subCategory: "Hazards",
+    eventType: "Public safety",
+  },
+];
+
+async function getSubCategoryMap() {
+  const subCategories = await strapi
+    .documents("api::event-type-sub-category.event-type-sub-category")
+    .findMany({
+      fields: ["documentId", "subCategory"],
+    });
+  const subCategoryMap = {};
+
+  for (const existingSubCategory of subCategories) {
+    subCategoryMap[existingSubCategory.subCategory] = existingSubCategory;
+  }
+
+  return subCategoryMap;
+}
+
+module.exports = {
+  async up(knex) {
+    if (!(await knex.schema.hasTable("event_types"))) {
+      return;
+    }
+
+    // create event_type_sub_categories if it doesn't exist yet
+    if (!(await knex.schema.hasTable("event_type_sub_categories"))) {
+      await knex.schema.createTable("event_type_sub_categories", (table) => {
+        table.increments("id").primary();
+        table.string("document_id", 255);
+        table.string("sub_category", 255);
+        table.string("category", 255);
+        table.timestamp("created_at", { precision: 6 });
+        table.timestamp("updated_at", { precision: 6 });
+        table.timestamp("published_at", { precision: 6 });
+        table
+          .integer("created_by_id")
+          .references("id")
+          .inTable("admin_users")
+          .onDelete("SET NULL");
+        table
+          .integer("updated_by_id")
+          .references("id")
+          .inTable("admin_users")
+          .onDelete("SET NULL");
+        table.string("locale", 255);
+        table.index(
+          ["document_id", "locale", "published_at"],
+          "event_type_sub_categories_documents_idx",
+        );
+        table.index(
+          ["created_by_id"],
+          "event_type_sub_categories_created_by_id_fk",
+        );
+        table.index(
+          ["updated_by_id"],
+          "event_type_sub_categories_updated_by_id_fk",
+        );
+      });
+    }
+
+    // create the link table if it doesn't exist yet
+    if (
+      !(await knex.schema.hasTable("event_types_event_type_sub_categories_lnk"))
+    ) {
+      await knex.schema.createTable(
+        "event_types_event_type_sub_categories_lnk",
+        (table) => {
+          table.increments("id").primary();
+          table
+            .integer("event_type_id")
+            .references("id")
+            .inTable("event_types")
+            .onDelete("CASCADE");
+          table
+            .integer("event_type_sub_category_id")
+            .references("id")
+            .inTable("event_type_sub_categories")
+            .onDelete("CASCADE");
+          table.double("event_type_sub_category_ord");
+          table.unique(["event_type_id", "event_type_sub_category_id"], {
+            indexName: "event_types_event_type_sub_categories_lnk_uq",
+          });
+          table.index(
+            ["event_type_id"],
+            "event_types_event_type_sub_categories_lnk_fk",
+          );
+          table.index(
+            ["event_type_sub_category_id"],
+            "event_types_event_type_sub_categories_lnk_ifk",
+          );
+          table.index(
+            ["event_type_sub_category_ord"],
+            "event_types_event_type_sub_categories_lnk_ofk",
+          );
+        },
+      );
+    }
+
+    // upsert sub-categories and connect event types
+    {
+      let subCategoryMap = await getSubCategoryMap();
+
+      const eventTypeSubCategoryDocuments = strapi.documents(
+        "api::event-type-sub-category.event-type-sub-category",
+      );
+
+      // loop through the subCategories and upsert
+      for (const { category, subCategory } of subCategories) {
+        const existingSubCategory = subCategoryMap[subCategory];
+
+        if (existingSubCategory) {
+          await eventTypeSubCategoryDocuments.update({
+            documentId: existingSubCategory.documentId,
+            data: {
+              category,
+              subCategory,
+            },
+          });
+          continue;
+        }
+
+        await eventTypeSubCategoryDocuments.create({
+          data: {
+            category,
+            subCategory,
+          },
+        });
+      }
+
+      // get the map again
+      subCategoryMap = await getSubCategoryMap();
+
+      // use knex sql to delete extra eventTypes
+      await knex("event_types")
+        .whereIn("event_type", ["Freshet", "Road hazards"])
+        .andWhere("precedence", null)
+        .del();
+
+      // delete the "Shellfish" record with the highest id
+      const shellfishRecords = await knex("event_types")
+        .where("event_type", "Shellfish")
+        .orderBy("id", "desc")
+        .select("id");
+
+      if (shellfishRecords.length > 1) {
+        await knex("event_types").where("id", shellfishRecords[0].id).del();
+      }
+
+      // use `connect()` in the Strapi document api to connect the sub-categories to the event types
+      const eventTypeDocuments = strapi.documents("api::event-type.event-type");
+
+      for (const { subCategory, eventType } of eventTypes) {
+        const existingSubCategory = subCategoryMap[subCategory];
+
+        if (!existingSubCategory) {
+          console.warn(
+            `Sub-category "${subCategory}" not found for event type "${eventType}". Skipping...`,
+          );
+          continue;
+        }
+
+        const existingEventType = await eventTypeDocuments.findMany({
+          filters: {
+            eventType,
+          },
+          limit: 1,
+        });
+
+        if (existingEventType.length === 0) {
+          console.warn(
+            `Event type "${eventType}" not found for sub-category "${subCategory}". Skipping...`,
+          );
+          continue;
+        }
+
+        await eventTypeDocuments.update({
+          documentId: existingEventType[0].documentId,
+          data: {
+            eventTypeSubCategories: {
+              connect: [existingSubCategory.documentId],
+            },
+          },
+        });
+      }
+    }
+  },
+};

--- a/src/cms/src/api/event-type-sub-category/content-types/event-type-sub-category/schema.json
+++ b/src/cms/src/api/event-type-sub-category/content-types/event-type-sub-category/schema.json
@@ -16,6 +16,12 @@
     },
     "category": {
       "type": "string"
+    },
+    "eventTypes": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::event-type.event-type",
+      "inversedBy": "eventTypeSubCategories"
     }
   }
 }

--- a/src/cms/src/api/event-type-sub-category/content-types/event-type-sub-category/schema.json
+++ b/src/cms/src/api/event-type-sub-category/content-types/event-type-sub-category/schema.json
@@ -1,0 +1,21 @@
+{
+  "kind": "collectionType",
+  "collectionName": "event_type_sub_categories",
+  "info": {
+    "singularName": "event-type-sub-category",
+    "pluralName": "event-type-sub-categories",
+    "displayName": "Event-type-sub-category"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "subCategory": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    }
+  }
+}

--- a/src/cms/src/api/event-type-sub-category/controllers/event-type-sub-category.js
+++ b/src/cms/src/api/event-type-sub-category/controllers/event-type-sub-category.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * event-type-sub-category controller
+ */
+
+const { createCoreController } = require("@strapi/strapi").factories;
+
+module.exports = createCoreController(
+  "api::event-type-sub-category.event-type-sub-category",
+);

--- a/src/cms/src/api/event-type-sub-category/routes/event-type-sub-category.js
+++ b/src/cms/src/api/event-type-sub-category/routes/event-type-sub-category.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * event-type-sub-category router
+ */
+
+const { createCoreRouter } = require("@strapi/strapi").factories;
+
+module.exports = createCoreRouter(
+  "api::event-type-sub-category.event-type-sub-category",
+);

--- a/src/cms/src/api/event-type-sub-category/services/event-type-sub-category.js
+++ b/src/cms/src/api/event-type-sub-category/services/event-type-sub-category.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * event-type-sub-category service
+ */
+
+const { createCoreService } = require("@strapi/strapi").factories;
+
+module.exports = createCoreService(
+  "api::event-type-sub-category.event-type-sub-category",
+);

--- a/src/cms/src/api/event-type/content-types/event-type/schema.json
+++ b/src/cms/src/api/event-type/content-types/event-type/schema.json
@@ -26,32 +26,13 @@
       "type": "enumeration",
       "required": true,
       "default": "Both",
-      "enum": [
-        "BCP",
-        "RST",
-        "Both"
-      ]
+      "enum": ["BCP", "RST", "Both"]
     },
-    "groupLabel": {
-      "type": "enumeration",
-      "required": true,
-      "enum": [
-        "Access",
-        "Activities",
-        "Area closures",
-        "Community",
-        "Construction/maintenance",
-        "Environment and wildlife",
-        "Facilities",
-        "Hazards",
-        "Human health",
-        "Natural disasters and emergencies",
-        "Park management",
-        "Public behaviour",
-        "Public safety",
-        "Weather and seasonal",
-        "Wildfire"
-      ]
+    "eventTypeSubCategories": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::event-type-sub-category.event-type-sub-category",
+      "mappedBy": "eventTypes"
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-1722

### Description:

Adds a new eventTypeSubCategory collection to support multiple subcategories per event type and remove reliance on duplicated data.
Refactors eventType to use relationships instead of groupLabel.

This was apparently the original intention for the spreadsheet we were given.

Note: Cross dependency on https://github.com/bcgov/bcparks-staff-portal/pull/640
