### PR TITLE
CMS-1878: Add sourceDateRangeId to parkDates and implement upsert logic

### DIFF
--- a/src/cms/src/api/park-date/content-types/park-date/schema.json
+++ b/src/cms/src/api/park-date/content-types/park-date/schema.json
@@ -19,8 +19,7 @@
       "default": true
     },
     "isDateAnnual": {
-      "type": "boolean",
-      "default": null
+      "type": "boolean"
     },
     "operatingYear": {
       "type": "integer",
@@ -53,6 +52,10 @@
       "relation": "manyToOne",
       "target": "api::park-feature.park-feature",
       "inversedBy": "parkDates"
+    },
+    "sourceDateRangeId": {
+      "type": "integer",
+      "unique": true
     }
   }
 }

--- a/src/scheduler/doot/scripts/publish.js
+++ b/src/scheduler/doot/scripts/publish.js
@@ -173,7 +173,7 @@ exports.dootPublish = async function () {
               parkFeature: parkFeatureDocId ? { documentId: parkFeatureDocId } : undefined,
               operatingYear: item.operatingYear,
             },
-            fields: ["documentId"],
+            fields: ["documentId", "sourceDateRangeId"],
             populate: {
               parkDateType: {
                 fields: ["dateTypeId"],
@@ -195,13 +195,33 @@ exports.dootPublish = async function () {
             item.dateRanges?.map((dateRange) => dateRange.dateTypeId).filter(Boolean) || [],
           );
 
+          // collect incoming sourceDateRangeIds to skip deleting records that can be updated with PUT
+          const incomingSourceIds = new Set(
+            item.dateRanges?.map((dateRange) => dateRange.id).filter((id) => id != null) || [],
+          );
+
+          // build a map of sourceDateRangeId -> documentId for existing records
+          const existingBySourceId = new Map();
+          for (const dateRange of datesToDelete.data.data) {
+            if (dateRange.sourceDateRangeId != null) {
+              existingBySourceId.set(dateRange.sourceDateRangeId, dateRange.documentId);
+            }
+          }
+
+          let deletedCount = 0;
+          let createdCount = 0;
+          let updatedCount = 0;
+
           try {
             for (const dateRange of datesToDelete.data.data) {
               if (
                 DOOT_MANAGED_DATE_TYPE_IDS.includes(dateRange.parkDateType.dateTypeId) &&
-                incomingDateTypeIds.has(dateRange.parkDateType.dateTypeId)
+                incomingDateTypeIds.has(dateRange.parkDateType.dateTypeId) &&
+                (dateRange.sourceDateRangeId == null ||
+                  !incomingSourceIds.has(dateRange.sourceDateRangeId))
               ) {
                 await cmsAxios.delete(`/api/park-dates/${dateRange.documentId}`);
+                deletedCount++;
               }
             }
           } catch (error) {
@@ -234,7 +254,7 @@ exports.dootPublish = async function () {
               }
               // create the date ranges
               for (const dootDateRange of item.dateRanges) {
-                const createDateRangeData = {
+                const parkDateData = {
                   startDate: dootDateRange.startDate,
                   endDate: dootDateRange.endDate,
                   isActive: dootDateRange.isActive,
@@ -245,12 +265,33 @@ exports.dootPublish = async function () {
                   protectedArea: protectedAreaDocId ? protectedAreaDocId : undefined,
                   parkFeature: parkFeatureDocId ? parkFeatureDocId : undefined,
                   publishedAt: new Date(),
+                  sourceDateRangeId: dootDateRange.id ?? null,
                 };
-                await cmsAxios.post("/api/park-dates", { data: createDateRangeData });
+                const existingDocId =
+                  dootDateRange.id != null ? existingBySourceId.get(dootDateRange.id) : undefined;
+                if (existingDocId) {
+                  await cmsAxios.put(`/api/park-dates/${existingDocId}`, {
+                    data: parkDateData,
+                  });
+                  updatedCount++;
+                } else {
+                  await cmsAxios.post("/api/park-dates", {
+                    data: parkDateData,
+                  });
+                  createdCount++;
+                }
               }
-              // After creating all date ranges, log a summary message
-              const count = item.dateRanges.length;
-              logger.info(`Created ${count} park-dates records for ${relationName}`);
+              // Log a summary of non-zero park-dates operations
+              const summary = [
+                deletedCount && `Deleted ${deletedCount}`,
+                createdCount && `Created ${createdCount}`,
+                updatedCount && `Updated ${updatedCount}`,
+              ]
+                .filter(Boolean)
+                .join(", ");
+              if (summary) {
+                logger.info(`${summary} park-dates record(s) for ${relationName}.`);
+              }
             } catch (error) {
               logger.error(`dootPublish() failed while creating park-dates: ${error}`);
               errorProcessingMessage = true;


### PR DESCRIPTION
### Jira Ticket:
CMS-1878

### Description:
Another PR was created in the Staff Portal repo to include `DateRange.id` in the publishing data sent to the Strapi `queued-tasks` collection. https://github.com/bcgov/bcparks-staff-portal/pull/686 

This PR utilizes the extra data:

1. Added a `sourceDateRangeId` field to the `park-dates` strapi collection
2. Populate the `sourceDateRangeId` field in the scheduler `dootpublish` task
3. Use the `sourceDateRangeId` to selectively perform `PUT` (update) operations instead of always deleting and re-creating `park-date` records when data is published.

This achieves three goals:

1. Provides a better audit trail between DOOT and Strapi
2. Reduces the data churn in Strapi 
3. Preserves values manually entered into the `adminNote` field in Strapi


