### PR TITLE
CMS-946: Use update date for advisories sorting first

### DIFF
--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -33,13 +33,11 @@ export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus
       'listingRank',
       'urgency.sequence',
       'accessStatus.precedence',
-      // updatedDate first when available
-      advisory => getTimestamp(advisory.updatedDate),
-      // then advisoryDate
-      advisory => getTimestamp(advisory.advisoryDate),
+      // use updatedDate when available, fall back to advisoryDate
+      advisory => getTimestamp(advisory.updatedDate) ?? getTimestamp(advisory.advisoryDate),
       'eventType.precedence'
     ],
-    ['desc', 'desc', 'asc', 'desc', 'desc', 'asc']
+    ['desc', 'desc', 'asc', 'desc', 'asc']
   )
 
   const [openAccordions, setOpenAccordions] = useState({})


### PR DESCRIPTION
### Jira Ticket:
CMS-946

### Description:
- The advisories should be sorted by the updated date even if the display date is not using updated date
- If the update date is null for an advisory, then it should use the advisory date