### PR TITLE
CMS-1756: ACT history section fixes

### DIFF
--- a/src/cms/src/api/public-advisory/services/scheduling.js
+++ b/src/cms/src/api/public-advisory/services/scheduling.js
@@ -122,10 +122,12 @@ module.exports = ({ strapi }) => {
                   advisoryStatus: {
                     id: advisoryStatusMap["UNP"].id,
                   },
-                  modifiedByName: "system",
-                  modifiedDate: new Date(),
                   unpublishedByName: "system",
                   unpublishedDate: new Date(),
+                  reviewedByName: null,
+                  reviewedDate: null,
+                  publishedByName: null,
+                  publishedDate: null,
                 },
               })
               .catch((error) => {
@@ -173,6 +175,12 @@ module.exports = ({ strapi }) => {
                 },
                 modifiedByName: "system",
                 modifiedDate: new Date(),
+                publishedByName: "system",
+                publishedDate: new Date(),
+                reviewedByName: null,
+                reviewedDate: null,
+                unpublishedByName: null,
+                unpublishedDate: null,
               },
             })
             .then(async (advisory) => {

--- a/src/cms/src/middlewares/staff-portal-advisory-audit.js
+++ b/src/cms/src/middlewares/staff-portal-advisory-audit.js
@@ -155,18 +155,18 @@ module.exports = () => {
 
     if (isAdvisoryEqual(updatedPublicAdvisory, oldPublicAdvisory)) return;
 
-    // revision flow 1: published by system
     if (
-      newAdvisoryStatusCode === "PUB" &&
-      updatedPublicAdvisory.publishedByName === "system"
+      updatedPublicAdvisory.reviewedByName &&
+      !updatedPublicAdvisory.modifiedByName &&
+      !updatedPublicAdvisory.publishedByName &&
+      !updatedPublicAdvisory.unpublishedByName
     ) {
-      await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
-      updatedPublicAdvisory.revisionNumber =
-        oldPublicAdvisory.revisionNumber + 1;
+      // Review-only updates: no new revision needed.
+      // The review payload is sent via PUT with minimal data
       return;
     }
 
-    // revision flow 2: changes to published advisories
+    // revision flow 1: changes to published advisories
     if (oldAdvisoryStatus === "PUB") {
       await archiveOldPublicAdvisoryAudit(oldPublicAdvisory);
       updatedPublicAdvisory.revisionNumber =
@@ -174,7 +174,7 @@ module.exports = () => {
       return;
     }
 
-    // revision flow 3: non-published advisory modified by a different user
+    // revision flow 2: non-published advisory modified by a different user
     if (
       oldPublicAdvisory.modifiedByName !==
         updatedPublicAdvisory.modifiedByName &&
@@ -299,6 +299,11 @@ module.exports = () => {
 
     // replicate beforeCreate/afterCreate lifecycles in Strapi 4
     if (context.action === "create") {
+      // skip if we are creating an audit record
+      if (context.params?.data?.isLatestRevision === false) {
+        return await next();
+      }
+
       await beforeCreate(context);
       context.result = await next();
       await afterCreate(context);


### PR DESCRIPTION
### Jira Ticket:
CMS-1756

### Description:
Various fixes to AdvisoryHistory. The rest of the fixes are on the other repo https://github.com/bcgov/bcparks-staff-portal/pull/669

-  Updated the audit fields that are recorded when an advisory is published or unpublished by the system
- Removed the "Flow 1" case. We no longer need to create an audit record when the system published an advisory because we have enough info in the other audit fields.
- Added a condition to prevent the create hooks from running when an audit record is created.
- Prevent creation of a new revision when an advisory is reviewd
