### PR TITLE
CMS-1752: Import missing group labels for standard messages

### DIFF
--- a/src/cms/database/migrations/2026.06.22T00.00.018-update-bcp-standard-messages.js
+++ b/src/cms/database/migrations/2026.06.22T00.00.018-update-bcp-standard-messages.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const rstCategoryByTitle = {
+  "Avalanche - Closure": "Environmental",
+  "Construction / rehabilitation - Closure": "Access",
+  "Danger trees - Closure": "Public safety",
+  "Flood - Closure": "Environmental",
+  "General public safety - Closure": "Public safety",
+  "Landslide - Closure": "Environmental",
+  "Public safety assessment - Closure": "Public safety",
+  "Road damage - Warning": "Access",
+  "Road washout - Closure": "Access",
+  "Seasonal - Closure": "Seasonal restrictions",
+  "Seasonal not maintained - Warning": "Seasonal restrictions",
+  "Wildfire - Closure": "Environmental",
+  "Wildlife - Closure": "Environmental",
+};
+
+module.exports = {
+  async up(knex) {
+    if (await knex.schema.hasTable("standard_messages")) {
+      // create the group_label column if it doesn't exist
+      if (!(await knex.schema.hasColumn("standard_messages", "group_label"))) {
+        await knex.schema.table("standard_messages", (table) => {
+          table.string("group_label");
+        });
+      }
+
+      // split BCP titles
+      await knex.raw(`
+        UPDATE standard_messages
+        SET
+          group_label = trim(split_part(title, ' - ', 1)),
+          title = trim(split_part(title, ' - ', 2))
+        WHERE scope = 'BCP'
+          AND title LIKE '% - %'
+      `);
+
+      // Boil water advisory fix
+      await knex("standard_messages")
+        .where({ scope: "BCP", title: "Boil water advisory" })
+        .update({ group_label: "Public safety" });
+
+      // RST updates
+      for (const [title, group_label] of Object.entries(rstCategoryByTitle)) {
+        await knex("standard_messages")
+          .whereRaw("scope = 'RST' AND lower(trim(title)) = lower(?)", [title])
+          .update({
+            group_label,
+            title,
+          });
+      }
+    }
+  },
+};

--- a/src/cms/src/api/standard-message/content-types/standard-message/schema.json
+++ b/src/cms/src/api/standard-message/content-types/standard-message/schema.json
@@ -44,6 +44,19 @@
       "required": true,
       "default": "Both",
       "enum": ["BCP", "RST", "Both"]
+    },
+    "groupLabel": {
+      "type": "enumeration",
+      "required": true,
+      "enum": [
+        "Access",
+        "Environmental",
+        "Public safety",
+        "Seasonal restrictions",
+        "Wildfire",
+        "Wildlife",
+        "Pandemic"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket:
CMS-1752

### Description:
Add the missing "category" column from the spreadsheet as a new `groupLabel` field

The category column was added the the spreadsheet on May 27th, but the migration to import the data was on May 20th. There were also some titles that were changed from title case to sentence case in that period.
