### PR TITLE
CMS-1942: Update email from parksweb to cardweb

### DIFF
--- a/infrastructure/helm/deployment/values.yaml
+++ b/infrastructure/helm/deployment/values.yaml
@@ -152,8 +152,8 @@ scheduler:
     emailEnabled: true
     emailServer: apps.smtp.gov.bc.ca
     emailPort: 25
-    emailSender: parksweb@gov.bc.ca
-    emailRecipient: parksweb@gov.bc.ca
+    emailSender: cardweb@gov.bc.ca
+    emailRecipient: cardweb@gov.bc.ca
     emailRecipientWhitelist: ""
 
   resources:

--- a/src/scheduler/.env.example
+++ b/src/scheduler/.env.example
@@ -15,7 +15,7 @@ EMAIL_SERVER=
 EMAIL_USERNAME=
 EMAIL_PASSWORD=
 EMAIL_PORT=25
-EMAIL_SENDER=parksweb@gov.bc.ca
+EMAIL_SENDER=cardweb@gov.bc.ca
 EMAIL_RECIPIENT=
 # Required for advisory emails in non-prod environments.
 # Comma-separated allowlist; any other recipient will be filtered out with a warning.


### PR DESCRIPTION
### Jira Ticket:
CMS-1942

### Description:
The BC Parks Staff Web portal is being rebranded as the BC Ministry of Environment and Parks Parks and Recreation Web Portal to reflect the expansion of the platform to support both BC Parks and Recreation Sites and Trails BC.

As part of this change, email addresses have been updated from parksweb@gov.bc.ca to cardweb@gov.bc.ca, where CARD refers to the Conservation and Recreation Division.

This PR updates Helm configuration and .env.example files to reflect the new email addresses.