### PR TITLE
CMS-1797: Check isDisplayed in RST resource link code

### DIFF
--- a/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
+++ b/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
@@ -90,10 +90,12 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
       // Add Rec Sites & Trails Resource links where applicable
       const recResources = advisory.recreationResources ?? [];
       advisory.recreationResources = recResources.map((resource) => {
-        // Build the sitesandtrailsbc.ca deep-link using the same logic as the frontend
-        const link = resource.recResourceId
-          ? `https://www.sitesandtrailsbc.ca/resource/${encodeURIComponent(resource.recResourceId)}`
-          : null;
+        // Build the sitesandtrailsbc.ca deep-link using the same logic as the frontend:
+        // Only if isDisplayed is true, and recResourceId is present
+        const link =
+          resource.isDisplayed && resource.recResourceId
+            ? `https://www.sitesandtrailsbc.ca/resource/${encodeURIComponent(resource.recResourceId)}`
+            : null;
         return { ...resource, link };
       });
 
@@ -241,7 +243,9 @@ const getAdvisoryInfo = async function (advisoryNumber) {
           fields: ["siteName", "slug"],
           populate: { protectedArea: { fields: "slug" } },
         },
-        recreationResources: { fields: ["resourceName", "recResourceId"] },
+        recreationResources: {
+          fields: ["resourceName", "recResourceId", "isDisplayed"],
+        },
         standardMessages: { fields: ["description"] },
         urgency: { fields: ["urgency"] },
       },


### PR DESCRIPTION
### Jira Ticket:
CMS-1797

### Description:

Updating the ACT notification email's RST link logic to match the frontend after clarifying that we need to consider `isDisplayed` in our meeting this morning.

Now the link will be left "null" and not used in the email template unless isDisplayed is true.