### PR TITLE
CMS-1826: Remove RST workarounds and use bulk advisory endpoint

### DIFF
--- a/src/cms/src/helpers/recSpacePayloadBuilder.js
+++ b/src/cms/src/helpers/recSpacePayloadBuilder.js
@@ -37,13 +37,9 @@ function buildPayload(paAudit) {
     end_date: paAudit.endDate ?? null,
     expiry_date: paAudit.expiryDate ?? null,
     removal_date: paAudit.unpublishedDate ?? null,
-    // TODO: this should be nullable in the API, but the RecSpace API still expects a date
-    updated_date: paAudit.updatedDate ?? new Date(0).toISOString(),
-    // updated_date: paAudit.updatedDate ?? null,
+    updated_date: paAudit.updatedDate ?? null,
     modified_date: paAudit.modifiedDate ?? null,
-    // TODO: this will be renamed to published_date soon, but the RecSpace API still expects published_at for now
-    published_at: paAudit.publishedDate ?? null,
-    // published_date: paAudit.publishedDate ?? null,
+    published_date: paAudit.publishedDate ?? null,
     listing_rank: paAudit.listingRank ?? 0,
     urgency_sequence: paAudit.urgency?.sequence ?? 0,
     access_status_precedence: paAudit.accessStatus?.precedence ?? 0,

--- a/src/scheduler/recspace/scripts/publishAdvisories.js
+++ b/src/scheduler/recspace/scripts/publishAdvisories.js
@@ -8,13 +8,14 @@ const { recSpaceAxios } = require("../utils/axiosRecSpaceAuth");
 async function postRecSpacePublicAdvisory(payload) {
   const logger = getLogger();
   try {
-    await recSpaceAxios.post("/api/v1/act/advisories", payload);
+    await recSpaceAxios.post("/api/v1/act/advisories/bulk", payload);
     logger.info(
-      `Advisory ${payload.advisory_number} with rec_resource_id ${payload.rec_resource_id} posted successfully`,
+      `Advisory ${payload.advisory_number} posted successfully for ${payload.rec_resource_ids?.length || 0} rec_resource_id(s)`,
     );
   } catch (error) {
+    const recResourceIdsText = `(${(payload?.rec_resource_ids || []).map((id) => `'${id}'`).join(", ")})`;
     logger.error(
-      `postRecSpacePublicAdvisory() failed for advisory ${payload.advisory_number} with rec_resource_id ${payload.rec_resource_id}: ${error?.message ?? error}`,
+      `postRecSpacePublicAdvisory() failed for advisory ${payload.advisory_number} with rec_resource_ids ${recResourceIdsText}: ${error?.message ?? error}`,
     );
     if (error?.response?.data) {
       logger.error(`Response body: ${JSON.stringify(error.response.data)}`);
@@ -94,15 +95,16 @@ exports.publishToRecSpace = async function () {
       }
 
       // if the after status is "Scheduled" or "Published" then we need to send a POST request
-      // to the API for each recResourceId in the after payload
+      // to the API with rec_resource_ids in the after payload
       // Note: POST endpoint performs upsert, so PUT is unnecessary
       if (afterStatus === "Scheduled" || afterStatus === "Published") {
-        const { revision_number, rec_resource_ids, ...basePayload } =
-          afterJsonData;
-
-        for (const recResourceId of rec_resource_ids || []) {
-          const payload = { ...basePayload, rec_resource_id: recResourceId };
+        if (afterRecResourceIds.length > 0) {
+          const { revision_number, ...payload } = afterJsonData;
           await postRecSpacePublicAdvisory(payload);
+        } else {
+          logger.info(
+            `Skipping bulk POST for advisory ${advisoryNumber} because rec_resource_ids is empty`,
+          );
         }
 
         // if any recResourceIds were removed then we need to send a DELETE request


### PR DESCRIPTION
### Jira Ticket:
CMS-1826

### Description:
- Undid temporary workarounds that were put in place to enable short-term integration with the RST CRUD API while waiting for Team ORCA to fix underlying bugs. 
- Removed the associated TODOs.
- Updated the publish task to use the new `/api/v1/act/advisories/bulk` endpoint instead of splitting the `rec_resource_ids` array and sending multiple POST requests. 
