### PR TITLE
CMS-1987: Adjust email queue de-dupe logic to check subject

### DIFF
--- a/src/cms/src/helpers/taskQueue.js
+++ b/src/cms/src/helpers/taskQueue.js
@@ -102,6 +102,7 @@ module.exports = {
           action: "email advisory",
           numericData: advisoryNumber,
         },
+        fields: ["jsonData"],
       });
 
     // Check if any existing queued tasks for this advisory have the same subject

--- a/src/cms/src/helpers/taskQueue.js
+++ b/src/cms/src/helpers/taskQueue.js
@@ -95,15 +95,20 @@ module.exports = {
     if (!subject || !title || !advisoryNumber) {
       return;
     }
-    const exists =
-      (
-        await strapi.documents("api::queued-task.queued-task").findMany({
-          filters: {
-            action: "email advisory",
-            numericData: advisoryNumber,
-          },
-        })
-      ).length > 0;
+    const existingTasks = await strapi
+      .documents("api::queued-task.queued-task")
+      .findMany({
+        filters: {
+          action: "email advisory",
+          numericData: advisoryNumber,
+        },
+      });
+
+    // Check if any existing queued tasks for this advisory have the same subject
+    const exists = existingTasks.some(
+      (task) => task?.jsonData?.subject === subject,
+    );
+
     if (!exists) {
       strapi.log.info(
         `queued advisoryNumber ${advisoryNumber} for "${subject}" notification`,

--- a/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
+++ b/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
@@ -17,7 +17,7 @@ const { buildEmailMetadata } = require("./advisoryEmailMetadata");
  * Sends queued emails
  */
 exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
-  const THROTTLE_MINUTES = 10; // min. time before sending 2 emails about 1 advisory
+  const THROTTLE_MINUTES = 10; // min. time before sending duplicate emails for an advisory+subject
   let queue;
   let sent = [];
   const logger = getLogger();
@@ -38,11 +38,17 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
 
   for (const message of queue) {
     const advisoryNumber = message?.numericData;
+    const throttleSubject = message?.jsonData?.subject || "";
+
     if (
-      !recentAdvisoryEmails.find((e) => e.advisoryNumber === advisoryNumber)
+      !recentAdvisoryEmails.find(
+        (e) =>
+          e.advisoryNumber === advisoryNumber && e.subject === throttleSubject,
+      )
     ) {
       sent.push({
         advisoryNumber: advisoryNumber,
+        subject: throttleSubject,
         lastEmailSent: new Date().toISOString(),
       });
       const emailInfo = message?.jsonData;
@@ -111,6 +117,15 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
         },
       };
 
+      if (scriptKeySpecified("emailtest")) {
+        // For testing, add all recipient addresses to emailData
+        // so they can be included in the rendered document for verification.
+        emailData.allRecipients = [
+          ...(process.env.EMAIL_RECIPIENT || "").split(","),
+          ...(emailInfo.additionalRecipients ?? []),
+        ].filter(Boolean);
+      }
+
       // render the email template
       const htmlMessageBody = await ejs.renderFile(
         "./email-alerts/templates/public-advisory.ejs",
@@ -119,7 +134,7 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
 
       if (scriptKeySpecified("emailtest")) {
         writeFile(
-          `./mail-test-${advisoryNumber}.html`,
+          `./mail-test-${advisoryNumber}-${message.documentId}.html`,
           htmlMessageBody,
           (err) => {
             if (err) throw err;
@@ -208,6 +223,10 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
           );
         }
       }
+    } else {
+      logger.info(
+        `Throttled advisory email ${advisoryNumber} with subject "${throttleSubject}". Removing duplicate queue item.`,
+      );
     }
     if (scriptKeySpecified("emailsend") || noCommandLineArgs()) {
       await removeFromQueue([message.documentId]);

--- a/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
+++ b/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
@@ -42,8 +42,9 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
 
     if (
       !recentAdvisoryEmails.find(
-        (e) =>
-          e.advisoryNumber === advisoryNumber && e.subject === throttleSubject,
+        (email) =>
+          email.advisoryNumber === advisoryNumber &&
+          email.subject === throttleSubject,
       )
     ) {
       sent.push({
@@ -239,7 +240,9 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
   ).toISOString();
 
   return [
-    ...recentAdvisoryEmails.filter((a) => a.lastEmailSent > throttleMinutesAgo),
+    ...recentAdvisoryEmails.filter(
+      (email) => email.lastEmailSent > throttleMinutesAgo,
+    ),
     ...sent,
   ];
 };

--- a/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
+++ b/src/scheduler/email-alerts/scripts/sendAdvisoryEmails.js
@@ -225,7 +225,7 @@ exports.sendAdvisoryEmails = async function (recentAdvisoryEmails) {
       }
     } else {
       logger.info(
-        `Throttled advisory email ${advisoryNumber} with subject "${throttleSubject}". Removing duplicate queue item.`,
+        `Skipped advisory email ${advisoryNumber} with subject "${throttleSubject}" because a duplicate was sent recently. Email not sent.`,
       );
     }
     if (scriptKeySpecified("emailsend") || noCommandLineArgs()) {

--- a/src/scheduler/email-alerts/templates/public-advisory.ejs
+++ b/src/scheduler/email-alerts/templates/public-advisory.ejs
@@ -6,6 +6,10 @@
   <title><%= title %></title>
 </head>
 
+<% if (allRecipients && allRecipients.length > 0) { %>
+<!-- Email recipients: <%= allRecipients.join(", ") %> -->
+<% } %>
+
 <body style="font-family: Arial, Helvetica; color: #1a1a1a">
   <img src="cid:logo.png" alt="BC Parks" title="BC Parks Logo" style="margin: 8px 16px 0px 0px;" width="150" />
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1987

### Description:

Some tweaks to the email queue system, now that there are more emails and more recipients involved:

- Instead of de-duplicating emails just based on the advisoryNumber, now consider the advisoryNumber and subject. This allows multiple emails to be dispatched for the same event without being discarded as duplicates
- Adjusted the email throttling that discarded more than one email per advisory per queue, as well as the 10-minute throttle. now they both check the subject to make sure the email really is a duplicate before discarding it.
- For testing and troubleshooting, I also added the email addresses of the recipients to the files that get generated if you run `node manage.js emailtest`. It shows up in an HTML comment so you can see it if you view source.
- I also added the documentId to the name of the files generated from `emailtest`, since an advisory might have more than one email in the queue at the same time.