### PR TITLE
CMS-1832: Don't record modified metadata when publishing

### DIFF
--- a/src/cms/src/middlewares/helpers/advisoryData.js
+++ b/src/cms/src/middlewares/helpers/advisoryData.js
@@ -192,7 +192,6 @@ function isAdvisoryEqual(newData, oldData) {
     isUpdatedDateDisplayed: null,
     isReservationsAffected: null,
     isUrgentAfterHours: null,
-    modifiedByName: null,
   };
 
   for (const key of Object.keys(fieldsToCompare)) {


### PR DESCRIPTION
### Jira Ticket:
CMS-1832

### Description:
This change removes `modifiedByName` from the list of fields evaluated in the `isAdvisoryEqual()` function. 
This is part of https://github.com/bcgov/bcparks-staff-portal/pull/695 and it ensures payloads missing `modifiedByName` these values are correctly evaluated for changes in the Strapi middlware.

There should be no valid scenarios where `modifiedByName`, `modifiedDate` or `modifiedByRole` are the only fields updated on the form and a new revision should be created.
