### PR TITLE
CMS-1949: Strapi/Gatsby support for dates spanning two years

### DIFF
--- a/src/cms/src/api/search-indexing/controllers/search-indexing.js
+++ b/src/cms/src/api/search-indexing/controllers/search-indexing.js
@@ -80,8 +80,8 @@ module.exports = ({ strapi }) => ({
               $eq: GATE_DATE_TYPE_ID,
             },
           },
-          operatingYear: {
-            $gte: thisYear,
+          endDate: {
+            $gte: `${thisYear}-01-01`,
           },
         },
       },
@@ -107,8 +107,8 @@ module.exports = ({ strapi }) => ({
                   $eq: OPERATION_DATE_TYPE_ID,
                 },
               },
-              operatingYear: {
-                $gte: thisYear,
+              endDate: {
+                $gte: `${thisYear}-01-01`,
               },
             },
           },

--- a/src/gatsby/src/utils/apiHelper.js
+++ b/src/gatsby/src/utils/apiHelper.js
@@ -34,7 +34,7 @@ const PARK_DATES = {
         isActive: { $eq: true },
       },
       {
-        operatingYear: { $gte: currentYear },
+        endDate: { $gte: `${currentYear}-01-01` },
       },
     ],
   },
@@ -57,7 +57,7 @@ const PARK_GATE_DATES = {
         isActive: { $eq: true },
       },
       {
-        operatingYear: { $gte: currentYear },
+        endDate: { $gte: `${currentYear}-01-01` },
       },
       {
         parkDateType: {

--- a/src/gatsby/src/utils/parkDatesHelper.js
+++ b/src/gatsby/src/utils/parkDatesHelper.js
@@ -85,7 +85,7 @@ const getParkDates = (parkOperationDates) => {
 
   const currentYear = new Date().getFullYear()
 
-  // Format each date range, filter by operating year
+  // Format each date range; include current operating year and prior-year ranges that extend into the current year
   const formattedDateRanges = parkOperationDates
     .filter((date) => {
       return (

--- a/src/gatsby/src/utils/parkDatesHelper.js
+++ b/src/gatsby/src/utils/parkDatesHelper.js
@@ -87,9 +87,14 @@ const getParkDates = (parkOperationDates) => {
 
   // Format each date range, filter by operating year
   const formattedDateRanges = parkOperationDates
-    .filter(date => {
-      return date.operatingYear === currentYear &&
-             date.startDate && date.endDate
+    .filter((date) => {
+      return (
+        (date.operatingYear === currentYear ||
+          (date.endDate >= `${currentYear}-01-01` &&
+            date.endDate <= `${currentYear}-12-31`)) &&
+        date.startDate &&
+        date.endDate
+      );
     })
     .sort((a, b) => new Date(a.startDate) - new Date(b.startDate))
     .map(date => formatDateRange(date.startDate, date.endDate))

--- a/src/gatsby/src/utils/parkDatesHelper.js
+++ b/src/gatsby/src/utils/parkDatesHelper.js
@@ -94,7 +94,7 @@ const getParkDates = (parkOperationDates) => {
             date.endDate <= `${currentYear}-12-31`)) &&
         date.startDate &&
         date.endDate
-      );
+      )
     })
     .sort((a, b) => new Date(a.startDate) - new Date(b.startDate))
     .map(date => formatDateRange(date.startDate, date.endDate))

--- a/src/scheduler/elasticsearch/transformers/park/operatingDates.js
+++ b/src/scheduler/elasticsearch/transformers/park/operatingDates.js
@@ -7,7 +7,11 @@ const convertParkDates = function (parkDates) {
   const thisYear = new Date().getFullYear();
   return parkDates
     .filter(
-      (d) => d.operatingYear >= thisYear && d.publishedAt !== null && d.startDate && d.endDate
+      (d) =>
+        d.endDate >= `${thisYear}-01-01` &&
+        d.publishedAt !== null &&
+        d.startDate &&
+        d.endDate,
     )
     .map((d) => {
       delete d.id;
@@ -31,7 +35,7 @@ const convertParkFeatures = function (parkFeatures) {
         parkDates: feature.parkDates
           .filter(
             (d) =>
-              d.operatingYear >= thisYear &&
+              d.endDate >= `${thisYear}-01-01` &&
               d.isActive &&
               d.publishedAt !== null &&
               d.startDate &&


### PR DESCRIPTION
### Jira Ticket:
CMS-1949

### Description:
The "Dates spanning two years"  feature in DOOT slightly changes the definition of what is a "current" date.  It used to be defined by strictly the operating year, but now a date with an earlier operating year can still be current. 

This feature is scheduled to be launched in DOOT v2.5.0 and it's related to this PR: https://github.com/bcgov/bcparks-staff-portal/pull/598

This change is backward compatible with the existing data and does not need to wait for the v2.5.0 launch
