### PR TITLE
CMS-1938: Use custom server-side sorting for advisory pagination

### DIFF
--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -118,10 +118,11 @@ module.exports = createCoreController(
           .service("api::public-advisory.search")
           .countSearch(ctx.query);
       }
-
-      return await strapi
-        .service("api::public-advisory.public-advisory")
-        .count(ctx.query);
+      return (
+        await strapi
+          .service("api::public-advisory.public-advisory")
+          .find(ctx.query)
+      ).pagination.total;
     },
     async items(ctx) {
       let entities;

--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -43,6 +43,20 @@ const appendStandardMessages = function (entity) {
   return entity;
 };
 
+// Enables display-date sorting path only when the request includes _displaySort=1.
+const isDisplaySortEnabled = function (query) {
+  return query?._displaySort === "1";
+};
+
+// Use custom search for text/event filters or when display-date sorting is explicitly enabled.
+const shouldUseSearchService = function (query) {
+  return (
+    isDisplaySortEnabled(query) ||
+    (query?.queryText && query.queryText.length > 0) ||
+    (query?._eventType && query._eventType.length > 0)
+  );
+};
+
 module.exports = createCoreController(
   "api::public-advisory.public-advisory",
   ({ strapi }) => ({
@@ -75,14 +89,10 @@ module.exports = createCoreController(
 
       ctx.query = populateStandardMessages(ctx.query);
 
-      if (
-        ctx.query.queryText !== undefined ||
-        ctx.query._eventType !== undefined
-      ) {
-        ({ results: entities } = await strapi
+      if (shouldUseSearchService(ctx.query)) {
+        ({ results: entities, pagination } = await strapi
           .service("api::public-advisory.search")
           .search(ctx.query));
-        pagination = {};
       } else {
         ({ results: entities, pagination } = await strapi
           .service("api::public-advisory.public-advisory")
@@ -103,19 +113,15 @@ module.exports = createCoreController(
       };
     },
     async count(ctx) {
-      if (
-        ctx.query.queryText !== undefined ||
-        ctx.query._eventType !== undefined
-      ) {
+      if (shouldUseSearchService(ctx.query)) {
         return await strapi
           .service("api::public-advisory.search")
           .countSearch(ctx.query);
       }
-      return (
-        await strapi
-          .service("api::public-advisory.public-advisory")
-          .find(ctx.query)
-      ).pagination.total;
+
+      return await strapi
+        .service("api::public-advisory.public-advisory")
+        .count(ctx.query);
     },
     async items(ctx) {
       let entities;

--- a/src/cms/src/api/public-advisory/controllers/public-advisory.js
+++ b/src/cms/src/api/public-advisory/controllers/public-advisory.js
@@ -93,6 +93,7 @@ module.exports = createCoreController(
         ({ results: entities, pagination } = await strapi
           .service("api::public-advisory.search")
           .search(ctx.query));
+        pagination = pagination || {};
       } else {
         ({ results: entities, pagination } = await strapi
           .service("api::public-advisory.public-advisory")

--- a/src/cms/src/api/public-advisory/services/search.js
+++ b/src/cms/src/api/public-advisory/services/search.js
@@ -6,29 +6,47 @@
 
 module.exports = ({ strapi }) => ({
   search: async (query) => {
-    // Read the full matching set, sort once, then slice to keep pagination stable.
+    // Only apply display-date sorting when the request includes _displaySort=1.
+    const isDisplaySortEnabled = query._displaySort === "1";
+
     const pagination = normalizePagination(query);
     query = buildQuery(stripPagination(query));
-    query.sort = ["effectiveDate:DESC", "advisoryDate:DESC", "updatedDate:DESC", "id:DESC"];
+
+    // If display-date sorting is enabled, we need to fetch all matching results and apply a custom sort function.
+    if (isDisplaySortEnabled) {
+      // Apply a coarse DB sort before the final compareAdvisories sort runs in memory
+      query.sort = ["effectiveDate:DESC", "advisoryDate:DESC", "updatedDate:DESC", "id:DESC"];
+
+      const results = await strapi
+        .documents("api::public-advisory.public-advisory")
+        .findMany(query);
+
+      const sortedResults = [...results].sort(compareAdvisories);
+
+      return {
+        results: sortedResults.slice(
+          pagination.start,
+          pagination.start + pagination.limit,
+        ),
+        pagination: {
+          page: Math.floor(pagination.start / pagination.limit) + 1,
+          pageSize: pagination.limit,
+          pageCount: Math.ceil(sortedResults.length / pagination.limit),
+          total: sortedResults.length,
+        },
+      };
+    }
+
+    // If display-date sorting is not enabled, we can rely on the DB to sort and paginate results as usual.
+    query.limit = pagination.limit;
+    query.start = pagination.start;
+    query.sort = ["advisoryDate:DESC", "updatedDate:DESC", "id:DESC"];
 
     const results = await strapi
       .documents("api::public-advisory.public-advisory")
       .findMany(query);
 
-    const sortedResults = [...results].sort(compareAdvisories);
-
-    return {
-      results: sortedResults.slice(
-        pagination.start,
-        pagination.start + pagination.limit,
-      ),
-      pagination: {
-        page: Math.floor(pagination.start / pagination.limit) + 1,
-        pageSize: pagination.limit,
-        pageCount: Math.ceil(sortedResults.length / pagination.limit),
-        total: sortedResults.length,
-      },
-    };
+    return { results };
   },
   countSearch: async (query) => {
     // Count against the same filtered set used by search, without paging controls.

--- a/src/cms/src/api/public-advisory/services/search.js
+++ b/src/cms/src/api/public-advisory/services/search.js
@@ -6,60 +6,33 @@
 
 module.exports = ({ strapi }) => ({
   search: async (query) => {
-    query = buildQuery(query);
-
-    const toInteger = (value) => {
-      if (value === undefined || value === null) {
-        return undefined;
-      }
-
-      if (typeof value === "string" && value.trim() === "") {
-        return undefined;
-      }
-
-      const numericValue = Number(value);
-      return Number.isInteger(numericValue) ? numericValue : undefined;
-    };
-
-    const directLimit = toInteger(query.limit);
-    const directStart = toInteger(query.start);
-    const paginationLimit = toInteger(query.pagination?.limit);
-    const paginationPageSize = toInteger(query.pagination?.pageSize);
-    const paginationStart = toInteger(query.pagination?.start);
-    const paginationPage = toInteger(query.pagination?.page);
-
-    if (directLimit > 0) {
-      query.limit = directLimit;
-    } else {
-      if (paginationLimit > 0) {
-        query.limit = paginationLimit;
-      } else if (paginationPageSize > 0) {
-        query.limit = paginationPageSize;
-      } else {
-        query.limit = 10;
-      }
-    }
-
-    if (directStart >= 0) {
-      query.start = directStart;
-    } else {
-      if (paginationStart >= 0) {
-        query.start = paginationStart;
-      } else {
-        const safePage = paginationPage >= 1 ? paginationPage : 1;
-        query.start = (safePage - 1) * query.limit;
-      }
-    }
-
-    query.sort = ["advisoryDate:DESC", "updatedDate:DESC", "id:DESC"];
+    // Read the full matching set, sort once, then slice to keep pagination stable.
+    const pagination = normalizePagination(query);
+    query = buildQuery(stripPagination(query));
+    query.sort = ["effectiveDate:DESC", "advisoryDate:DESC", "updatedDate:DESC", "id:DESC"];
 
     const results = await strapi
       .documents("api::public-advisory.public-advisory")
       .findMany(query);
-    return { results: results };
+
+    const sortedResults = [...results].sort(compareAdvisories);
+
+    return {
+      results: sortedResults.slice(
+        pagination.start,
+        pagination.start + pagination.limit,
+      ),
+      pagination: {
+        page: Math.floor(pagination.start / pagination.limit) + 1,
+        pageSize: pagination.limit,
+        pageCount: Math.ceil(sortedResults.length / pagination.limit),
+        total: sortedResults.length,
+      },
+    };
   },
   countSearch: async (query) => {
-    query = buildQuery(query);
+    // Count against the same filtered set used by search, without paging controls.
+    query = buildQuery(stripPagination(query));
     query.fields = ["id"];
     const results = await strapi
       .documents("api::public-advisory.public-advisory")
@@ -68,6 +41,114 @@ module.exports = ({ strapi }) => ({
   },
 });
 
+// Safely parse integer-like values from query params.
+const toInteger = (value) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    return undefined;
+  }
+
+  const numericValue = Number(value);
+  return Number.isInteger(numericValue) ? numericValue : undefined;
+};
+
+// Normalize Strapi pagination inputs (limit/start or pagination.*) into one shape.
+const normalizePagination = (query) => {
+  const directLimit = toInteger(query.limit);
+  const directStart = toInteger(query.start);
+  const paginationLimit = toInteger(query.pagination?.limit);
+  const paginationPageSize = toInteger(query.pagination?.pageSize);
+  const paginationStart = toInteger(query.pagination?.start);
+  const paginationPage = toInteger(query.pagination?.page);
+
+  let limit = 10;
+  if (directLimit > 0) {
+    limit = directLimit;
+  } else {
+    if (paginationLimit > 0) {
+      limit = paginationLimit;
+    } else {
+      if (paginationPageSize > 0) {
+        limit = paginationPageSize;
+      }
+    }
+  }
+
+  let start;
+  if (directStart >= 0) {
+    start = directStart;
+  } else {
+    if (paginationStart >= 0) {
+      start = paginationStart;
+    } else {
+      const safePage = paginationPage >= 1 ? paginationPage : 1;
+      start = (safePage - 1) * limit;
+    }
+  }
+
+  return { limit, start };
+};
+
+// Remove request controls that should not be passed to the DB query layer.
+const stripPagination = (query) => {
+  const nextQuery = { ...query };
+
+  delete nextQuery.limit;
+  delete nextQuery.start;
+  delete nextQuery.sort;
+  delete nextQuery.pagination;
+  delete nextQuery._displaySort;
+
+  return nextQuery;
+};
+
+// Derive the timestamp used for advisory display ordering.
+const getDisplayTimestamp = (advisory) => {
+  if (advisory.isEffectiveDateDisplayed && advisory.effectiveDate) {
+    return Date.parse(advisory.effectiveDate) || 0;
+  }
+
+  if (advisory.isAdvisoryDateDisplayed && advisory.advisoryDate) {
+    return Date.parse(advisory.advisoryDate) || 0;
+  }
+
+  if (advisory.isUpdatedDateDisplayed && advisory.updatedDate) {
+    return Date.parse(advisory.updatedDate) || 0;
+  }
+
+  return Date.parse(advisory.updatedDate || advisory.advisoryDate) || 0;
+};
+
+// Keep ordering deterministic by applying date precedence, then stable tie-breakers.
+const compareAdvisories = (a, b) => {
+  // 1) Primary sort: displayed date precedence (effective, advisory, updated).
+  const displayDateDiff = getDisplayTimestamp(b) - getDisplayTimestamp(a);
+  if (displayDateDiff !== 0) {
+    return displayDateDiff;
+  }
+
+  // 2) Tie-breaker: most recently updated advisory first.
+  const updatedDateDiff =
+    (Date.parse(b.updatedDate) || 0) - (Date.parse(a.updatedDate) || 0);
+  if (updatedDateDiff !== 0) {
+    return updatedDateDiff;
+  }
+
+  // 3) Tie-breaker: most recent advisory date first.
+  const advisoryDateDiff =
+    (Date.parse(b.advisoryDate) || 0) - (Date.parse(a.advisoryDate) || 0);
+  if (advisoryDateDiff !== 0) {
+    return advisoryDateDiff;
+  }
+
+  // 4) Final tie-breaker: higher id first for stable ordering.
+  return (Number(b.id) || 0) - (Number(a.id) || 0);
+};
+
+// Build shared filters/populate for public advisory search requests.
 const buildQuery = function (query) {
   let textSearch = {};
   let typeSearch = {};

--- a/src/cms/src/api/public-advisory/services/search.js
+++ b/src/cms/src/api/public-advisory/services/search.js
@@ -45,8 +45,7 @@ module.exports = ({ strapi }) => ({
     const results = await strapi
       .documents("api::public-advisory.public-advisory")
       .findMany(query);
-
-    return { results };
+    return { results: results };
   },
   countSearch: async (query) => {
     // Count against the same filtered set used by search, without paging controls.

--- a/src/gatsby/src/components/park/advisoryDetails.js
+++ b/src/gatsby/src/components/park/advisoryDetails.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
-import { parseJSON, format } from "date-fns";
+import { parseJSON, format, startOfDay } from "date-fns";
 import Accordion from "react-bootstrap/Accordion";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
@@ -14,7 +14,6 @@ import AdvisoryDate from "../advisories/advisoryDate";
 import blueAlertIcon from "../../images/park/blue-alert.svg";
 import redAlertIcon from "../../images/park/red-alert.svg";
 import yellowAlertIcon from "../../images/park/yellow-alert.svg";
-import { getAdvisoryDate } from "../../utils/advisoryHelper";
 import { trackSnowplowEvent } from "../../utils/snowplowHelper";
 import "../../styles/advisories/advisoryDetails.scss";
 

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -175,7 +175,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
     (advisoryTypeFilter) => {
       // Build query object for Strapi v5
       let queryObj = {
-        // Tell the API to sort the full advisory list before paging results.
+        // Tell the API to sort the full advisory list by the display date before paging results.
         _displaySort: "1",
       };
 

--- a/src/gatsby/src/pages/active-advisories.js
+++ b/src/gatsby/src/pages/active-advisories.js
@@ -14,10 +14,7 @@ import AdvisoryList from "../components/advisories/advisoryList";
 import AdvisoryPageNav from "../components/advisories/advisoryPageNav";
 import AdvisoryLegend from "../components/advisories/advisoryLegend";
 import ScrollToTop from "../components/scrollToTop";
-import {
-  getAdvisoryTypeFromUrl,
-  compareAdvisories,
-} from "../utils/advisoryHelper";
+import { getAdvisoryTypeFromUrl } from "../utils/advisoryHelper";
 
 import "../styles/home.scss";
 
@@ -177,7 +174,10 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
   const getApiQuery = useCallback(
     (advisoryTypeFilter) => {
       // Build query object for Strapi v5
-      let queryObj = {};
+      let queryObj = {
+        // Tell the API to sort the full advisory list before paging results.
+        _displaySort: "1",
+      };
 
       let useParksFilter = isParksFilter;
       let useKeywordFilter = isKeywordFilter;
@@ -225,9 +225,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       // q = api query
       const params = qs.stringify(
         {
-          // Use deterministic sorting for offset pagination: posting date, then
-          // updated date, then id to keep page boundaries stable across calls.
-          sort: ["advisoryDate:desc", "updatedDate:desc", "id:desc"],
+          // Sorting is handled in the CMS service before pagination is applied.
           pagination: {
             limit: pageLen,
             start: pageLen * (pageIndex - 1),
@@ -249,7 +247,6 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
           .get(newApiCall)
           .then(function (data) {
             let results = data.data.data;
-            results.sort(compareAdvisories);
             // Append new advisories to the existing list if 'Load more' button is clicked
             if (pageIndex > 1) {
               setAdvisories(prevAdvisories => [...prevAdvisories, ...results])
@@ -311,9 +308,7 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
 
     const params = qs.stringify(
       {
-        // Maintain a deterministic multi-key sort so "Load more" pages stay
-        // stable even when multiple advisories share the same advisoryDate.
-        sort: ["advisoryDate:desc", "updatedDate:desc", "id:desc"],
+        // Sorting is handled in the CMS service before pagination is applied.
         pagination: {
           limit: pageLen,
           start: pageStart,
@@ -331,9 +326,6 @@ const PublicActiveAdvisoriesPage = ({ data }) => {
       .then(resultResponse => {
         if (resultResponse.status === 200) {
           const newResults = resultResponse.data.data
-          // Apply the same client-side comparison used by the initial fetch so
-          // appended results stay aligned with the page's chronological rules.
-          newResults.sort(compareAdvisories)
           setAdvisories(prevResults => [...prevResults, ...newResults])
         }
       })

--- a/src/gatsby/src/utils/advisoryHelper.js
+++ b/src/gatsby/src/utils/advisoryHelper.js
@@ -74,24 +74,6 @@ const loadAllAdvisories = (apiBaseUrl) => {
   return axios.get(`${apiBaseUrl}/public-advisories/?${params}`);
 };
 
-// Get advisory displayed date
-const getAdvisoryDate = (advisory) => {
-  if (advisory.isAdvisoryDateDisplayed && advisory.advisoryDate) {
-    return new Date(advisory.advisoryDate);
-  }
-  if (advisory.isEffectiveDateDisplayed && advisory.effectiveDate) {
-    return new Date(advisory.effectiveDate);
-  }
-  if (advisory.isUpdatedDateDisplayed && advisory.updatedDate) {
-    return new Date(advisory.updatedDate);
-  }
-  // If none of the above conditions are met
-  // return updatedDate if available, otherwise return advisoryDate
-  return advisory.updatedDate
-    ? new Date(advisory.updatedDate)
-    : new Date(advisory.advisoryDate);
-};
-
 // Parses a date-like value to a sortable timestamp.
 // Invalid or missing values fall back to 0 so sorting stays deterministic.
 const getSortableTimestamp = value => {
@@ -150,7 +132,6 @@ export {
   loadAdvisories,
   loadAllAdvisories,
   getAdvisoryTypeFromUrl,
-  getAdvisoryDate,
   compareAdvisories,
   WINTER_FULL_PARK_ADVISORY,
   WINTER_SUB_AREA_ADVISORY,

--- a/src/gatsby/src/utils/advisoryHelper.js
+++ b/src/gatsby/src/utils/advisoryHelper.js
@@ -74,38 +74,6 @@ const loadAllAdvisories = (apiBaseUrl) => {
   return axios.get(`${apiBaseUrl}/public-advisories/?${params}`);
 };
 
-// Parses a date-like value to a sortable timestamp.
-// Invalid or missing values fall back to 0 so sorting stays deterministic.
-const getSortableTimestamp = value => {
-  const parsed = Date.parse(value)
-  return Number.isFinite(parsed) ? parsed : 0
-}
-
-// Sort advisories by posting date first, then by updated date, then id to
-// guarantee a deterministic order for offset pagination. This intentionally
-// differs from the UI display date, which may show effective or updated dates.
-const compareAdvisories = (a, b) => {
-  const advisoryDateA = getSortableTimestamp(a.advisoryDate)
-  const advisoryDateB = getSortableTimestamp(b.advisoryDate)
-  const advisoryDateDiff = advisoryDateB - advisoryDateA
-
-  if (advisoryDateDiff !== 0) {
-    return advisoryDateDiff
-  }
-
-  // If advisoryDate matches, compare updatedDate.
-  const updatedDateA = getSortableTimestamp(a.updatedDate)
-  const updatedDateB = getSortableTimestamp(b.updatedDate)
-  const updatedDateDiff = updatedDateB - updatedDateA
-
-  if (updatedDateDiff !== 0) {
-    return updatedDateDiff
-  }
-
-  // Final tie-breaker: id keeps ordering stable when date fields are identical.
-  return (Number(b.id) || 0) - (Number(a.id) || 0)
-}
-
 const WINTER_FULL_PARK_ADVISORY = {
   id: -1,
   title: "Limited access to this park during winter season",
@@ -132,7 +100,6 @@ export {
   loadAdvisories,
   loadAllAdvisories,
   getAdvisoryTypeFromUrl,
-  compareAdvisories,
   WINTER_FULL_PARK_ADVISORY,
   WINTER_SUB_AREA_ADVISORY,
 };


### PR DESCRIPTION
### Jira Ticket:
CMS-1938

### Description:

This updates Active Advisories to use a custom server-side sort when `_displaySort=1` is set in the query. The API now sorts the full advisory result set before pagination using the date shown to users, with tie-breakers on `updatedDate`, `advisoryDate`, and finally `id`. This keeps ordering stable across pages and load-more results while limiting the change to requests that explicitly opt in with this `_displaySort` parameter.

---

Sorting is based on the date shown to users, using the same display flags that control which advisory dates are shown in the advisory card:

- Use `effectiveDate` when `isEffectiveDateDisplayed` is true
- Otherwise, use `advisoryDate` when `isAdvisoryDateDisplayed` is true
- Otherwise, use `updatedDate` when `isUpdatedDateDisplayed` is true
- If none of those display flags apply, fall back to `updatedDate`, then `advisoryDate`

To keep ordering deterministic when those dates match, the server then sorts by:

- `updatedDate` descending
- `advisoryDate` descending
- `id` descending