### PR TITLE
CMS-2000: Add deterministic sort ordering to multi-page queries

### DIFF
--- a/src/cms/src/api/protected-area/services/search.js
+++ b/src/cms/src/api/protected-area/services/search.js
@@ -114,7 +114,7 @@ module.exports = ({ strapi }) => ({
 
     let sortOrder;
     if (isNaN(latitude) || isNaN(longitude)) {
-      sortOrder = ["_score", "nameLowerCase.keyword"];
+      sortOrder = ["_score", "nameLowerCase.keyword", "orcs"];
     } else {
       sortOrder = [
         {
@@ -127,6 +127,10 @@ module.exports = ({ strapi }) => ({
             ignore_unmapped: true,
           },
         },
+        // if two parks are the same distance away, sort by score and then by keyword
+        { _score: { order: "desc" } },
+        { "nameLowerCase.keyword": { order: "asc" } },
+        { orcs: { order: "asc" } },
       ];
     }
 

--- a/src/etl/scripts/rst-resources.js
+++ b/src/etl/scripts/rst-resources.js
@@ -221,15 +221,12 @@ async function fetchRSTResources() {
   const rstSummaryUrl = `${process.env.RST_API}/recreation-resource/summary`;
 
   const rstResources = [];
-  const { data } = await axios.get(`${rstSummaryUrl}?page=1&sort=id`, rstAxiosConfig);
+  const { data } = await axios.get(`${rstSummaryUrl}?page=1`, rstAxiosConfig);
   const totalPages = data.totalPages;
   rstResources.push(...data.data);
 
   for (let page = 2; page <= totalPages; page++) {
-    const { data } = await axios.get(
-      `${rstSummaryUrl}?page=${page}&sort=id`,
-      rstAxiosConfig,
-    );
+    const { data } = await axios.get(`${rstSummaryUrl}?page=${page}`, rstAxiosConfig);
     rstResources.push(...data.data);
   }
   return rstResources;

--- a/src/etl/scripts/rst-resources.js
+++ b/src/etl/scripts/rst-resources.js
@@ -221,12 +221,15 @@ async function fetchRSTResources() {
   const rstSummaryUrl = `${process.env.RST_API}/recreation-resource/summary`;
 
   const rstResources = [];
-  const { data } = await axios.get(`${rstSummaryUrl}?page=1`, rstAxiosConfig);
+  const { data } = await axios.get(`${rstSummaryUrl}?page=1&sort=id`, rstAxiosConfig);
   const totalPages = data.totalPages;
   rstResources.push(...data.data);
 
   for (let page = 2; page <= totalPages; page++) {
-    const { data } = await axios.get(`${rstSummaryUrl}?page=${page}`, rstAxiosConfig);
+    const { data } = await axios.get(
+      `${rstSummaryUrl}?page=${page}&sort=id`,
+      rstAxiosConfig,
+    );
     rstResources.push(...data.data);
   }
   return rstResources;
@@ -235,6 +238,7 @@ async function fetchRSTResources() {
 // Fetches all recreation resources from Strapi, handling pagination
 async function fetchStrapiResources(strapiResourcesUrl) {
   const queryParams = {
+    sort: ["id:asc"],
     populate: {
       recreationDistrict: { fields: ["documentId"] },
       recreationResourceType: { fields: ["documentId"] },

--- a/src/gatsby/src/pages/find-a-park.js
+++ b/src/gatsby/src/pages/find-a-park.js
@@ -120,6 +120,7 @@ export default function FindAPark({ location, data }) {
   // useState and constants
   const menuContent = data?.allStrapiMenu?.nodes || [];
   const searchCities = data?.allStrapiSearchCity?.nodes || [];
+  // Sort is defined server-side in protected-area searchParks (Elasticsearch) to keep _start/_limit paging deterministic.
   const searchApiUrl = `${data.site.siteMetadata.apiURL}/api/protected-areas/search`;
 
   const [areasCount, setAreasCount] = useState([]);
@@ -430,6 +431,7 @@ export default function FindAPark({ location, data }) {
     const newPage = +currentPage + 1;
     setCurrentPage(newPage);
     const pageStart = (newPage - 1) * itemsPerPage;
+    // Request slices by offset/limit; ordering comes from the searchParks service.
     axios
       .get(searchApiUrl, {
         params: { ...params, _start: pageStart, _limit: itemsPerPage },
@@ -569,7 +571,7 @@ export default function FindAPark({ location, data }) {
     if (queryParamStateSyncComplete()) {
       setIsLoading(true);
       setFilters();
-      // first Axios request
+      // first Axios request (deterministic sort is applied by searchParks)
       const request1 = axios.get(searchApiUrl, {
         params: { ...params, _start: 0, _limit: currentPage * itemsPerPage },
       });

--- a/src/scheduler/temporary-scripts/rst-import/import-closures.js
+++ b/src/scheduler/temporary-scripts/rst-import/import-closures.js
@@ -64,7 +64,10 @@ const loadData = async function () {
     for (let page = 1, pageCount = 1; page <= pageCount; page++) {
       const { data } = await axios.get(url, {
         headers: httpReqHeaders,
-        params: { pagination: { page, pageSize: 1000 } },
+        params: {
+          sort: ["id:asc"],
+          pagination: { page, pageSize: 1000 },
+        },
         paramsSerializer: (params) =>
           qs.stringify(params, { encodeValuesOnly: true }),
       });

--- a/src/scheduler/temporary-scripts/rst-import/import-rec-resources.js
+++ b/src/scheduler/temporary-scripts/rst-import/import-rec-resources.js
@@ -215,13 +215,13 @@ async function fetchRSTResources() {
   console.log(`Fetching recreation resources from RST API: ${rstSummaryUrl}`);
 
   const rstResources = [];
-  const { data } = await axios.get(`${rstSummaryUrl}?page=1&sort=id`, rstAxiosConfig);
+  const { data } = await axios.get(`${rstSummaryUrl}?page=1`, rstAxiosConfig);
   const totalPages = data.totalPages;
   rstResources.push(...data.data);
 
   for (let page = 2; page <= totalPages; page++) {
     const { data } = await axios.get(
-      `${rstSummaryUrl}?page=${page}&sort=id`,
+      `${rstSummaryUrl}?page=${page}`,
       rstAxiosConfig,
     );
     rstResources.push(...data.data);

--- a/src/scheduler/temporary-scripts/rst-import/import-rec-resources.js
+++ b/src/scheduler/temporary-scripts/rst-import/import-rec-resources.js
@@ -215,13 +215,13 @@ async function fetchRSTResources() {
   console.log(`Fetching recreation resources from RST API: ${rstSummaryUrl}`);
 
   const rstResources = [];
-  const { data } = await axios.get(`${rstSummaryUrl}?page=1`, rstAxiosConfig);
+  const { data } = await axios.get(`${rstSummaryUrl}?page=1&sort=id`, rstAxiosConfig);
   const totalPages = data.totalPages;
   rstResources.push(...data.data);
 
   for (let page = 2; page <= totalPages; page++) {
     const { data } = await axios.get(
-      `${rstSummaryUrl}?page=${page}`,
+      `${rstSummaryUrl}?page=${page}&sort=id`,
       rstAxiosConfig,
     );
     rstResources.push(...data.data);
@@ -232,6 +232,7 @@ async function fetchRSTResources() {
 // Fetches all recreation resources from Strapi, handling pagination
 async function fetchStrapiResources(strapiResourcesUrl) {
   const queryParams = {
+    sort: ["id:asc"],
     populate: {
       recreationDistrict: { fields: ["documentId"] },
       recreationResourceType: { fields: ["documentId"] },


### PR DESCRIPTION
### Jira Ticket:
CMS-2000

### Description:

Did a review through the repo for paginated data fetches that didn't have a fully deterministic sort order and added something like ID/ORCS where appropriate.

Tested by re-building the ElasticSearch index locally and clicking "Load more" on various park searches, compared with the behavior on the production site.

I also updated a few scripts and tested them with a "dry run" by replacing the db writes with console logs locally. It all looks good to me, but I'm looking for feedback! 

I have a few similar tweaks to make for the SP repo as well. 

TBD how we want to deploy this once it's tested. It could be a hotfix or it could wait until Oct. I haven't added any version tags yet.
