### PR TITLE
CMS-1889: Fix advisory loading bug

### DIFF
--- a/src/cms/src/api/public-advisory/services/search.js
+++ b/src/cms/src/api/public-advisory/services/search.js
@@ -9,12 +9,27 @@ module.exports = ({ strapi }) => ({
   search: async (query) => {
     query = buildQuery(query);
 
+    const paginationLimit = Number(query.pagination?.limit);
+    const paginationPageSize = Number(query.pagination?.pageSize);
+    const paginationStart = Number(query.pagination?.start);
+    const paginationPage = Number(query.pagination?.page);
+
     if (query.limit === undefined) {
-      query.limit = query.pagination?.pageSize || 10;
+      if (Number.isFinite(paginationLimit) && paginationLimit >= 0) {
+        query.limit = paginationLimit;
+      } else if (Number.isFinite(paginationPageSize) && paginationPageSize >= 0) {
+        query.limit = paginationPageSize;
+      } else {
+        query.limit = 10;
+      }
     }
 
     if (query.start === undefined) {
-      query.start = ((query.pagination?.page || 1) - 1) * query.limit;
+      if (Number.isFinite(paginationStart) && paginationStart >= 0) {
+        query.start = paginationStart;
+      } else {
+        query.start = ((Number.isFinite(paginationPage) ? paginationPage : 1) - 1) * query.limit;
+      }
     }
 
     query.sort = ["advisoryDate:DESC"];

--- a/src/cms/src/api/public-advisory/services/search.js
+++ b/src/cms/src/api/public-advisory/services/search.js
@@ -9,26 +9,46 @@ module.exports = ({ strapi }) => ({
   search: async (query) => {
     query = buildQuery(query);
 
-    const paginationLimit = Number(query.pagination?.limit);
-    const paginationPageSize = Number(query.pagination?.pageSize);
-    const paginationStart = Number(query.pagination?.start);
-    const paginationPage = Number(query.pagination?.page);
+    const toInteger = (value) => {
+      if (value === undefined || value === null) {
+        return undefined;
+      }
 
-    if (query.limit === undefined) {
-      if (Number.isFinite(paginationLimit) && paginationLimit >= 0) {
+      if (typeof value === "string" && value.trim() === "") {
+        return undefined;
+      }
+
+      const numericValue = Number(value);
+      return Number.isInteger(numericValue) ? numericValue : undefined;
+    };
+
+    const directLimit = toInteger(query.limit);
+    const directStart = toInteger(query.start);
+    const paginationLimit = toInteger(query.pagination?.limit);
+    const paginationPageSize = toInteger(query.pagination?.pageSize);
+    const paginationStart = toInteger(query.pagination?.start);
+    const paginationPage = toInteger(query.pagination?.page);
+
+    if (directLimit > 0) {
+      query.limit = directLimit;
+    } else {
+      if (paginationLimit > 0) {
         query.limit = paginationLimit;
-      } else if (Number.isFinite(paginationPageSize) && paginationPageSize >= 0) {
+      } else if (paginationPageSize > 0) {
         query.limit = paginationPageSize;
       } else {
         query.limit = 10;
       }
     }
 
-    if (query.start === undefined) {
-      if (Number.isFinite(paginationStart) && paginationStart >= 0) {
+    if (directStart >= 0) {
+      query.start = directStart;
+    } else {
+      if (paginationStart >= 0) {
         query.start = paginationStart;
       } else {
-        query.start = ((Number.isFinite(paginationPage) ? paginationPage : 1) - 1) * query.limit;
+        const safePage = paginationPage >= 1 ? paginationPage : 1;
+        query.start = (safePage - 1) * query.limit;
       }
     }
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1889

### Description:
- The bug happened because the search endpoint ignored offset pagination from the frontend (`pagination[start]`/`[pagination[limit]`) and only handled page-based params, so every “Load more” call effectively returned page 1 again from `search.js`
