### PR TITLE
CMS-1938: Fix advisory order for "Load more" requests  d850c8

### DIFF
--- a/src/cms/src/api/public-advisory/services/search.js
+++ b/src/cms/src/api/public-advisory/services/search.js
@@ -52,7 +52,7 @@ module.exports = ({ strapi }) => ({
       }
     }
 
-    query.sort = ["advisoryDate:DESC"];
+    query.sort = ["advisoryDate:DESC", "updatedDate:DESC", "id:DESC"];
 
     const results = await strapi.documents("api::public-advisory.public-advisory").findMany(query);
     return { results: results };

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -225,7 +225,9 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       // q = api query
       const params = qs.stringify(
         {
-          sort: ["advisoryDate:desc"],
+          // Use deterministic sorting for offset pagination: posting date, then
+          // updated date, then id to keep page boundaries stable across calls.
+          sort: ["advisoryDate:desc", "updatedDate:desc", "id:desc"],
           pagination: {
             limit: pageLen,
             start: pageLen * (pageIndex - 1),
@@ -309,6 +311,9 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
     const params = qs.stringify(
       {
+        // Maintain a deterministic multi-key sort so "Load more" pages stay
+        // stable even when multiple advisories share the same advisoryDate.
+        sort: ["advisoryDate:desc", "updatedDate:desc", "id:desc"],
         pagination: {
           limit: pageLen,
           start: pageStart,
@@ -326,6 +331,9 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       .then(resultResponse => {
         if (resultResponse.status === 200) {
           const newResults = resultResponse.data.data
+          // Apply the same client-side comparison used by the initial fetch so
+          // appended results stay aligned with the page's chronological rules.
+          newResults.sort(compareAdvisories)
           setAdvisories(prevResults => [...prevResults, ...newResults])
         }
       })

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -14,7 +14,10 @@ import AdvisoryList from "../components/advisories/advisoryList"
 import AdvisoryPageNav from "../components/advisories/advisoryPageNav"
 import AdvisoryLegend from "../components/advisories/advisoryLegend"
 import ScrollToTop from "../components/scrollToTop"
-import { getAdvisoryTypeFromUrl, compareAdvisories } from "../utils/advisoryHelper"
+import {
+  getAdvisoryTypeFromUrl,
+  compareAdvisories,
+} from "../utils/advisoryHelper"
 
 import "../styles/home.scss"
 
@@ -48,12 +51,17 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   const [isKeyDownLoadingMore, setIsKeyDownLoadingMore] = useState(false)
 
   /* Advisory Event Types */
-  const defaultAdvisoryEventType = useMemo(() => ({ label: 'All', value: 'all' }), [])
+  const defaultAdvisoryEventType = useMemo(
+    () => ({ label: "All", value: "all" }),
+    []
+  )
   const [eventTypes, setEventTypes] = useState([])
-  const [advisoryType, setAdvisoryType] = useState(defaultAdvisoryEventType.value)
+  const [advisoryType, setAdvisoryType] = useState(
+    defaultAdvisoryEventType.value
+  )
 
   useEffect(() => {
-    const fetchEvenType = async () => {
+    const fetchEventType = async () => {
       try {
         const params = qs.stringify(
           {
@@ -64,28 +72,28 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
             encodeValuesOnly: true,
           }
         )
-        const response = await axios.get(`${apiUrl}/event-types?${params}`);
+        const response = await axios.get(`${apiUrl}/event-types?${params}`)
 
-        const formattedEventTypes = response.data.data.map((obj) => ({
+        const formattedEventTypes = response.data.data.map(obj => ({
           label: obj.eventType,
           value: obj.eventType,
-        }));
+        }))
 
         const localeSortEvent = formattedEventTypes?.sort((a, b) =>
           a.value.localeCompare(b.value, "en", { sensitivity: "base" })
-        );
+        )
 
-        setEventTypes(localeSortEvent);
+        setEventTypes(localeSortEvent)
       } catch (err) {
-        console.error("Fetch Even Type error:", err);
+        console.error("Fetch Event Type error:", err)
       }
-    };
+    }
 
-    fetchEvenType();
+    fetchEventType()
 
-    let eventType = getAdvisoryTypeFromUrl();
-    setAdvisoryType(eventType);
-  }, [defaultAdvisoryEventType, apiUrl]);
+    let eventType = getAdvisoryTypeFromUrl()
+    setAdvisoryType(eventType)
+  }, [defaultAdvisoryEventType, apiUrl])
 
   // Filter getters and setters --------------------
   const getSearchText = () => {
@@ -157,10 +165,10 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       encodeValuesOnly: true,
     })
 
-    const newApiCountCall = params 
+    const newApiCountCall = params
       ? `${apiUrl}/public-advisories/count?${params}`
       : `${apiUrl}/public-advisories/count`
-      
+
     if (newApiCountCall !== apiCountCall) {
       setApiCountCall(newApiCountCall)
     }
@@ -242,7 +250,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
             results.sort(compareAdvisories)
             // Append new advisories to the existing list if 'Load more' button is clicked
             if (pageIndex > 1) {
-             setAdvisories(prevAdvisories => [...prevAdvisories, ...results]) 
+              setAdvisories(prevAdvisories => [...prevAdvisories, ...results])
             } else {
               setAdvisories(results)
             }
@@ -313,33 +321,36 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     )
     const newApiCall = `${apiUrl}/public-advisories?${params}`
 
-    axios.get(newApiCall).then(resultResponse => {
-      if (resultResponse.status === 200) {
-        const newResults = resultResponse.data.data;
-        setAdvisories(prevResults => [...prevResults, ...newResults])
-      }
-    }).catch(error => {
-      console.log(error)
-      setIsSearchError(true)
-    })
+    axios
+      .get(newApiCall)
+      .then(resultResponse => {
+        if (resultResponse.status === 200) {
+          const newResults = resultResponse.data.data
+          setAdvisories(prevResults => [...prevResults, ...newResults])
+        }
+      })
+      .catch(error => {
+        console.log(error)
+        setIsSearchError(true)
+      })
   }
 
