### PR TITLE
CMS-1825: Queued task events for calling RecSpace crud API

### DIFF
--- a/src/cms/src/helpers/recSpacePayloadSanitizer.js
+++ b/src/cms/src/helpers/recSpacePayloadSanitizer.js
@@ -1,0 +1,93 @@
+/**
+ * Builds a compact Rec Space payload from advisory audit records before
+ * queueing `recspace push public-advisory` tasks.
+ */
+
+/**
+ * Removes common Strapi metadata fields from related entities.
+ */
+function stripCommonEntityMetadata(entity) {
+  if (!entity) {
+    return entity;
+  }
+
+  const { createdAt, updatedAt, documentId, publishedAt, locale, ...rest } =
+    entity;
+
+  return rest;
+}
+
+/**
+ * Removes unused metadata and coordinates from recreation resource entries.
+ */
+function stripRecreationResourceFields(resource) {
+  if (!resource) {
+    return resource;
+  }
+
+  const cleanedResource = stripCommonEntityMetadata(resource);
+  const { latitude, longitude, ...rest } = cleanedResource;
+
+  return rest;
+}
+
+/**
+ * Removes BCP-specific or redundant advisory fields that are not required by
+ * Rec Space queue consumers.
+ */
+function stripBcpSpecificAdvisoryFields(publicAdvisoryAudit) {
+  if (!publicAdvisoryAudit) {
+    return null;
+  }
+
+  const {
+    links,
+    mapZoom,
+    latitude,
+    longitude,
+    createdBy,
+    updatedBy,
+    createdAt,
+    updatedAt,
+    documentId,
+    publishedAt,
+    locale,
+    localizations,
+    protectedAreas,
+    sites,
+    naturalResourceDistricts,
+    managementAreas,
+    regions,
+    sections,
+    fireZones,
+    fireCentres,
+    recreationDistricts,
+    ...rstFields
+  } = publicAdvisoryAudit;
+
+  if (rstFields.urgency) {
+    rstFields.urgency = stripCommonEntityMetadata(rstFields.urgency);
+  }
+  if (rstFields.eventType) {
+    rstFields.eventType = stripCommonEntityMetadata(rstFields.eventType);
+  }
+  if (rstFields.accessStatus) {
+    rstFields.accessStatus = stripCommonEntityMetadata(rstFields.accessStatus);
+  }
+  if (rstFields.advisoryStatus) {
+    rstFields.advisoryStatus = stripCommonEntityMetadata(
+      rstFields.advisoryStatus,
+    );
+  }
+  if (Array.isArray(rstFields.recreationResources)) {
+    rstFields.recreationResources = rstFields.recreationResources.map(
+      stripRecreationResourceFields,
+    );
+  }
+
+  return rstFields;
+}
+
+module.exports = {
+  stripBcpSpecificAdvisoryFields,
+};

--- a/src/cms/src/helpers/taskQueue.js
+++ b/src/cms/src/helpers/taskQueue.js
@@ -1,3 +1,7 @@
+const {
+  stripBcpSpecificAdvisoryFields,
+} = require("./recSpacePayloadSanitizer.js");
+
 module.exports = {
   indexPark: async function (orcs) {
     if (!orcs) {
@@ -121,6 +125,44 @@ module.exports = {
       } catch (error) {
         strapi.log.error(error);
       }
+    }
+  },
+  queueRecSpacePublicAdvisoryCrudEvent: async function (
+    operation,
+    triggerInfo,
+    newPublicAdvisoryAudit,
+    oldPublicAdvisoryAudit = null,
+  ) {
+    if (!operation || !newPublicAdvisoryAudit) {
+      return;
+    }
+
+    const queuedNewPublicAdvisoryAudit = stripBcpSpecificAdvisoryFields(
+      newPublicAdvisoryAudit,
+    );
+    const queuedOldPublicAdvisoryAudit = stripBcpSpecificAdvisoryFields(
+      oldPublicAdvisoryAudit,
+    );
+
+    try {
+      await strapi.documents("api::queued-task.queued-task").create({
+        data: {
+          action: "recspace push public-advisory",
+          numericData: queuedNewPublicAdvisoryAudit.advisoryNumber,
+          jsonData: {
+            operation: operation,
+            triggeredBy: triggerInfo,
+            newPublicAdvisoryAudit: queuedNewPublicAdvisoryAudit,
+            oldPublicAdvisoryAudit: queuedOldPublicAdvisoryAudit,
+          },
+        },
+      });
+
+      strapi.log.info(
+        `queued recspace push public-advisory ${operation} for advisory ${queuedNewPublicAdvisoryAudit.advisoryNumber}`,
+      );
+    } catch (error) {
+      strapi.log.error(error);
     }
   },
 };

