### PR TITLE
CMS-1826: RST API Helm refactoring

### DIFF
--- a/infrastructure/helm/deployment/templates/etl/etl-cronjob.yaml
+++ b/infrastructure/helm/deployment/templates/etl/etl-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
                 - name: STRAPI_BASE_URL
                   value: {{ .Values.cms.env.externalUrl }}
                 - name: RST_API
-                  value: {{ .Values.etl.env.rstApi }}
+                  value: {{ .Values.cluster.recSpaceApiUrl }}/api/v1
                 - name: STRAPI_API_TOKEN
                   valueFrom:
                     secretKeyRef:

--- a/infrastructure/helm/deployment/templates/scheduler/scheduler-deployment.yaml
+++ b/infrastructure/helm/deployment/templates/scheduler/scheduler-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: ADMIN_URL
               value: {{ .Values.cluster.staffPortalUrl | quote }}
             - name: REC_SPACE_BASE_URL
-              value: {{ .Values.scheduler.env.recSpaceBaseUrl | quote }}
+              value: {{ .Values.cluster.recSpaceApiUrl | quote }}
             - name: REC_SPACE_KEYCLOAK_TOKEN_URL
               value: {{ .Values.scheduler.env.recSpaceKeycloakTokenUrl | quote }}
             - name: REC_SPACE_KEYCLOAK_CLIENT_ID

--- a/infrastructure/helm/deployment/values-alpha-dev.yaml
+++ b/infrastructure/helm/deployment/values-alpha-dev.yaml
@@ -2,6 +2,7 @@ cluster:
   ssoAuthUrl: https://dev.loginproxy.gov.bc.ca/auth
   publicUrl: https://alpha-dev.bcparks.ca
   staffPortalUrl: https://alpha-dev-staff.bcparks.ca
+  recSpaceApiUrl: https://d1b4b6mhsdovf2.cloudfront.net
 
 images:
   strapi:
@@ -33,6 +34,5 @@ scheduler:
     emailEnabled: true
     emailRecipient: manuji@oxd.com,mike@oxd.com
     emailRecipientWhitelist: manuji@oxd.com,mike@oxd.com
-    recSpaceBaseUrl: https://d1b4b6mhsdovf2.cloudfront.net
     recSpaceKeycloakTokenUrl: https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token
     recSpaceKeycloakClientId: testing-act-integration-6456

--- a/infrastructure/helm/deployment/values-alpha-test.yaml
+++ b/infrastructure/helm/deployment/values-alpha-test.yaml
@@ -2,6 +2,7 @@ cluster:
   ssoAuthUrl: https://test.loginproxy.gov.bc.ca/auth
   publicUrl: https://alpha-test.bcparks.ca
   staffPortalUrl: https://alpha-test-staff.bcparks.ca
+  recSpaceApiUrl: https://dpeu7dmgz4j6y.cloudfront.net
 
 images:
   strapi:
@@ -43,6 +44,5 @@ scheduler:
     emailEnabled: true
     emailRecipient: manuji@oxd.com,mike@oxd.com
     emailRecipientWhitelist: manuji@oxd.com,mike@oxd.com
-    recSpaceBaseUrl: https://dk1yyyipojdmy.cloudfront.net
     recSpaceKeycloakTokenUrl: https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token
     recSpaceKeycloakClientId: testing-act-integration-6456

--- a/infrastructure/helm/deployment/values-dev.yaml
+++ b/infrastructure/helm/deployment/values-dev.yaml
@@ -2,6 +2,7 @@ cluster:
   ssoAuthUrl: https://loginproxy.gov.bc.ca/auth
   publicUrl: https://dev.bcparks.ca
   staffPortalUrl: https://dev-staff.bcparks.ca
+  recSpaceApiUrl: https://dv5oa6g5xh0tq.cloudfront.net
 
 cms:
   env:
@@ -16,7 +17,6 @@ scheduler:
     emailEnabled: true
     emailRecipient: manuji@oxd.com,mike@oxd.com
     emailRecipientWhitelist: manuji@oxd.com,mike@oxd.com