-  const handleKeyDownLoadMore = (e) => {
+  const handleKeyDownLoadMore = e => {
     if (e.key === "Enter" || e.key === " ") {
-      setIsKeyDownLoadingMore(true);
+      setIsKeyDownLoadingMore(true)
       e.preventDefault()
       handleLoadMore()
     }
   }
 
-  // This hashset is used by the advisoryCard.js component to quiclky 
-  // determine if the advisoriy is associated with any parks in addition 
-  // to the specified  Fire Centres, Fire Zones, Regions, or Sections.
+  // This hashset is used by the advisoryCard.js component to quickly
+  // determine if the advisory is associated with any parks in addition
+  // to the specified Fire Centres, Fire Zones, Regions, or Sections.
   // Management Areas are not currently used for anything but are included
   // for completeness. The data comes from GraphQL.
   const buildParkInfoHash = () => {
-    const hash = {};
-    for (const x of (data?.allStrapiProtectedArea.nodes || [])) {
+    const hash = {}
+    for (const x of data?.allStrapiProtectedArea.nodes || []) {
       const nodeId = x?.strapi_id
       if (!nodeId) {
         continue
@@ -350,15 +361,27 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       const naturalResourceDistricts = x.naturalResourceDistricts || []
 
       hash[nodeId.toString()] = {
-        managementAreas: managementAreas.map(m => { return m.strapi_id }),
-        sections: managementAreas.map(m => { return m.section?.id }),
-        regions: managementAreas.map(m => { return m.region?.id }),
-        fireZones: fireZones.map(m => { return m.strapi_id }),
-        fireCentres: fireZones.map(m => { return m.fireCentre?.id }),
-        naturalResourceDistricts: naturalResourceDistricts.map(m => m.strapi_id),
-      };
+        managementAreas: managementAreas.map(m => {
+          return m.strapi_id
+        }),
+        sections: managementAreas.map(m => {
+          return m.section?.id
+        }),
+        regions: managementAreas.map(m => {
+          return m.region?.id
+        }),
+        fireZones: fireZones.map(m => {
+          return m.strapi_id
+        }),
+        fireCentres: fireZones.map(m => {
+          return m.fireCentre?.id
+        }),
+        naturalResourceDistricts: naturalResourceDistricts.map(
+          m => m.strapi_id
+        ),
+      }
     }
-    return hash;
+    return hash
   }
 
   // If the filter changes, set data as old and get new data
@@ -391,10 +414,10 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     }
   }, [pageIndex, advisoryType, isNewFilter, getApiQuery, getAdvisories])
 