--- a/src/cms/src/middlewares/helpers/advisoryData.js
+++ b/src/cms/src/middlewares/helpers/advisoryData.js
@@ -1,3 +1,7 @@
+const {
+  queueRecSpacePublicAdvisoryCrudEvent,
+} = require("../../helpers/taskQueue.js");
+
 /**
  * Creates an archived copy of the provided advisory data.
  */
@@ -21,9 +25,125 @@ async function archiveOldPublicAdvisoryAudit(data) {
   }
 }
 
-async function savePublicAdvisory(publicAdvisory) {
-  delete publicAdvisory.updatedBy;
-  delete publicAdvisory.createdBy;
+async function savePublicAdvisoryAndRecSpaceSync(
+  newPublicAdvisoryAudit,
+  oldPublicAdvisoryAudit = null,
+) {
+  delete newPublicAdvisoryAudit.updatedBy;
+  delete newPublicAdvisoryAudit.createdBy;
+
+  const advisoryStatusCode = newPublicAdvisoryAudit.advisoryStatus?.code;
+
+  // SCH advisories never write to the public-advisory projection table.
+  // Always queue a RecSpace scheduled-create event, then stop.
+  if (advisoryStatusCode === "SCH") {
+    await queueRecSpacePublicAdvisoryCrudEvent(
+      "create scheduled",
+      "advisoryData::savePublicAdvisoryAndRecSpaceSync()#scheduled-public-advisory",
+      newPublicAdvisoryAudit,
+      oldPublicAdvisoryAudit,
+    );
+    return;
+  }
+
+  const isExist = await strapi
+    .documents("api::public-advisory.public-advisory")
+    .findFirst({
+      filters: {
+        advisoryNumber: newPublicAdvisoryAudit.advisoryNumber,
+      },
+      fields: ["id", "documentId", "advisoryNumber"],
+    });
+
+  if (advisoryStatusCode === "PUB") {
+    if (isExist) {
+      try {
+        newPublicAdvisoryAudit.id = isExist.id;
+        newPublicAdvisoryAudit.documentId = isExist.documentId;
+        strapi.log.info(
+          `updating public-advisory advisoryNumber ${newPublicAdvisoryAudit.advisoryNumber}...`,
+        );
+        await strapi.documents("api::public-advisory.public-advisory").update({
+          documentId: isExist.documentId,
+          data: newPublicAdvisoryAudit,
+        });
+        await queueRecSpacePublicAdvisoryCrudEvent(
+          "update",
+          "advisoryData::savePublicAdvisoryAndRecSpaceSync()#update-public-advisory",
+          newPublicAdvisoryAudit,
+          oldPublicAdvisoryAudit,
+        );
+      } catch (error) {
+        strapi.log.error(
+          `error updating public-advisory advisoryNumber ${newPublicAdvisoryAudit.advisoryNumber}...`,
+          error,
+        );
+      }
+    } else {
+      try {
+        delete newPublicAdvisoryAudit.id;
+        delete newPublicAdvisoryAudit.documentId;
+        strapi.log.info(
+          `creating public-advisory advisoryNumber ${newPublicAdvisoryAudit.advisoryNumber}...`,
+        );
+        await strapi.documents("api::public-advisory.public-advisory").create({
+          data: newPublicAdvisoryAudit,
+        });
+        await queueRecSpacePublicAdvisoryCrudEvent(
+          "create",
+          "advisoryData::savePublicAdvisoryAndRecSpaceSync()#create-public-advisory",
+          newPublicAdvisoryAudit,
+          oldPublicAdvisoryAudit,
+        );
+      } catch (error) {
+        strapi.log.error(
+          `error creating public-advisory ${newPublicAdvisoryAudit.id}...`,
+          error,
+        );
+      }
+    }
+  } else if (isExist) {
+    try {
+      strapi.log.info(
+        `deleting public-advisory advisoryNumber ${newPublicAdvisoryAudit.advisoryNumber}...`,
+      );
+      await strapi
+        .documents("api::public-advisory.public-advisory")
+        .delete({ documentId: isExist.documentId });
+      await queueRecSpacePublicAdvisoryCrudEvent(
+        "delete",
+        "advisoryData::savePublicAdvisoryAndRecSpaceSync()#delete-public-advisory",
+        newPublicAdvisoryAudit,
+        oldPublicAdvisoryAudit,
+      );
+    } catch (error) {
+      strapi.log.error(
+        `error deleting public-advisory ${newPublicAdvisoryAudit.id}...`,
+        error,
+      );
+    }
+  }
+}
+
+async function syncProjections(newPublicAdvisory, oldPublicAdvisory = null) {
+  if (newPublicAdvisory.isLatestRevision && newPublicAdvisory.advisoryStatus) {
+    const triggerStatuses = ["PUB", "SCH", "UNP"];
+    if (triggerStatuses.includes(newPublicAdvisory.advisoryStatus.code)) {
+      await savePublicAdvisoryAndRecSpaceSync(
+        newPublicAdvisory,
+        oldPublicAdvisory,
+      );
+    }
+  }
+}
+
+async function queueRecSpaceDelete(publicAdvisory, triggerInfo) {
+  const advisoryStatusCode = publicAdvisory?.advisoryStatus?.code;
+  const scheduledDeleteStatuses = ["UNP", "DFT", "HQR"];
+  if (!scheduledDeleteStatuses.includes(advisoryStatusCode)) {
+    return;
+  }
+
   const isExist = await strapi
     .documents("api::public-advisory.public-advisory")
     .findFirst({
@@ -32,66 +152,19 @@ async function savePublicAdvisory(publicAdvisory) {
       },
       fields: ["advisoryNumber"],
     });
-  if (publicAdvisory.advisoryStatus.code === "PUB") {
-    publicAdvisory.publishedAt = new Date();
-    if (isExist) {
-      try {
-        publicAdvisory.id = isExist.id;
-        publicAdvisory.documentId = isExist.documentId;
-        strapi.log.info(
-          `updating public-advisory advisoryNumber ${publicAdvisory.advisoryNumber}...`,
-        );
-        await strapi.documents("api::public-advisory.public-advisory").update({
-          documentId: isExist.documentId,
-          data: publicAdvisory,
-        });
-      } catch (error) {
-        strapi.log.error(
-          `error updating public-advisory advisoryNumber ${publicAdvisory.advisoryNumber}...`,
-          error,
-        );
-      }
-    } else {
-      try {
-        delete publicAdvisory.id;
-        delete publicAdvisory.documentId;
-        strapi.log.info(
-          `creating public-advisory advisoryNumber ${publicAdvisory.advisoryNumber}...`,
-        );
-        await strapi.documents("api::public-advisory.public-advisory").create({
-          data: publicAdvisory,
-        });
-      } catch (error) {
-        strapi.log.error(
-          `error creating public-advisory ${publicAdvisory.id}...`,
-          error,
-        );
-      }
-    }
-  } else if (isExist) {
-    try {
-      strapi.log.info(
-        `deleting public-advisory advisoryNumber ${publicAdvisory.advisoryNumber}...`,
-      );
-      await strapi
-        .documents("api::public-advisory.public-advisory")
-        .delete({ documentId: isExist.documentId });
-    } catch (error) {
-      strapi.log.error(
-        `error deleting public-advisory ${publicAdvisory.id}...`,
-        error,
-      );
-    }
-  }
-}
 
-async function copyToPublicAdvisory(newPublicAdvisory) {
-  if (newPublicAdvisory.isLatestRevision && newPublicAdvisory.advisoryStatus) {
-    const triggerStatuses = ["PUB", "UNP"];
-    if (triggerStatuses.includes(newPublicAdvisory.advisoryStatus.code)) {
-      await savePublicAdvisory(newPublicAdvisory);
-    }
+  // If there is a projection of the advisory in the public-advisory table,
+  // then an earlier revision is currently published. Skip the delete
+  // event so we don't delete the published advisory in RecSpace.
+  if (isExist) {
+    return;
   }
+
+  await queueRecSpacePublicAdvisoryCrudEvent(
+    "delete scheduled",
+    triggerInfo,
+    publicAdvisory,
+  );
 }
 
 function isAdvisoryEqual(newData, oldData) {
@@ -146,7 +219,7 @@ function isAdvisoryEqual(newData, oldData) {
 
 module.exports = {
   archiveOldPublicAdvisoryAudit,
-  savePublicAdvisory,
-  copyToPublicAdvisory,
+  queueRecSpaceDelete,
+  syncProjections,
   isAdvisoryEqual,
 };

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -12,7 +12,8 @@ const {
 } = require("./helpers/advisoryStatus.js");
 const {
   archiveOldPublicAdvisoryAudit,
-  copyToPublicAdvisory,
+  syncProjections,
+  queueRecSpaceDelete,
   isAdvisoryEqual,
 } = require("./helpers/advisoryData.js");
 const { METADATA_FIELDS } = require("../helpers/advisoryEmailMetadata.js");
@@ -55,7 +56,7 @@ module.exports = () => {
         `Review draft: ${urgency} urgency advisory / closure`,
         "A draft advisory / closure is ready for review:",
         newPublicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterCreate()",
+        "staff-portal-advisory-audit::afterCreate()",
         [],
         [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
       );
@@ -71,7 +72,7 @@ module.exports = () => {
         "After-hours advisory / closure was posted",
         "An after-hours advisory / closure was posted:",
         newPublicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterCreate()",
+        "staff-portal-advisory-audit::afterCreate()",
         [],
         [METADATA_FIELDS.POSTING_DATE],
       );
@@ -87,13 +88,13 @@ module.exports = () => {
         `Review posting: ${urgency} urgency advisory / closure`,
         "An advisory / closure is ready for review:",
         newPublicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterCreate()",
+        "staff-portal-advisory-audit::afterCreate()",
         [],
         [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
       );
     }
 
-    await copyToPublicAdvisory(newPublicAdvisoryAudit);
+    await syncProjections(newPublicAdvisoryAudit, null);
   }
 
   /**
@@ -193,24 +194,35 @@ module.exports = () => {
   async function afterUpdate(ctx) {
     if (!ctx?.result?.documentId) return;
 
-    const publicAdvisoryAudit = await strapi
+    const newPublicAdvisoryAudit = await strapi
       .documents("api::public-advisory-audit.public-advisory-audit")
       .findOne({
         documentId: ctx.result.documentId,
         populate: "*",
       });
 
-    const oldAdvisoryStatus = ctx.state?.oldStatus; // saved by beforeUpdate() above
-    const newAdvisoryStatus = publicAdvisoryAudit.advisoryStatus?.code;
+    const oldPublicAdvisory = await strapi
+      .documents("api::public-advisory-audit.public-advisory-audit")
+      .findFirst({
+        filters: {
+          advisoryNumber: newPublicAdvisoryAudit.advisoryNumber,
+          revisionNumber: newPublicAdvisoryAudit.revisionNumber - 1,
+        },
+        populate: "*",
+      });
 
-    const urgency = publicAdvisoryAudit.urgency?.urgency?.toLowerCase() ?? "";
+    const oldAdvisoryStatus = ctx.state?.oldStatus; // saved by beforeUpdate() above
+    const newAdvisoryStatus = newPublicAdvisoryAudit.advisoryStatus?.code;
+
+    const urgency =
+      newPublicAdvisoryAudit.urgency?.urgency?.toLowerCase() ?? "";
 
     if (newAdvisoryStatus === "HQR" && oldAdvisoryStatus !== "HQR") {
       await queueAdvisoryEmail(
         `Review draft: ${urgency} urgency advisory / closure`,
         "A draft advisory / closure is ready for review:",
-        publicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterUpdate()",
+        newPublicAdvisoryAudit.advisoryNumber,
+        "staff-portal-advisory-audit::afterUpdate()",
         [],
         [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
       );
@@ -219,17 +231,17 @@ module.exports = () => {
     if (
       newAdvisoryStatus === "PUB" &&
       oldAdvisoryStatus !== "PUB" &&
-      (publicAdvisoryAudit.modifiedByRole === "submitter" ||
-        publicAdvisoryAudit.modifiedByRole === "contributor") && // TODO: determine after-hours rules for contributors
-      publicAdvisoryAudit.isUrgentAfterHours
+      (newPublicAdvisoryAudit.modifiedByRole === "submitter" ||
+        newPublicAdvisoryAudit.modifiedByRole === "contributor") &&
+      newPublicAdvisoryAudit.isUrgentAfterHours
     ) {
       // After-hours posting notification
       // If users with after-hours posting permission posted this with an urgent/after-hours flag
       await queueAdvisoryEmail(
         "After-hours advisory / closure was posted",
         "An after-hours advisory / closure was posted:",
-        publicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterUpdate()",
+        newPublicAdvisoryAudit.advisoryNumber,
+        "staff-portal-advisory-audit::afterUpdate()",
         [],
         [METADATA_FIELDS.POSTING_DATE],
       );
@@ -238,21 +250,31 @@ module.exports = () => {
         (newAdvisoryStatus === "PUB" && oldAdvisoryStatus !== "PUB")) &&
       // Don't send a notification if the advisory was posted by HQ Staff (approver role)
       // because they are the ones who will be reviewing it.
-      publicAdvisoryAudit.modifiedByRole !== "approver"
+      newPublicAdvisoryAudit.modifiedByRole !== "approver"
     ) {
       // Regular posting notification:
       // If the status changed from some other status to SCH or PUB
       await queueAdvisoryEmail(
         `Review posting: ${urgency} urgency advisory / closure`,
         "An advisory / closure is ready for review:",
-        publicAdvisoryAudit.advisoryNumber,
-        "public-advisory-audit::lifecycles::afterUpdate()",
+        newPublicAdvisoryAudit.advisoryNumber,
+        "staff-portal-advisory-audit::afterUpdate()",
         [],
         [METADATA_FIELDS.POSTING_DATE, METADATA_FIELDS.SUBMITTER],
       );
     }
 
-    await copyToPublicAdvisory(publicAdvisoryAudit);
+    if (
+      oldAdvisoryStatus === "SCH" &&
+      !["SCH", "PUB"].includes(newAdvisoryStatus)
+    ) {
+      await queueRecSpaceDelete(
+        newPublicAdvisoryAudit,
+        "staff-portal-advisory-audit::afterUpdate()",
+      );
+    }
+
+    await syncProjections(newPublicAdvisoryAudit, oldPublicAdvisory);
   }
 
   // Middleware entry point


### PR DESCRIPTION
### Jira Ticket:
CMS-1825

### Description:
This PR lays the groundwork for Orca CRUD integration by ensuring advisory lifecycle activity is consistently emitted to the queued tasks table for downstream processing. In this change, the system now publishes queue messages when advisory records are created, updated, unpublished/deleted, and when scheduled advisory states change. That includes scheduled advisories that are intentionally not projected to the public-advisory table today, but still need to be represented in RST’s downstream system.

The queued payload now carries both the current advisory audit record and the previous advisory audit record when available, so a later consumer can make revision-aware decisions during CRUD processing. To support this reliably, the previous revision is resolved using advisory number and prior revision matching, rather than relying on documentId-only semantics.

The important scope boundary is that this PR does not call the Orca API yet. The outcome here is queue-message generation only, with the required context included so the follow-up ticket can consume these messages and perform the actual Orca CRUD calls.