### PR TITLE
NOBUG: Revert sort order fix in gatsby config

### DIFF
--- a/src/gatsby/gatsby-config.js
+++ b/src/gatsby/gatsby-config.js
@@ -83,7 +83,6 @@ module.exports = {
             singularName: "protected-area",
             queryParams: {
               fields: "*",
-              sort: ["id:asc"],
               populate: {
                 parkActivities: {
                   populate: ["activityType"],
@@ -215,7 +214,6 @@ module.exports = {
           {
             singularName: "site",
             queryParams: {
-              sort: ["id:asc"],
               populate: {
                 protectedArea: {
                   fields: "*",


### PR DESCRIPTION
### Jira Ticket:
None

### Description:

_One of several branches I'm pushing for review/discussion._ 

This branch reverts the query sort order changes I made for "v3.0.4.9" - if we wanted to deploy it somewhere to test and see if we can isolate whether or not that's the change that fixed the build issues. I recognize that we don't have any environments to spare right now with all the UAT going on, though.