### PR TITLE
CMS-946: Fix advisories sorting by dates

### DIFF
--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -25,6 +25,16 @@ const getTimestamp = isoDate => {
   return isoDate ? parseJSON(isoDate).getTime() : null
 }
 
+// Returns a day-precision timestamp for sorting: 
+// Uses updatedDate when available, falls back to advisoryDate.
+// Same-day advisories compare as equal, allowing eventType.precedence to act as the tiebreaker.
+const getEffectiveDayTimestamp = advisory => {
+  const d = advisory.updatedDate ?? advisory.advisoryDate
+  if (!d) return null
+  const date = parseJSON(d)
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}
+
 export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus }) {
   const sortedAdvisories = orderBy(
     advisories,
@@ -33,9 +43,8 @@ export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus
       'listingRank',
       'urgency.sequence',
       'accessStatus.precedence',
-      // use updatedDate when available, fall back to advisoryDate
-      advisory => getTimestamp(advisory.updatedDate) ?? getTimestamp(advisory.advisoryDate),
-      'eventType.precedence'
+      getEffectiveDayTimestamp,
+      'eventType.precedence',
     ],
     ['desc', 'desc', 'asc', 'desc', 'asc']
   )

--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -21,10 +21,6 @@ const formatDate = isoDate => {
   return isoDate ? format(parseJSON(isoDate), "MMMM d, yyyy") : ""
 }
 
-const getTimestamp = isoDate => {
-  return isoDate ? parseJSON(isoDate).getTime() : null
-}
-
 // Returns a day-precision timestamp for sorting: 
 // Uses updatedDate when available, falls back to advisoryDate.
 // Same-day advisories compare as equal, allowing eventType.precedence to act as the tiebreaker.

--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react"
 import PropTypes from "prop-types"
-import { parseJSON, format } from "date-fns"
+import { parseJSON, format, startOfDay } from "date-fns"
 import Accordion from "react-bootstrap/Accordion"
 import Row from "react-bootstrap/Row"
 import Col from "react-bootstrap/Col"
@@ -27,8 +27,7 @@ const formatDate = isoDate => {
 const getEffectiveDayTimestamp = advisory => {
   const d = advisory.updatedDate ?? advisory.advisoryDate
   if (!d) return null
-  const date = parseJSON(d)
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+  return startOfDay(parseJSON(d)).getTime()
 }
 
 export default function AdvisoryDetails({ advisories, parkType, parkAccessStatus }) {


### PR DESCRIPTION
### Jira Ticket:
CMS-946

### Description:
- Previously, `eventType.precedence` was the last sort criterion and was compared after a millisecond-precision date, meaning two advisories would almost never tie on date and event type sorting would never take effect. 
- Now, the date is compared at day precision only (time of day is ignored), so advisories set to the same calendar day compare as equal and get sorted by event type as intended.