### PR TITLE
CMS-1955: Generating rollback images in publish-gatsby.yaml

### DIFF
--- a/infrastructure/helm/tools/templates/cronjobs/imagetag-pruner-cronjob.yaml
+++ b/infrastructure/helm/tools/templates/cronjobs/imagetag-pruner-cronjob.yaml
@@ -46,7 +46,7 @@ spec:
                   value: '10'
                 - name: IMAGESTRAMS_TO_CLEAN
                   value: >-
-                    admin-alpha,admin-main,etl-alpha,etl-main,maintenance-alpha,maintenance-main,public-builder-alpha,public-builder-main,public-alpha,public-main,strapi-alpha,strapi-main,scheduler-main,scheduler-alpha
+                    admin-alpha,admin-main,etl-alpha,etl-main,maintenance-alpha,maintenance-main,public-builder-alpha,public-builder-main,strapi-alpha,strapi-main,scheduler-main,scheduler-alpha
               resources: {}
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File


### PR DESCRIPTION
### Jira Ticket:
CMS-1955

### Description:
This PR updates the image-tag-pruner cronjob environment variables so that timestamp‑based rollback tags created by the Publish Gatsby workflow are not deleted daily.

These rollback tags were introduced in the following two commits, which did not have PRs and will now be captured in the generated release notes via this PR:

- https://github.com/bcgov/bcparks.ca/commit/77900cd19e55e521d0e084c378ec0ec05c3041c7
- https://github.com/bcgov/bcparks.ca/commit/9f6a46adf41034e03383ea2ea7f87bf30818ea58

These three commits together provide partial support for retaining rollback tags, but they do not implement the full retention rules described in CMS‑1955. The changes here are a stop‑gap until Sprint 24, when the ImageTag Pruner will be updated to enforce proper retention logic (e.g., keep all images for 0–3 days, keep daily snapshots for 4–14 days, delete older than 14 days).

The rollback tags themselves are permanent and will continue to be created after Sprint 24 — only the manual pruning workflow is temporary. Until the pruner is updated, rollback tags will be pruned manually.