### PR TITLE
NOBUG: Restore reverted action version upgrades

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -18,13 +18,13 @@ jobs:
       BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-22
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set env
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -32,7 +32,7 @@ jobs:
 
       # Downgrade/pin Docker Engine to v28.x on the hosted runner
       - name: Set up Docker 28.x
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           version: "28.5.2"
           set-host: true # <— this sets DOCKER_HOST for all following steps
@@ -61,7 +61,7 @@ jobs:
       IMAGE_NAME: public-builder-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set env
         run: |
@@ -69,7 +69,7 @@ jobs:
           echo "REGISTRY_IMAGE=${{ secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY }}/${{ secrets.OPENSHIFT_GOLD_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -91,7 +91,7 @@ jobs:
       IMAGE_NAME: maintenance-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set env
         run: |
@@ -99,7 +99,7 @@ jobs:
           echo "REGISTRY_IMAGE=${{ secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY }}/${{ secrets.OPENSHIFT_GOLD_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -122,13 +122,13 @@ jobs:
       BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-22
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set env
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -136,7 +136,7 @@ jobs:
 
       # Downgrade/pin Docker Engine to v28.x on the hosted runner
       - name: Set up Docker 28.x
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           version: "28.5.2"
           set-host: true # <— this sets DOCKER_HOST for all following steps
@@ -164,13 +164,13 @@ jobs:
       BUILDER_IMAGE: registry.access.redhat.com/ubi9/nodejs-22
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set env
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
@@ -178,7 +178,7 @@ jobs:
 
       # Downgrade/pin Docker Engine to v28.x on the hosted runner
       - name: Set up Docker 28.x
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           version: "28.5.2"
           set-host: true # <— this sets DOCKER_HOST for all following steps
@@ -205,12 +205,13 @@ jobs:
     needs: [build-cms]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1
@@ -225,7 +226,7 @@ jobs:
           oc -n ${{ secrets.OPENSHIFT_GOLD_LICENSE_PLATE }}-dev rollout restart deployment ${{ github.ref_name }}-scheduler
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-alpha-test.yaml
+++ b/.github/workflows/deploy-alpha-test.yaml
@@ -15,7 +15,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1
@@ -32,7 +33,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag scheduler-alpha:latest scheduler-alpha:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 
@@ -33,7 +33,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1
@@ -50,7 +51,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag scheduler-main:${{ github.event.inputs.releaseTag }} scheduler-main:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 
@@ -30,7 +30,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1
@@ -47,7 +48,7 @@ jobs:
           oc -n ${{ env.TOOLS_NAMESPACE }} tag scheduler-main:${{ github.event.inputs.releaseTag }} scheduler-main:${{ env.ENVIRONMENT }}
 
       - name: Trigger Gatsby static build workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-gatsby

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -12,10 +12,10 @@ jobs:
   test-strapi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -36,10 +36,10 @@ jobs:
   test-gatsby:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -21,7 +21,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/publish-gatsby.yaml
+++ b/.github/workflows/publish-gatsby.yaml
@@ -95,14 +95,14 @@ jobs:
               fi
           fi
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{secrets.OPENSHIFT_GOLD_EXTERNAL_REPOSITORY}}
           username: ${{secrets.OPENSHIFT_GOLD_SA_USERNAME}}
           password: ${{secrets.OPENSHIFT_GOLD_SA_PASSWORD}}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -117,7 +117,7 @@ jobs:
       - run: mkdir -p gatsby/public gatsby/.cache
 
       - name: Cache Gatsby Cache Folder
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: gatsby-cache-folder
         with:
           path: gatsby/.cache
@@ -126,7 +126,7 @@ jobs:
             ${{ runner.os }}-cache-gatsby-${{ env.BRANCH }}-${{ env.ENV_SUFFIX }}
 
       - name: Cache Gatsby Public Folder
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: gatsby-public-folder
         with:
           path: gatsby/public
@@ -147,7 +147,7 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
           skip_cache: true
 
       - name: Login OpenShift

--- a/.github/workflows/publish-gatsby.yaml
+++ b/.github/workflows/publish-gatsby.yaml
@@ -106,16 +106,37 @@ jobs:
         with:
           node-version: "22"
 
-      - run: mkdir -p gatsby/public
-      - name: Build static
+      - run: mkdir -p gatsby
+      - name: Prepare Gatsby source
         run: |
           # Run the builder image as container since you can't directly copy file from an image
           docker run -d -t --name builder ${{ steps.vars.outputs.registry_builder_image }}:${{ env.IMAGE_TAG }}
           # Copy Gatsby source and packages to local.  Tried to just do the build in the container, but ran into some weird issues with the build
           docker cp builder:/gatsby/. gatsby
+
+      - run: mkdir -p gatsby/public gatsby/.cache
+
+      - name: Cache Gatsby Cache Folder
+        uses: actions/cache@v3
+        id: gatsby-cache-folder
+        with:
+          path: gatsby/.cache
+          key: ${{ runner.os }}-cache-gatsby-${{ env.BRANCH }}-${{ env.ENV_SUFFIX }}
+          restore-keys: |
+            ${{ runner.os }}-cache-gatsby-${{ env.BRANCH }}-${{ env.ENV_SUFFIX }}
+
+      - name: Cache Gatsby Public Folder
+        uses: actions/cache@v3
+        id: gatsby-public-folder
+        with:
+          path: gatsby/public
+          key: ${{ runner.os }}-public-gatsby-${{ env.BRANCH }}-${{ env.ENV_SUFFIX }}
+          restore-keys: |
+            ${{ runner.os }}-public-gatsby-${{ env.BRANCH }}-${{ env.ENV_SUFFIX }}
+
+      - name: Build static
+        run: |
           cd gatsby
-          # Ensure a fresh build from source data; avoid stale page-data from copied image cache.
-          rm -rf .cache public
           npm run build
       - name: Build and push public image
         run: |


### PR DESCRIPTION
### Jira Ticket:
None

### Description:

_One of several branches I'm pushing for review/discussion._ 

During the 3.0.9 deployment issues, I reverted the recent upgrades to various GH action runner packages. The version bumps don't seem to be the cause of the issue, but I didn't test to see if they're completely bug free or not.

This branch would restore the changes, if we all agree to do that 👍 