-    recSpaceBaseUrl: https://dv5oa6g5xh0tq.cloudfront.net
     recSpaceKeycloakTokenUrl: https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token
     recSpaceKeycloakClientId: testing-act-integration-6456
 

--- a/infrastructure/helm/deployment/values-prod.yaml
+++ b/infrastructure/helm/deployment/values-prod.yaml
@@ -2,6 +2,7 @@ cluster:
   ssoAuthUrl: https://loginproxy.gov.bc.ca/auth
   publicUrl: https://bcparks.ca
   staffPortalUrl: https://staff.bcparks.ca
+  recSpaceApiUrl: https://dj2qs6gf0wkg3.cloudfront.net
 
 images:
   strapi:
@@ -50,11 +51,9 @@ public:
 etl:
   env:
     parkNamesApi: https://data.bcparks.ca/api/parks/names?status=established
-    rstApi: https://dj2qs6gf0wkg3.cloudfront.net/api/v1
 
 scheduler:
   env:
     emailEnabled: true
-    recSpaceBaseUrl: https://dj2qs6gf0wkg3.cloudfront.net
     recSpaceKeycloakTokenUrl: https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token
     recSpaceKeycloakClientId: testing-act-integration-6456

--- a/infrastructure/helm/deployment/values-test.yaml
+++ b/infrastructure/helm/deployment/values-test.yaml
@@ -2,7 +2,7 @@ cluster:
   ssoAuthUrl: https://test.loginproxy.gov.bc.ca/auth
   publicUrl: https://test.bcparks.ca
   staffPortalUrl: https://test-staff.bcparks.ca
-  recSpaceApiUrl: https://dk1yyyipojdmy.cloudfront.net
+  recSpaceApiUrl: https://dj7ul2th5369y.cloudfront.net
 
 images:
   strapi:

--- a/infrastructure/helm/deployment/values-test.yaml
+++ b/infrastructure/helm/deployment/values-test.yaml
@@ -2,6 +2,7 @@ cluster:
   ssoAuthUrl: https://test.loginproxy.gov.bc.ca/auth
   publicUrl: https://test.bcparks.ca
   staffPortalUrl: https://test-staff.bcparks.ca
+  recSpaceApiUrl: https://dk1yyyipojdmy.cloudfront.net
 
 images:
   strapi:
@@ -28,6 +29,5 @@ crunchy:
 scheduler:
   env:
     emailEnabled: true
-    recSpaceBaseUrl: https://dk1yyyipojdmy.cloudfront.net
     recSpaceKeycloakTokenUrl: https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token
     recSpaceKeycloakClientId: testing-act-integration-6456

--- a/infrastructure/helm/deployment/values.yaml
+++ b/infrastructure/helm/deployment/values.yaml
@@ -4,6 +4,7 @@ cluster:
   ssoRealm: bcparks-service-transformation
   ssoClientId: staff-portal
   staffPortalUrl: https://dev-staff.bcparks.ca
+  recSpaceApiUrl: https://dv5oa6g5xh0tq.cloudfront.net
 
 images:
   strapi:
@@ -133,7 +134,6 @@ etl:
   env:
     bcwfsBansApi: https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=GetFeature&typeName=WHSE_LAND_AND_NATURAL_RESOURCE.PROT_BANS_AND_PROHIBITIONS_SP&count=50&outputFormat=json
     parkNamesApi: https://test-data.bcparks.ca/api/parks/names?status=established
-    rstApi: https://dj7ul2th5369y.cloudfront.net/api/v1
 
   resources:
     requests:


### PR DESCRIPTION
### Jira Ticket:
CMS-1826

### Description:
Combined ETL settings with scheduler settings since they both use the RST API. 

I could have standardized the environment variable names and URL path too, but I opted against that because it would change `.env` and `.env.example` in the etl and scheduler projects requiring everyone to update their local dev environments.
