### PR TITLE
CMS-1987: Fix existence check for allRecipients in email template

### DIFF
--- a/src/scheduler/email-alerts/templates/public-advisory.ejs
+++ b/src/scheduler/email-alerts/templates/public-advisory.ejs
@@ -6,7 +6,7 @@
   <title><%= title %></title>
 </head>
 
-<% if (allRecipients && allRecipients.length > 0) { %>
+<% if (typeof allRecipients !== "undefined" && Array.isArray(allRecipients) && allRecipients.length > 0) { %>
 <!-- Email recipients: <%= allRecipients.join(", ") %> -->
 <% } %>
 


### PR DESCRIPTION
### Jira Ticket:
CMS-1987

### Description:

The previous change in #1919 was using a syntax that doesn't work in EJS templates to check if `allRecipients` was defined. When it's undefined (in non-test mode) it crashes the scheduler. 

> allRecipients is not defined
    at eval ("./email-alerts/templates/public-advisory.ejs":15:8)

Normally that check would be fine, but I guess EJS does something weird with scoping when it evaluates code in templates.

This change uses an explicit check that it's defined and an array. `typeof` doesn't throw if the identifier is undefined.