### PR TITLE
CMS-946: Update advisory sort order

### DIFF
--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -14,12 +14,15 @@ import AdvisoryDate from "../advisories/advisoryDate"
 import blueAlertIcon from "../../images/park/blue-alert.svg"
 import redAlertIcon from "../../images/park/red-alert.svg"
 import yellowAlertIcon from "../../images/park/yellow-alert.svg"
-import { getAdvisoryDate } from "../../utils/advisoryHelper"
 import { trackSnowplowEvent } from "../../utils/snowplowHelper"
 import "../../styles/advisories/advisoryDetails.scss"
 
 const formatDate = isoDate => {
   return isoDate ? format(parseJSON(isoDate), "MMMM d, yyyy") : ""
+}
+
+const getTimestamp = isoDate => {
+  return isoDate ? parseJSON(isoDate).getTime() : null
 }
 
 export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus }) {
@@ -30,11 +33,13 @@ export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus
       'listingRank',
       'urgency.sequence',
       'accessStatus.precedence',
-      'eventType.precedence',
-      // display date
-      getAdvisoryDate
+      // updatedDate first when available
+      advisory => getTimestamp(advisory.updatedDate),
+      // then advisoryDate
+      advisory => getTimestamp(advisory.advisoryDate),
+      'eventType.precedence'
     ],
-    ['desc', 'desc', 'asc', 'asc', 'desc']
+    ['desc', 'desc', 'asc', 'desc', 'desc', 'asc']
   )
 
   const [openAccordions, setOpenAccordions] = useState({})


### PR DESCRIPTION
### Jira Ticket:
CMS-946

### Description:
- Updated the advisory sort order on the park page
- The new sort order
1. listingRank:DESC
2. urgency.sequence:DESC
3. accessStatus.precedence:ASC
4. updatedDate:DESC (if not null)
5. advisoryDate:DESC *updatedDate > advisoryDate, even if isXDateDisplayed=false; do not use isXDateDisplayed boolean fields for sort order logic
6. eventType.precedence:ASC