-    // Reset pageIndex to 1 when advisoryType or searchText changes
-    useEffect(() => {
-      setPageIndex(1)
-    }, [advisoryType, searchText])
+  // Reset pageIndex to 1 when advisoryType or searchText changes
+  useEffect(() => {
+    setPageIndex(1)
+  }, [advisoryType, searchText])
 
   // Get total advisory count of this type
   // only has to happen once, when type changes, page reloads
@@ -405,7 +428,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   // Focus on the last advisory card when 'Load more' button is clicked by keyboard
   useEffect(() => {
     if (isKeyDownLoadingMore) {
-      const advisoryCards = document.querySelectorAll('.advisory-card')
+      const advisoryCards = document.querySelectorAll(".advisory-card")
       if (advisoryCards.length >= pageLen) {
         let firstNewIndex = advisoryCards.length - 1
         advisoryCards[firstNewIndex].contentEditable = true
@@ -417,7 +440,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   }, [isKeyDownLoadingMore, advisories])
 
   const menuContent = data?.allStrapiMenu?.nodes || []
-  const parkInfoHash = buildParkInfoHash();
+  const parkInfoHash = buildParkInfoHash()
 
   const breadcrumbs = [
     <Link key="1" to="/">
@@ -425,13 +448,17 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     </Link>,
     <div key="2" className="breadcrumb-text">
       Active advisories
-    </div>
+    </div>,
   ]
 
   return (
     <div>
       <Header mode="internal" content={menuContent} />
-      <div id="main-content" tabIndex={-1} className="static-content--header unique-page--header page-breadcrumbs">
+      <div
+        id="main-content"
+        tabIndex={-1}
+        className="static-content--header unique-page--header page-breadcrumbs"
+      >
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </div>
       <div className="static-content-container">
@@ -449,20 +476,17 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
         </div>
 
         <div className={isDataOld ? "hidden" : undefined}>
-          {(isSearchError && isAnySearch) &&
+          {isSearchError && isAnySearch && (
             <div className="my-2">
               There was an error in your search. Tip: avoid using punctuation
             </div>
-          }
+          )}
 
           <AdvisoryLegend />
           <div className="mb-2">
             <b>{filterCount}</b> active advisories
           </div>
-          <AdvisoryList
-            advisories={advisories}
-            parkInfoHash={parkInfoHash}
-          />
+          <AdvisoryList advisories={advisories} parkInfoHash={parkInfoHash} />
           <AdvisoryPageNav
             pageIndex={pageIndex}
             pageCount={pageCount}
@@ -481,7 +505,10 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 export default PublicActiveAdvisoriesPage
 
 export const Head = () => (
-  <Seo title="Active advisories" description="Up-to-date information to help you plan your visit to a park in British Columbia. Get updates on access, closures, hazards, and trail conditions in BC Parks." />
+  <Seo
+    title="Active advisories"
+    description="Up-to-date information to help you plan your visit to a park in British Columbia. Get updates on access, closures, hazards, and trail conditions in BC Parks."
+  />
 )
 
 export const query = graphql`
@@ -491,10 +518,7 @@ export const query = graphql`
         apiURL
       }
     }
-    allStrapiMenu(
-      sort: {order: ASC},
-      filter: {show: {eq: true}}
-    ) {
+    allStrapiMenu(sort: { order: ASC }, filter: { show: { eq: true } }) {
       nodes {
         strapi_id
         title

--- a/src/gatsby/src/utils/advisoryHelper.js
+++ b/src/gatsby/src/utils/advisoryHelper.js
@@ -74,19 +74,43 @@ const getAdvisoryDate = (advisory) => {
   return advisory.updatedDate ? new Date(advisory.updatedDate) : new Date(advisory.advisoryDate)
 }
 
-// Compare advisories by date
+// Parses a date-like value to a sortable timestamp.
+// Invalid or missing values fall back to 0 so sorting stays deterministic.
+const getSortableTimestamp = value => {
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+// Sort advisories by posting date first, then by updated date, then id to
+// guarantee a deterministic order for offset pagination. This intentionally
+// differs from the UI display date, which may show effective or updated dates.
 const compareAdvisories = (a, b) => {
-  const dateA = getAdvisoryDate(a)
-  const dateB = getAdvisoryDate(b)
-  // Sort in descending order (latest date first)
-  return dateB - dateA
+  const advisoryDateA = getSortableTimestamp(a.advisoryDate)
+  const advisoryDateB = getSortableTimestamp(b.advisoryDate)
+  const advisoryDateDiff = advisoryDateB - advisoryDateA
+
+  if (advisoryDateDiff !== 0) {
+    return advisoryDateDiff
+  }
+
+  // If advisoryDate matches, compare updatedDate.
+  const updatedDateA = getSortableTimestamp(a.updatedDate)
+  const updatedDateB = getSortableTimestamp(b.updatedDate)
+  const updatedDateDiff = updatedDateB - updatedDateA
+
+  if (updatedDateDiff !== 0) {
+    return updatedDateDiff
+  }
+
+  // Final tie-breaker: id keeps ordering stable when date fields are identical.
+  return (Number(b.id) || 0) - (Number(a.id) || 0)
 }
 
 const WINTER_FULL_PARK_ADVISORY = {
   id: -1,
   title: "Limited access to this park during winter season",
-  description: `<p>Vehicle access to the park is not available during the winter season. Visitors 
-                can still access the park on foot, but parking may not be available. Check 
+  description: `<p>Vehicle access to the park is not available during the winter season. Visitors
+                can still access the park on foot, but parking may not be available. Check
                 <a href="#main-content">park opening dates</a>, <a href="#camping">camping</a>, and <a href="#facilities">facilities</a> for details and
                 opening dates.</p>`,
   urgency: { sequence: 1, color: "blue" },
@@ -96,9 +120,9 @@ const WINTER_FULL_PARK_ADVISORY = {
 const WINTER_SUB_AREA_ADVISORY = {
   id: -1,
   title: "Limited access to some areas during the winter season",
-  description: `<p>Vehicle access to some areas of the park is not available during the winter season. 
-                Visitors can still access them on foot, but parking may not be available. Check 
-                <a href="#camping">camping</a> and <a href="#facilities">facilities</a> for details and opening 
+  description: `<p>Vehicle access to some areas of the park is not available during the winter season.
+                Visitors can still access them on foot, but parking may not be available. Check
+                <a href="#camping">camping</a> and <a href="#facilities">facilities</a> for details and opening
                 dates.</p>`,
   urgency: { sequence: 1, color: "blue" },
   eventType: { eventType: "Winter access" }


### PR DESCRIPTION
### Jira Ticket:
CMS-1938

### Description:

Updated the "Load more" functionality on the Active Advisories page so all pages follow the same sorting rules and repeated clicks won't get results out of order.

This is similar to #1890 but I don't think I need to change anything in search.js for this one besides a small tweak Copilot suggested to handle sorting when two advisories have identical dates. I'm hoping @ayumi-oxd can confirm 🙏 

The ticket also mentions some old (2021, 2022..) advisories showing on the page. It looks like those are valid records, just probably stale and in need of updates. I wrote this in Jira:

> It looks like the very old (2021 etc.) advisories are just old advisories, still “PUB” published status with no end date and no expiry date. This ticket will fix the ordering, but those 2021 records will still be there. They’ll be much further down the list, you might need to press “Load more” many times after this ordering is fixed because the newer ones will all be at the top.
>
> Just FYI; that might be some stale data that can be cleaned up in ACT.

I also applied the Prettier formatting to the active-advisory.js file and fixed some typos. That makes the diff tricky to follow but the main changes are just in the second commit a95c6ce8f48f5a5c9316b629100f8132c9eeb647