### PR TITLE
CMS-1916: Fix gatsby build error

### DIFF
--- a/src/gatsby/gatsby-node.js
+++ b/src/gatsby/gatsby-node.js
@@ -224,7 +224,16 @@ exports.createSchemaCustomization = ({ actions }) => {
     updatedAt: Date
   }
 
+  type STRAPI_PROTECTED_AREA_DESCRIPTION_TEXTNODE implements Node @dontInfer {
+    description: String
+  }
+
+  type STRAPI_PROTECTED_AREADescription {
+    data: STRAPI_PROTECTED_AREA_DESCRIPTION_TEXTNODE @link(by: "id", from: "data___NODE")
+  }
+
   type STRAPI_PROTECTED_AREA implements Node {
+    description: STRAPI_PROTECTED_AREADescription
     managementDocuments:[STRAPI_MANAGEMENT_DOCUMENT] @link(by: "id", from: "managementDocuments___NODE")
     biogeoclimaticZones: [STRAPI_BIOGEOCLIMATIC_ZONE] @link(by: "id", from: "biogeoclimaticZones___NODE")
     marineEcosections: [STRAPI_MARINE_ECOSECTION] @link(by: "id", from: "marineEcosections___NODE")

--- a/src/gatsby/src/components/park/nearbyPark.js
+++ b/src/gatsby/src/components/park/nearbyPark.js
@@ -11,7 +11,7 @@ import { addSmallImagePrefix, handleImgError } from "../../utils/helpers"
 const NearbyPark = ({ park }) => {
   // sort photos to keep the same conditions as the find a park page
   // ref: scheduler/elasticsearch/transformers/park/main.js
-  const photos = park.parkPhotos
+  const photos = (park.parkPhotos || [])
     .filter(p => p.isActive)
     .sort((a, b) => {
       if (a.isFeatured && !b.isFeatured) {

--- a/src/gatsby/src/components/park/parkHeader.js
+++ b/src/gatsby/src/components/park/parkHeader.js
@@ -94,7 +94,7 @@ export default function ParkHeader({
   const externalLink =
     `${mapUrl}&center=${longitude},${latitude}&level=${linkZoom}`
   // Get the park operation dates
-  const parkDates = getParkDates(operationDates)
+  const parkDates = getParkDates(operationDates || [])
   const parkReservationsURL = parkOperation?.reservationUrl || reservationsURL
   const parkDayUsePassURL = parkOperation?.dayUsePassUrl || dayUsePassURL
   const hasParkDates = parkDates && parkDates.length > 0

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -347,14 +347,15 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
       const managementAreas = x.managementAreas || []
       const fireZones = x.fireZones || []
+      const naturalResourceDistricts = x.naturalResourceDistricts || []
 
       hash[nodeId.toString()] = {
         managementAreas: managementAreas.map(m => { return m.strapi_id }),
         sections: managementAreas.map(m => { return m.section?.id }),
         regions: managementAreas.map(m => { return m.region?.id }),
         fireZones: fireZones.map(m => { return m.strapi_id }),
-        naturalResourceDistricts: (x.naturalResourceDistricts || []).map(m => m.strapi_id),
-        fireCentres: fireZones.map(m => { return m.fireCentre?.id })
+        fireCentres: fireZones.map(m => { return m.fireCentre?.id }),
+        naturalResourceDistricts: naturalResourceDistricts.map(m => m.strapi_id),
       };
     }
     return hash;

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -340,13 +340,21 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   const buildParkInfoHash = () => {
     const hash = {};
     for (const x of (data?.allStrapiProtectedArea.nodes || [])) {
-      hash[x?.strapi_id.toString()] = {
-        managementAreas: x.managementAreas.map(m => { return m.strapi_id }),
-        sections: x.managementAreas.map(m => { return m.section?.id }),
-        regions: x.managementAreas.map(m => { return m.region?.id }),
-        fireZones: x.fireZones.map(m => { return m.strapi_id }),
+      const nodeId = x?.strapi_id
+      if (!nodeId) {
+        continue
+      }
+
+      const managementAreas = x.managementAreas || []
+      const fireZones = x.fireZones || []
+
+      hash[nodeId.toString()] = {
+        managementAreas: managementAreas.map(m => { return m.strapi_id }),
+        sections: managementAreas.map(m => { return m.section?.id }),
+        regions: managementAreas.map(m => { return m.region?.id }),
+        fireZones: fireZones.map(m => { return m.strapi_id }),
         naturalResourceDistricts: (x.naturalResourceDistricts || []).map(m => m.strapi_id),
-        fireCentres: x.fireZones.map(m => { return m.fireCentre?.id })
+        fireCentres: fireZones.map(m => { return m.fireCentre?.id })
       };
     }
     return hash;

--- a/src/gatsby/src/templates/park.js
+++ b/src/gatsby/src/templates/park.js
@@ -46,17 +46,17 @@ export default function ParkTemplate({ data }) {
   const operations = park.parkOperation || {}
   const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]
 
-  const description = park.description.data.description
-  const safetyInfo = park.safetyInfo.data.safetyInfo
-  const specialNotes = park.specialNotes.data.specialNotes
-  const locationNotes = park.locationNotes.data.locationNotes
-  const conservation = park.conservation.data.conservation
-  const culturalHeritage = park.culturalHeritage.data.culturalHeritage
-  const history = park.history.data.history
-  const wildlife = park.wildlife.data.wildlife
-  const reconciliationNotes = park.reconciliationNotes.data.reconciliationNotes
-  const maps = park.maps.data.maps
-  const contact = park.parkContact.data.parkContact
+  const description = park.description?.data?.description
+  const safetyInfo = park.safetyInfo?.data?.safetyInfo
+  const specialNotes = park.specialNotes?.data?.specialNotes
+  const locationNotes = park.locationNotes?.data?.locationNotes
+  const conservation = park.conservation?.data?.conservation
+  const culturalHeritage = park.culturalHeritage?.data?.culturalHeritage
+  const history = park.history?.data?.history
+  const wildlife = park.wildlife?.data?.wildlife
+  const reconciliationNotes = park.reconciliationNotes?.data?.reconciliationNotes
+  const maps = park.maps?.data?.maps
+  const contact = park.parkContact?.data?.parkContact
   const hasNearbyParks = park.nearbyParks?.length > 0
   const nearbyParks = park.nearbyParks
   const hasParkGuidelines = park.parkGuidelines?.length > 0
@@ -64,7 +64,7 @@ export default function ParkTemplate({ data }) {
   const searchArea = managementAreas[0]?.searchArea || {}
 
   const activeActivities = sortBy(
-    park.parkActivities.filter(
+    (park.parkActivities || []).filter(
       activity => activity.isActive && activity.activityType?.isActive
     ),
     ["activityType.rank", "activityType.activityName"],
@@ -159,7 +159,7 @@ export default function ParkTemplate({ data }) {
 
   // set active facilities
   useEffect(() => {
-    if (park.parkFacilities.length > 0 &&
+    if (park.parkFacilities?.length > 0 &&
       data.allStrapiFacilityType.nodes.length > 0
     ) {
       const facilities = combineFacilities(
@@ -173,7 +173,7 @@ export default function ParkTemplate({ data }) {
 
   // set active campings
   useEffect(() => {
-    if (park.parkCampingTypes.length > 0 &&
+    if (park.parkCampingTypes?.length > 0 &&
       data.allStrapiCampingType.nodes.length > 0
     ) {
       const campings = combineCampingTypes(
@@ -517,7 +517,7 @@ export default function ParkTemplate({ data }) {
               <div ref={contactRef} className="w-100">
                 <Contact
                   contact={contact}
-                  parkContacts={park.parkContacts}
+                  parkContacts={park.parkContacts || []}
                   operations={operations}
                 />
               </div>
@@ -538,7 +538,7 @@ export default function ParkTemplate({ data }) {
 export const Head = ({ data }) => {
   const park = data.strapiProtectedArea
   const seo = park.seo
-  const description = park.description.data.description
+  const description = park.description?.data?.description || ""
   const parkDescription = description.replace(/(<([^>]+)>)/ig, '');
   const parkDescriptionShort = truncate(parkDescription, { length: 160 });
   const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]

--- a/src/gatsby/src/templates/parkSubPage.js
+++ b/src/gatsby/src/templates/parkSubPage.js
@@ -87,9 +87,15 @@ export default function ParkSubPage({ data }) {
     >
       Find a park
     </GatsbyLink>,
-    <GatsbyLink key="3" to={`/${parkSlug}`}>
-      {parkName}
-    </GatsbyLink>,
+    park?.slug ? (
+      <GatsbyLink key="3" to={`/${parkSlug}`}>
+        {parkName}
+      </GatsbyLink>
+    ) : (
+      <div key="3" className="breadcrumb-text">
+        {parkName}
+      </div>
+    ),
     <div key="4" className="breadcrumb-text">
       {page.title}
     </div>,

--- a/src/gatsby/src/templates/parkSubPage.js
+++ b/src/gatsby/src/templates/parkSubPage.js
@@ -21,6 +21,8 @@ export default function ParkSubPage({ data }) {
   const contents = page.content
   const header = page.pageHeader
   const park = page.protectedArea
+  const parkSlug = park?.slug || "no-protected-area"
+  const parkName = park?.protectedAreaName || "Protected area"
   const menuContent = data?.allStrapiMenu?.nodes || []
   const sections = contents?.filter(content => Boolean(content.strapi_component === "parks.page-section")) || []
   const hasSections = sections.length > 0
@@ -85,8 +87,8 @@ export default function ParkSubPage({ data }) {
     >
       Find a park
     </GatsbyLink>,
-    <GatsbyLink key="3" to={`/${park.slug}`}>
-      {park.protectedAreaName}
+    <GatsbyLink key="3" to={`/${parkSlug}`}>
+      {parkName}
     </GatsbyLink>,
     <div key="4" className="breadcrumb-text">
       {page.title}
@@ -111,7 +113,7 @@ export default function ParkSubPage({ data }) {
           </div>
         )}
         <h1 className="header-title">
-          {park.protectedAreaName}: {header?.title ?? page.title}
+          {parkName}: {header?.title ?? page.title}
         </h1>
       </div>
       {hasSections && (
@@ -136,7 +138,7 @@ export default function ParkSubPage({ data }) {
               <div className="page-content col-md-8 col-12">
                 {header && (
                   <div className="header-content">
-                    {header.introHtml.data.introHtml &&
+                    {header.introHtml?.data?.introHtml &&
                       <HtmlContent>{header.introHtml.data.introHtml}</HtmlContent>
                     }
                   </div>
@@ -156,7 +158,7 @@ export default function ParkSubPage({ data }) {
             </div>
           ) : (
             <div>
-              {header && header.introHtml.data.introHtml && (
+              {header?.introHtml?.data?.introHtml && (
                 <div className="header-content">
                   <HtmlContent>{header.introHtml.data.introHtml}</HtmlContent>
                 </div>
@@ -183,10 +185,11 @@ export const Head = ({ data }) => {
   const page = data.strapiParkSubPage
   const park = page.protectedArea
   const seo = page.seo
+  const parkName = park?.protectedAreaName || "Protected area"
 
   return (
     <Seo
-      title={seo?.metaTitle ?? park.protectedAreaName + ": " + page.title}
+      title={seo?.metaTitle ?? parkName + ": " + page.title}
       description={seo?.metaDescription}
       keywords={seo?.metaKeywords}
       image={page.pageHeader?.imageUrl}

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -273,12 +273,18 @@ export default function SiteTemplate({ data }) {
     >
       Find a park
     </GatsbyLink>,
-    <GatsbyLink
-      key="3"
-      to={`/${parkSlug}`}
-    >
-      {parkName}
-    </GatsbyLink>,
+    park?.slug ? (
+      <GatsbyLink
+        key="3"
+        to={`/${parkSlug}`}
+      >
+        {parkName}
+      </GatsbyLink>
+    ) : (
+      <div key="3" className="breadcrumb-text">
+        {parkName}
+      </div>
+    ),
     <div key="4" className="breadcrumb-text">
       {site.siteName}
     </div>,

--- a/src/gatsby/src/templates/site.js
+++ b/src/gatsby/src/templates/site.js
@@ -37,18 +37,20 @@ export default function SiteTemplate({ data }) {
 
   const site = data.strapiSite
   const park = site.protectedArea
+  const parkSlug = park?.slug || "no-protected-area"
+  const parkName = park?.protectedAreaName || "Protected area"
   const operations = site.parkOperation || {}
   const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]
 
-  const description = site.description.data.description
+  const description = site.description?.data?.description
   const safetyInfo = site.safetyInfo?.data?.safetyInfo
-  const locationNotes = site.locationNotes.data.locationNotes
+  const locationNotes = site.locationNotes?.data?.locationNotes
   const hasSiteGuidelines = site.parkGuidelines?.length > 0
-  const managementAreas = park.managementAreas || []
+  const managementAreas = park?.managementAreas || []
   const searchArea = managementAreas[0]?.searchArea || {}
 
   const activeActivities = sortBy(
-    site.parkActivities.filter(
+    (site.parkActivities || []).filter(
       activity => activity.isActive && activity.activityType?.isActive
     ),
     ["activityType.rank", "activityType.activityName"],
@@ -104,6 +106,15 @@ export default function SiteTemplate({ data }) {
   
   const loadProtectedAreaData = async () => {
     setIsLoadingProtectedArea(true)
+    if (!park?.orcs) {
+      setHasCampfireBan(false)
+      setParkGate({})
+      setParkGateDates([])
+      setProtectedAreaLoadError(false)
+      setIsLoadingProtectedArea(false)
+      return
+    }
+
     try {
       const response = await getProtectedArea(apiBaseUrl, park.orcs)
       setHasCampfireBan(response.hasCampfireBan)
@@ -152,7 +163,7 @@ export default function SiteTemplate({ data }) {
 
   // set active facilities
   useEffect(() => {
-    if (site.parkFacilities.length > 0 &&
+    if (site.parkFacilities?.length > 0 &&
       data.allStrapiFacilityType.nodes.length > 0
     ) {
       const facilities = combineFacilities(
@@ -166,7 +177,7 @@ export default function SiteTemplate({ data }) {
 
     // set active campings
     useEffect(() => {
-      if (site.parkCampingTypes.length > 0 &&
+      if (site.parkCampingTypes?.length > 0 &&
         data.allStrapiCampingType.nodes.length > 0
       ) {
         const campings = combineCampingTypes(
@@ -264,9 +275,9 @@ export default function SiteTemplate({ data }) {
     </GatsbyLink>,
     <GatsbyLink
       key="3"
-      to={`/${park?.slug ? park.slug : 'parks/protected-area'}`}
+      to={`/${parkSlug}`}
     >
-      {park?.protectedAreaName}
+      {parkName}
     </GatsbyLink>,
     <div key="4" className="breadcrumb-text">
       {site.siteName}
@@ -283,8 +294,8 @@ export default function SiteTemplate({ data }) {
           </div>
           <ParkHeader
             orcs={site.orcsSiteNumber}
-            slug={`${park.slug}/${site.slug}`}
-            parkName={`${park?.protectedAreaName}: ${site.siteName}`}
+            slug={`${parkSlug}/${site.slug}`}
+            parkName={`${parkName}: ${site.siteName}`}
             parkType="site"
             mapZoom={site.mapZoom}
             latitude={site.latitude}
@@ -454,7 +465,7 @@ export default function SiteTemplate({ data }) {
 export const Head = ({ data }) => {
   const site = data.strapiSite
   const park = site.protectedArea
-  const description = site.description.data.description
+  const description = site.description?.data?.description || ""
   const siteDescription = description.replace(/(<([^>]+)>)/ig, '');
   const siteDescriptionShort = truncate(siteDescription, { length: 160 });
   const photos = [...data.featuredPhotos.nodes, ...data.regularPhotos.nodes]
@@ -462,7 +473,7 @@ export const Head = ({ data }) => {
 
   return (
     <Seo
-      title={`${park?.protectedAreaName}: ${site.siteName}`}
+      title={`${park?.protectedAreaName || "Protected area"}: ${site.siteName}`}
       description={siteDescriptionShort}
       image={photoUrl}
     />

--- a/src/gatsby/src/utils/parkDatesHelper.js
+++ b/src/gatsby/src/utils/parkDatesHelper.js
@@ -67,7 +67,7 @@ const joinDateRanges = (dateRanges) => {
 
 // Get feature dates formatted
 const getFeatureDates = (dateArray) => {
-  return dateArray
+  return (dateArray || [])
     .sort((a, b) => new Date(a.start) - new Date(b.start))
     .map(dateRange => {
       const dateStr = formatDateRange(dateRange.start, dateRange.end)
@@ -79,7 +79,7 @@ const getFeatureDates = (dateArray) => {
 
 // Get park dates formatted (current year only)
 const getParkDates = (parkOperationDates) => {  
-  if (parkOperationDates.length === 0) {
+  if (!parkOperationDates || parkOperationDates.length === 0) {
     return ""
   }
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1916

### Description:
- I'm not entirely sure why it got broken on PROD
  - The build error happens only on PROD, doesn't happen on DEV or TEST
  - The build on PROD doesn't create the cache: https://github.com/bcgov/bcparks.ca/actions/caches
- Added safe guards to safely access nested properties using optional chaining and default values, preventing crashes when data is missing
- Improved utility functions such as `getFeatureDates` and `getParkDates` to handle undefined or empty arrays, ensuring safer date formatting and display logic
- Modified the Gatsby schema in `gatsby-node.js` to add new types (`STRAPI_PROTECTED_AREA_DESCRIPTION_TEXTNODE`, `STRAPI_PROTECTED_AREADescription`) and updated the `STRAPI_PROTECTED_AREA` type to link to the new description structure, supporting richer and more flexible data modeling
- Fixed potential errors in data transformation logic (e.g., in `active-advisories.js`) by adding checks for missing IDs and defaulting to empty arrays, ensuring that data hashes are built only with valid entries